### PR TITLE
Harden storage pointer validation and add local sha256 helper

### DIFF
--- a/storage/__tests__/localFsAdapter.test.ts
+++ b/storage/__tests__/localFsAdapter.test.ts
@@ -1,0 +1,60 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { buildStoragePointer } from '../pointer';
+import { LocalFilesystemAdapter } from '../localFsAdapter';
+
+const STORAGE_DIR = '.aoc_storage';
+
+describe('LocalFilesystemAdapter', () => {
+  const baseDir = process.cwd();
+  const adapter = new LocalFilesystemAdapter(baseDir);
+
+  beforeEach(async () => {
+    await fs.rm(path.join(baseDir, STORAGE_DIR), { recursive: true, force: true });
+  });
+
+  it('stores and retrieves a blob with matching hash', async () => {
+    const blob = new TextEncoder().encode('hello world');
+    const pointer = await adapter.put(blob);
+    const retrieved = await adapter.get(pointer);
+
+    expect(Buffer.from(retrieved)).toEqual(Buffer.from(blob));
+  });
+
+  it('throws when stored data hash mismatches', async () => {
+    const blob = new TextEncoder().encode('original');
+    const pointer = await adapter.put(blob);
+    const tamperedPath = path.join(baseDir, STORAGE_DIR, pointer.hash);
+
+    await fs.writeFile(tamperedPath, new TextEncoder().encode('tampered'));
+
+    await expect(adapter.get(pointer)).rejects.toThrow('Storage hash mismatch');
+  });
+
+  it('builds pointer with expected format', () => {
+    const hash = 'abcdef'.padEnd(64, '0');
+    const pointer = buildStoragePointer('local', hash);
+
+    expect(pointer).toEqual({
+      backend: 'local',
+      hash,
+      uri: `aoc://storage/local/0x${hash}`
+    });
+  });
+
+  it('rejects invalid hash inputs', () => {
+    expect(() => buildStoragePointer('local', 'ABCDEF')).toThrow(
+      'Storage hash must be 64 lowercase hex characters.'
+    );
+  });
+
+  it('deletes stored blobs', async () => {
+    const blob = new TextEncoder().encode('delete me');
+    const pointer = await adapter.put(blob);
+    const filePath = path.join(baseDir, STORAGE_DIR, pointer.hash);
+
+    await adapter.delete(pointer);
+
+    await expect(fs.stat(filePath)).rejects.toThrow();
+  });
+});

--- a/storage/adapter.ts
+++ b/storage/adapter.ts
@@ -1,0 +1,7 @@
+import { StoragePointer } from './types';
+
+export interface IStorageAdapter {
+  put(blob: Uint8Array): Promise<StoragePointer>;
+  get(pointer: StoragePointer): Promise<Uint8Array>;
+  delete(pointer: StoragePointer): Promise<void>;
+}

--- a/storage/hash.ts
+++ b/storage/hash.ts
@@ -1,0 +1,5 @@
+import crypto from 'crypto';
+
+export function sha256Hex(data: Uint8Array): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -1,0 +1,5 @@
+export type { StoragePointer } from './types';
+export { buildStoragePointer } from './pointer';
+export type { IStorageAdapter } from './adapter';
+export { LocalFilesystemAdapter } from './localFsAdapter';
+export { CloudflareR2Adapter } from './r2Adapter';

--- a/storage/localFsAdapter.ts
+++ b/storage/localFsAdapter.ts
@@ -1,0 +1,48 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { sha256Hex } from './hash';
+import { IStorageAdapter } from './adapter';
+import { buildStoragePointer } from './pointer';
+import { StoragePointer } from './types';
+
+const STORAGE_DIR = '.aoc_storage';
+
+export class LocalFilesystemAdapter implements IStorageAdapter {
+  private baseDir: string;
+
+  constructor(baseDir: string = process.cwd()) {
+    this.baseDir = baseDir;
+  }
+
+  async put(blob: Uint8Array): Promise<StoragePointer> {
+    const hashHex = sha256Hex(blob);
+    const pointer = buildStoragePointer('local', hashHex);
+    const filePath = this.getFilePath(hashHex);
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, blob);
+
+    return pointer;
+  }
+
+  async get(pointer: StoragePointer): Promise<Uint8Array> {
+    const filePath = this.getFilePath(pointer.hash);
+    const data = await fs.readFile(filePath);
+    const hashHex = sha256Hex(data);
+
+    if (hashHex !== pointer.hash) {
+      throw new Error(`Storage hash mismatch for ${pointer.uri}`);
+    }
+
+    return data;
+  }
+
+  async delete(pointer: StoragePointer): Promise<void> {
+    const filePath = this.getFilePath(pointer.hash);
+    await fs.rm(filePath, { force: true });
+  }
+
+  private getFilePath(hashHex: string): string {
+    return path.join(this.baseDir, STORAGE_DIR, hashHex);
+  }
+}

--- a/storage/pointer.ts
+++ b/storage/pointer.ts
@@ -1,0 +1,19 @@
+import { StoragePointer } from './types';
+
+const HASH_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+export function buildStoragePointer(backend: string, hashHex: string): StoragePointer {
+  if (!backend) {
+    throw new Error('Storage backend must be non-empty.');
+  }
+
+  if (!HASH_HEX_PATTERN.test(hashHex)) {
+    throw new Error('Storage hash must be 64 lowercase hex characters.');
+  }
+
+  return {
+    uri: `aoc://storage/${backend}/0x${hashHex}`,
+    backend,
+    hash: hashHex
+  };
+}

--- a/storage/r2Adapter.ts
+++ b/storage/r2Adapter.ts
@@ -1,0 +1,46 @@
+import { sha256Hex } from './hash';
+import { IStorageAdapter } from './adapter';
+import { buildStoragePointer } from './pointer';
+import { StoragePointer } from './types';
+
+type R2Env = {
+  accountId?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  bucket?: string;
+};
+
+export class CloudflareR2Adapter implements IStorageAdapter {
+  private env: R2Env;
+
+  constructor(env: R2Env = {}) {
+    this.env = {
+      accountId: env.accountId ?? process.env.R2_ACCOUNT_ID,
+      accessKeyId: env.accessKeyId ?? process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: env.secretAccessKey ?? process.env.R2_SECRET_ACCESS_KEY,
+      bucket: env.bucket ?? process.env.R2_BUCKET
+    };
+  }
+
+  async put(blob: Uint8Array): Promise<StoragePointer> {
+    const hashHex = sha256Hex(blob);
+    const pointer = buildStoragePointer('r2', hashHex);
+
+    throw new Error(
+      `CloudflareR2Adapter not implemented for ${pointer.uri}. Provide @aws-sdk/client-s3 and wire up put().` // TODO
+    );
+
+  }
+
+  async get(_pointer: StoragePointer): Promise<Uint8Array> {
+    throw new Error(
+      'CloudflareR2Adapter not implemented. Provide @aws-sdk/client-s3 and wire up get().' // TODO
+    );
+  }
+
+  async delete(_pointer: StoragePointer): Promise<void> {
+    throw new Error(
+      'CloudflareR2Adapter not implemented. Provide @aws-sdk/client-s3 and wire up delete().' // TODO
+    );
+  }
+}

--- a/storage/types.ts
+++ b/storage/types.ts
@@ -1,0 +1,5 @@
+export type StoragePointer = {
+  uri: string; // aoc://storage/<backend>/0x<sha256>
+  backend: string; // "local" | "r2"
+  hash: string; // lowercase hex without 0x
+};


### PR DESCRIPTION
### Motivation
- Make the storage module self-contained and safer by moving SHA-256 hashing into a local helper and enforcing stricter pointer validation.
- Prevent malformed storage pointers (empty backend or non-lowercase/incorrect-length hashes) from being constructed or used.

### Description
- Add `storage/hash.ts` implementing `sha256Hex(data: Uint8Array): string` using Node `crypto` and switch adapters to import it (`storage/localFsAdapter.ts`, `storage/r2Adapter.ts`).
- Harden `buildStoragePointer` in `storage/pointer.ts` to validate `backend` is non-empty and `hashHex` matches `/^[0-9a-f]{64}$/`, throwing an `Error` on invalid input.
- Update tests in `storage/__tests__/localFsAdapter.test.ts` to produce a 64-char lowercase hash for the positive case and add a negative test asserting invalid hash inputs are rejected.
- Keep existing adapter behavior: `LocalFilesystemAdapter` computes and verifies SHA-256 on `put`/`get`, and `CloudflareR2Adapter` remains a stub that builds pointers and throws a not-implemented error.

### Testing
- No automated test suite was executed in this run; unit tests were updated but not run due to the test runner not being invoked in the environment.
- The repository contains updated Jest unit tests for the pointer behavior and local adapter, which should be executed in CI (e.g. `npm test`) to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812060a3ac8325bd77945ce04f2ab9)