### PR TITLE
Add AES-256-GCM crypto module

### DIFF
--- a/crypto/__tests__/engine.test.ts
+++ b/crypto/__tests__/engine.test.ts
@@ -1,0 +1,55 @@
+import { decryptObject, encryptObject } from '../engine';
+
+const toBytes = (value: string): Uint8Array => Buffer.from(value, 'utf8');
+
+const mutateBase64Url = (value: string): string => {
+  const buffer = Buffer.from(value, 'base64url');
+  buffer[0] = buffer[0] ^ 0xff;
+  return buffer.toString('base64url');
+};
+
+describe('crypto engine', () => {
+  const key = Buffer.alloc(32, 7);
+  const plaintext = toBytes('hello world');
+
+  it('roundtrips encryption/decryption', () => {
+    const encrypted = encryptObject(key, plaintext);
+    const decrypted = decryptObject(key, encrypted);
+
+    expect(Buffer.from(decrypted).toString('utf8')).toBe('hello world');
+  });
+
+  it('fails with the wrong key', () => {
+    const encrypted = encryptObject(key, plaintext);
+    const wrongKey = Buffer.alloc(32, 9);
+
+    expect(() => decryptObject(wrongKey, encrypted)).toThrow();
+  });
+
+  it('fails with modified ciphertext', () => {
+    const encrypted = encryptObject(key, plaintext);
+    const tampered = {
+      ...encrypted,
+      ciphertext: mutateBase64Url(encrypted.ciphertext),
+    };
+
+    expect(() => decryptObject(key, tampered)).toThrow();
+  });
+
+  it('fails with modified auth tag', () => {
+    const encrypted = encryptObject(key, plaintext);
+    const tampered = {
+      ...encrypted,
+      auth_tag: mutateBase64Url(encrypted.auth_tag),
+    };
+
+    expect(() => decryptObject(key, tampered)).toThrow();
+  });
+
+  it('uses a different nonce each time', () => {
+    const encryptedA = encryptObject(key, plaintext);
+    const encryptedB = encryptObject(key, plaintext);
+
+    expect(encryptedA.nonce).not.toBe(encryptedB.nonce);
+  });
+});

--- a/crypto/engine.ts
+++ b/crypto/engine.ts
@@ -1,0 +1,67 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+import type { EncryptedObject } from './types';
+
+const NONCE_LENGTH = 12;
+const KEY_LENGTH = 32;
+
+const toBase64Url = (data: Uint8Array): string =>
+  Buffer.from(data).toString('base64url');
+
+const fromBase64Url = (data: string): Uint8Array =>
+  new Uint8Array(Buffer.from(data, 'base64url'));
+
+const assertKeyLength = (key: Uint8Array): void => {
+  if (key.length !== KEY_LENGTH) {
+    throw new Error(`Invalid key length: expected ${KEY_LENGTH} bytes`);
+  }
+};
+
+export const encryptObject = (
+  key: Uint8Array,
+  plaintext: Uint8Array
+): EncryptedObject => {
+  assertKeyLength(key);
+
+  const nonce = randomBytes(NONCE_LENGTH);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    version: 1,
+    algorithm: 'AES-256-GCM',
+    nonce: toBase64Url(nonce),
+    ciphertext: toBase64Url(ciphertext),
+    auth_tag: toBase64Url(authTag),
+  };
+};
+
+export const decryptObject = (
+  key: Uint8Array,
+  encrypted: EncryptedObject
+): Uint8Array => {
+  assertKeyLength(key);
+
+  if (encrypted.version !== 1 || encrypted.algorithm !== 'AES-256-GCM') {
+    throw new Error('Unsupported encrypted object');
+  }
+
+  const nonce = fromBase64Url(encrypted.nonce);
+  const ciphertext = fromBase64Url(encrypted.ciphertext);
+  const authTag = fromBase64Url(encrypted.auth_tag);
+
+  const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+  decipher.setAuthTag(Buffer.from(authTag));
+
+  const plaintext = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+
+  return new Uint8Array(plaintext);
+};

--- a/crypto/index.ts
+++ b/crypto/index.ts
@@ -1,0 +1,2 @@
+export { decryptObject, encryptObject } from './engine';
+export type { EncryptedObject } from './types';

--- a/crypto/types.ts
+++ b/crypto/types.ts
@@ -1,0 +1,7 @@
+export type EncryptedObject = {
+  version: 1;
+  algorithm: 'AES-256-GCM';
+  nonce: string;
+  ciphertext: string;
+  auth_tag: string;
+};


### PR DESCRIPTION
### Motivation
- Implement a small AES-256-GCM encryption/decryption module for binary data using Node `crypto` with a 12-byte nonce and base64url serialization. 
- Enforce simple safety rules required by the module surface such as a 32-byte key length and authentication-tag verification.

### Description
- Add `crypto/engine.ts` implementing `encryptObject` and `decryptObject` using Node `crypto` (`createCipheriv`/`createDecipheriv`) with a random 12-byte nonce and base64url encoding of `nonce`, `ciphertext`, and `auth_tag`.
- Validate key length (32 bytes) in `assertKeyLength` and throw on unsupported `version`/`algorithm` or failed authentication during decryption.
- Add `EncryptedObject` type in `crypto/types.ts` and re-export API from `crypto/index.ts`.
- Add unit tests in `crypto/__tests__/engine.test.ts` covering roundtrip, wrong key, modified ciphertext, modified auth tag, and nonce uniqueness.

### Testing
- Added Jest unit tests in `crypto/__tests__/engine.test.ts` that exercise roundtrip, tampering, wrong-key, and nonce uniqueness scenarios.
- Attempted to run `npm test` but it failed in this environment with `jest: not found`, so the tests were not executed here (they should pass when `jest` is available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811e7fb31083259f88defec6964252)