### PR TITLE
Add AOC-ID canonicalization, hashing, and builder utilities

### DIFF
--- a/__tests__/aocId.test.ts
+++ b/__tests__/aocId.test.ts
@@ -1,0 +1,42 @@
+import { canonicalizeJSON } from '../canonicalize';
+import { computeContentHash, buildAOCId } from '../aocId';
+
+describe('canonicalizeJSON', () => {
+  it('produces the same canonical string for identical objects', () => {
+    const obj = { name: 'Ada', age: 30, tags: ['engineer', 'mathematician'] };
+    expect(canonicalizeJSON(obj)).toBe(canonicalizeJSON(obj));
+  });
+
+  it('sorts object keys lexicographically', () => {
+    const objA = { b: 2, a: 1 };
+    const objB = { a: 1, b: 2 };
+    expect(canonicalizeJSON(objA)).toBe(canonicalizeJSON(objB));
+  });
+});
+
+describe('content hash and AOC-ID', () => {
+  it('produces the same hash for the same object', () => {
+    const obj = { title: 'Record', count: 1, ratio: 1.5 };
+    expect(computeContentHash(obj)).toBe(computeContentHash(obj));
+  });
+
+  it('builds an AOC-ID in the expected format', () => {
+    const obj = { id: 42 };
+    const aocId = buildAOCId('employment', 'history', 'v1', '0', obj);
+    expect(aocId).toMatch(/^aoc:\/\/employment\/history\/v1\/0\/0x[0-9a-f]{64}$/);
+  });
+
+  it('matches the snapshot for a fixed object', () => {
+    const obj = {
+      person: {
+        name: 'Ada Lovelace',
+        score: 99.5,
+        active: true,
+        tags: ['science', 'math']
+      },
+      createdAt: '2024-01-01T00:00:00Z'
+    };
+
+    expect(buildAOCId('identity', 'profile', 'v2', '1', obj)).toMatchSnapshot();
+  });
+});

--- a/aocId.ts
+++ b/aocId.ts
@@ -1,0 +1,20 @@
+import { canonicalizeJSON } from './canonicalize';
+import { sha256Hex } from './hash';
+
+export function computeContentHash(obj: any): string {
+  const canonical = canonicalizeJSON(obj);
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(canonical);
+  return sha256Hex(bytes);
+}
+
+export function buildAOCId(
+  domain: string,
+  type: string,
+  schema: string,
+  version: string,
+  obj: any
+): string {
+  const contentHash = computeContentHash(obj);
+  return `aoc://${domain}/${type}/${schema}/${version}/0x${contentHash}`;
+}

--- a/canonicalize.ts
+++ b/canonicalize.ts
@@ -1,0 +1,52 @@
+export function canonicalizeJSON(value: any): string {
+  if (value === null) {
+    return 'null';
+  }
+
+  const valueType = typeof value;
+
+  if (valueType === 'string') {
+    return JSON.stringify(value);
+  }
+
+  if (valueType === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('Non-finite numbers are not supported in canonical JSON');
+    }
+
+    if (Number.isInteger(value)) {
+      return value.toString();
+    }
+
+    let numberString = value.toString();
+    if (numberString.includes('.')) {
+      numberString = numberString.replace(/0+$/, '');
+      if (numberString.endsWith('.')) {
+        numberString = numberString.slice(0, -1);
+      }
+    }
+
+    return numberString;
+  }
+
+  if (valueType === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalizeJSON(item));
+    return `[${items.join(',')}]`;
+  }
+
+  if (valueType === 'object') {
+    const keys = Object.keys(value).sort();
+    const pairs = keys.map((key) => {
+      const keyString = JSON.stringify(key);
+      const valueString = canonicalizeJSON(value[key]);
+      return `${keyString}:${valueString}`;
+    });
+    return `{${pairs.join(',')}}`;
+  }
+
+  throw new Error(`Unsupported type in canonical JSON: ${valueType}`);
+}

--- a/hash.ts
+++ b/hash.ts
@@ -1,0 +1,9 @@
+import crypto from 'crypto';
+
+export function sha256(data: Uint8Array): Uint8Array {
+  return crypto.createHash('sha256').update(data).digest();
+}
+
+export function sha256Hex(data: Uint8Array): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,2 @@
+export { canonicalizeJSON } from './canonicalize';
+export { computeContentHash, buildAOCId } from './aocId';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "aoc-id",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "typescript": "^5.5.4"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic canonical JSON serialization and SHA-256 content hashing so objects can be referenced by stable AOC Object Identifiers (AOC-IDs). 
- Expose a small TypeScript API to compute content hashes and construct `aoc://.../0x<hash>` identifiers and include tests and config to validate behavior.

### Description
- Add `canonicalizeJSON(value: any)` in `canonicalize.ts` that serializes to UTF-8-safe strings with lexicographically sorted object keys, arrays preserving order, integers unchanged, floats normalized (no trailing zeros), booleans as `true`/`false`, and `null` as `null`.
- Add `sha256` and `sha256Hex` in `hash.ts` using Node `crypto` to produce raw and hex SHA-256 digests respectively.
- Add `computeContentHash(obj: any)` and `buildAOCId(...)` in `aocId.ts` where `computeContentHash` canonicalizes, UTF-8 encodes, and returns the SHA-256 hex, and `buildAOCId` returns `aoc://<domain>/<type>/<schema>/<version>/0x<contentHash>`.
- Re-export public API from `index.ts` and add TypeScript/Jest configuration files plus tests in `__tests__/aocId.test.ts` covering canonicalization invariants and AOC-ID formatting.

### Testing
- Added Jest configuration (`jest.config.js`) and a test suite `__tests__/aocId.test.ts` which checks identical-object stability, key-order independence, content-hash consistency, an AOC-ID format regex, and a snapshot for a fixed object.
- Tests target the functions `canonicalizeJSON`, `computeContentHash`, and `buildAOCId` via the test file and use `ts-jest` to run TypeScript tests.
- Automated tests were added but were not executed as part of this change, so test results are currently unverified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811971606c8325a19297979042f918)