### PR TITLE
Revert pack/** additions and retain content/** module

### DIFF
--- a/content/__tests__/content.test.ts
+++ b/content/__tests__/content.test.ts
@@ -1,0 +1,138 @@
+import { buildContentId } from '../contentId';
+import { buildContentManifest } from '../contentManifest';
+import { StoragePointer } from '../../storage/types';
+
+const baseStorage = (): StoragePointer => ({
+  backend: 'local',
+  hash: 'a'.repeat(64),
+  uri: `aoc://storage/local/0x${'a'.repeat(64)}`
+});
+
+describe('content manifest', () => {
+
+  it('produces deterministic content hashes for identical inputs', () => {
+    const manifestA = buildContentManifest(
+      'subject',
+      'text/plain',
+      baseStorage(),
+      128,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+    const manifestB = buildContentManifest(
+      'subject',
+      'text/plain',
+      baseStorage(),
+      128,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    expect(manifestA.content_hash).toBe(manifestB.content_hash);
+  });
+
+  it('changes content hash when inputs change', () => {
+    const base = buildContentManifest(
+      'subject',
+      'text/plain',
+      baseStorage(),
+      128,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const bytesChanged = buildContentManifest(
+      'subject',
+      'text/plain',
+      baseStorage(),
+      256,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const typeChanged = buildContentManifest(
+      'subject',
+      'application/json',
+      baseStorage(),
+      128,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const storageChanged = buildContentManifest(
+      'subject',
+      'text/plain',
+      {
+        backend: 'local',
+        hash: 'b'.repeat(64),
+        uri: `aoc://storage/local/0x${'b'.repeat(64)}`
+      },
+      128,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    expect(base.content_hash).not.toBe(bytesChanged.content_hash);
+    expect(base.content_hash).not.toBe(typeChanged.content_hash);
+    expect(base.content_hash).not.toBe(storageChanged.content_hash);
+  });
+
+  it('rejects invalid inputs', () => {
+    expect(() =>
+      buildContentManifest('', 'text/plain', baseStorage(), 128)
+    ).toThrow('Content subject must be non-empty.');
+
+    expect(() =>
+      buildContentManifest('subject', '', baseStorage(), 128)
+    ).toThrow('Content content_type must be non-empty.');
+
+    expect(() =>
+      buildContentManifest('subject', 'text/plain', {
+        backend: 'local',
+        hash: 'INVALID',
+        uri: 'aoc://storage/local/0xINVALID'
+      }, 128)
+    ).toThrow('Content storage hash must be 64 lowercase hex characters.');
+
+    expect(() =>
+      buildContentManifest('subject', 'text/plain', baseStorage(), 0)
+    ).toThrow('Content bytes must be a positive integer.');
+  });
+
+  it('rejects mismatched storage uri', () => {
+    const storage = baseStorage();
+    storage.uri = `aoc://storage/${storage.backend}/0x${'b'.repeat(64)}`;
+
+    expect(() =>
+      buildContentManifest('subject', 'text/plain', storage, 128)
+    ).toThrow('Content storage uri must match backend and hash.');
+  });
+});
+
+describe('content id', () => {
+  it('builds a valid content id', () => {
+    const manifest = buildContentManifest(
+      'subject',
+      'text/plain',
+      {
+        backend: 'local',
+        hash: 'a'.repeat(64),
+        uri: `aoc://storage/local/0x${'a'.repeat(64)}`
+      },
+      128,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const contentId = buildContentId(manifest);
+    expect(contentId).toMatch(/^aoc:\/\/content\/blob\/v1\/0\/0x[0-9a-f]{64}$/);
+  });
+
+  it('rejects invalid content hash', () => {
+    const manifest = buildContentManifest(
+      'subject',
+      'text/plain',
+      baseStorage(),
+      128,
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+    manifest.content_hash = 'INVALID';
+
+    expect(() => buildContentId(manifest)).toThrow(
+      'Content hash must be 64 lowercase hex characters.'
+    );
+  });
+});

--- a/content/canonical.ts
+++ b/content/canonical.ts
@@ -1,0 +1,11 @@
+import { canonicalizeJSON } from '../canonicalize';
+import { ContentManifestV1 } from './types';
+
+type ContentManifestPayload = Omit<ContentManifestV1, 'content_hash'>;
+
+export function canonicalizeContentManifestPayload(
+  payload: ContentManifestPayload
+): Uint8Array {
+  const canonical = canonicalizeJSON(payload);
+  return new TextEncoder().encode(canonical);
+}

--- a/content/contentId.ts
+++ b/content/contentId.ts
@@ -1,0 +1,21 @@
+import { buildAOCId } from '../aocId';
+import { ContentManifestV1 } from './types';
+
+export function buildContentId(manifest: ContentManifestV1): string {
+  if (typeof manifest.subject !== 'string' || manifest.subject.trim() === '') {
+    throw new Error('Content subject must be non-empty.');
+  }
+
+  if (typeof manifest.content_hash !== 'string' || !/^[0-9a-f]{64}$/.test(manifest.content_hash)) {
+    throw new Error('Content hash must be 64 lowercase hex characters.');
+  }
+
+  return buildAOCId('content', 'blob', 'v1', '0', {
+    subject: manifest.subject,
+    content_type: manifest.content_type,
+    bytes: manifest.bytes,
+    storage: manifest.storage,
+    created_at: manifest.created_at,
+    content_hash: manifest.content_hash
+  });
+}

--- a/content/contentManifest.ts
+++ b/content/contentManifest.ts
@@ -1,0 +1,62 @@
+import { canonicalizeContentManifestPayload } from './canonical';
+import { computeContentHash } from './hash';
+import { BuildContentOptions, ContentManifestV1 } from './types';
+import { StoragePointer } from '../storage/types';
+
+export function buildContentManifest(
+  subject: string,
+  content_type: string,
+  storage: StoragePointer,
+  bytes: number,
+  opts: BuildContentOptions = {}
+): ContentManifestV1 {
+  if (typeof subject !== 'string' || subject.trim() === '') {
+    throw new Error('Content subject must be non-empty.');
+  }
+
+  if (typeof content_type !== 'string' || content_type.trim() === '') {
+    throw new Error('Content content_type must be non-empty.');
+  }
+
+  if (typeof storage.backend !== 'string' || storage.backend.trim() === '') {
+    throw new Error('Content storage backend must be non-empty.');
+  }
+
+  if (typeof storage.hash !== 'string' || !/^[0-9a-f]{64}$/.test(storage.hash)) {
+    throw new Error('Content storage hash must be 64 lowercase hex characters.');
+  }
+
+  const expectedUri = `aoc://storage/${storage.backend}/0x${storage.hash}`;
+  if (storage.uri !== expectedUri) {
+    throw new Error('Content storage uri must match backend and hash.');
+  }
+
+  if (!Number.isInteger(bytes) || bytes <= 0) {
+    throw new Error('Content bytes must be a positive integer.');
+  }
+
+  const trimmedSubject = subject.trim();
+  const trimmedContentType = content_type.trim();
+  const created_at = (opts.now ?? new Date()).toISOString();
+
+  const payloadBytes = canonicalizeContentManifestPayload({
+    version: 1,
+    subject: trimmedSubject,
+    content_type: trimmedContentType,
+    bytes,
+    storage,
+    created_at
+  });
+
+  const content_hash = computeContentHash(payloadBytes);
+
+  return {
+    version: 1,
+    subject: trimmedSubject,
+    content_type: trimmedContentType,
+    bytes,
+    storage,
+    created_at,
+    content_hash
+  };
+}

--- a/content/hash.ts
+++ b/content/hash.ts
@@ -1,0 +1,5 @@
+import { sha256Hex } from '../storage/hash';
+
+export function computeContentHash(payloadBytes: Uint8Array): string {
+  return sha256Hex(payloadBytes);
+}

--- a/content/index.ts
+++ b/content/index.ts
@@ -1,0 +1,5 @@
+export { buildContentManifest } from './contentManifest';
+export { buildContentId } from './contentId';
+export { canonicalizeContentManifestPayload } from './canonical';
+export { computeContentHash } from './hash';
+export type { BuildContentOptions, ContentManifestV1 } from './types';

--- a/content/types.ts
+++ b/content/types.ts
@@ -1,0 +1,15 @@
+import { StoragePointer } from '../storage/types';
+
+export type ContentManifestV1 = {
+  version: 1;
+  subject: string;
+  content_type: string;
+  bytes: number;
+  storage: StoragePointer;
+  created_at: string;
+  content_hash: string;
+};
+
+export type BuildContentOptions = {
+  now?: Date;
+};


### PR DESCRIPTION
### Motivation
- Undo the previously added `pack/**` module files that the user requested to revert while preserving the newly added `content/**` implementation and its deterministic behavior.

### Description
- Removed all `pack/**` files that were introduced earlier, including `pack/types.ts`, `pack/canonical.ts`, `pack/hash.ts`, `pack/packManifest.ts`, `pack/packId.ts`, `pack/index.ts`, and `pack/__tests__/pack.test.ts` so the repository no longer contains the new pack helpers.
- Kept the `content/**` additions intact, which include `content/types.ts`, `content/canonical.ts`, `content/hash.ts`, `content/contentManifest.ts`, `content/contentId.ts`, `content/index.ts`, and `content/__tests__/content.test.ts` to provide deterministic content manifests and content ID builders.
- Updated repository state to reflect removal of the pack files while ensuring `content/**` remains exactly as implemented.

### Testing
- Ran `npm test` and all automated suites passed: `4` test suites, `21` tests passed, and `1` snapshot written.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698247a7b4608325889cd00259262536)