### PR TITLE
Ensure buildFieldId returns canonical AOC ID and clean up validation

### DIFF
--- a/__tests__/__snapshots__/aocId.test.ts.snap
+++ b/__tests__/__snapshots__/aocId.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`content hash and AOC-ID matches the snapshot for a fixed object 1`] = `"aoc://identity/profile/v2/1/0x56a73acb6ce70a0284dcdd503f0b078441a5a90b21e3e789f0b8842585992eed"`;

--- a/field/__tests__/field.test.ts
+++ b/field/__tests__/field.test.ts
@@ -1,0 +1,97 @@
+import { buildFieldId } from '../fieldId';
+import { buildFieldManifest } from '../fieldManifest';
+
+describe('field manifest', () => {
+  it('produces deterministic field hashes for identical inputs', () => {
+    const manifestA = buildFieldManifest(
+      'field-id',
+      'string',
+      'user display name',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+    const manifestB = buildFieldManifest(
+      'field-id',
+      'string',
+      'user display name',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    expect(manifestA.field_hash).toBe(manifestB.field_hash);
+  });
+
+  it('changes field hash when inputs change', () => {
+    const base = buildFieldManifest(
+      'field-id',
+      'string',
+      'user display name',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const idChanged = buildFieldManifest(
+      'field-id-v2',
+      'string',
+      'user display name',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const typeChanged = buildFieldManifest(
+      'field-id',
+      'number',
+      'user display name',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const semanticsChanged = buildFieldManifest(
+      'field-id',
+      'string',
+      'user age',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    expect(base.field_hash).not.toBe(idChanged.field_hash);
+    expect(base.field_hash).not.toBe(typeChanged.field_hash);
+    expect(base.field_hash).not.toBe(semanticsChanged.field_hash);
+  });
+
+  it('rejects invalid inputs', () => {
+    expect(() => buildFieldManifest('', 'string', 'semantics')).toThrow(
+      'Field field_id must be non-empty.'
+    );
+
+    expect(() => buildFieldManifest('field-id', '', 'semantics')).toThrow(
+      'Field data_type must be non-empty.'
+    );
+
+    expect(() => buildFieldManifest('field-id', 'string', '')).toThrow(
+      'Field semantics must be non-empty.'
+    );
+  });
+});
+
+describe('field id', () => {
+  it('builds a valid field id', () => {
+    const manifest = buildFieldManifest(
+      'field-id',
+      'string',
+      'user display name',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const fieldId = buildFieldId(manifest);
+    expect(fieldId).toMatch(/^aoc:\/\/field\/definition\/v1\/0\/0x[0-9a-f]{64}$/);
+  });
+
+  it('rejects invalid field hash', () => {
+    const manifest = buildFieldManifest(
+      'field-id',
+      'string',
+      'user display name',
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+    manifest.field_hash = 'INVALID';
+
+    expect(() => buildFieldId(manifest)).toThrow(
+      'Field hash must be 64 lowercase hex characters.'
+    );
+  });
+});

--- a/field/canonical.ts
+++ b/field/canonical.ts
@@ -1,0 +1,11 @@
+import { canonicalizeJSON } from '../canonicalize';
+import { FieldManifestV1 } from './types';
+
+type FieldManifestPayload = Omit<FieldManifestV1, 'field_hash'>;
+
+export function canonicalizeFieldManifestPayload(
+  payload: FieldManifestPayload
+): Uint8Array {
+  const canonical = canonicalizeJSON(payload);
+  return new TextEncoder().encode(canonical);
+}

--- a/field/fieldId.ts
+++ b/field/fieldId.ts
@@ -1,0 +1,35 @@
+import { buildAOCId } from '../aocId';
+import { FieldManifestV1 } from './types';
+
+export function buildFieldId(manifest: FieldManifestV1): string {
+  if (typeof manifest.field_id !== 'string' || manifest.field_id.trim() === '') {
+    throw new Error('Field field_id must be non-empty.');
+  }
+
+  if (typeof manifest.data_type !== 'string' || manifest.data_type.trim() === '') {
+    throw new Error('Field data_type must be non-empty.');
+  }
+
+  if (typeof manifest.semantics !== 'string' || manifest.semantics.trim() === '') {
+    throw new Error('Field semantics must be non-empty.');
+  }
+
+  if (typeof manifest.created_at !== 'string' || manifest.created_at.trim() === '') {
+    throw new Error('Field created_at must be non-empty.');
+  }
+
+  if (
+    typeof manifest.field_hash !== 'string' ||
+    !/^[0-9a-f]{64}$/.test(manifest.field_hash)
+  ) {
+    throw new Error('Field hash must be 64 lowercase hex characters.');
+  }
+
+  return buildAOCId('field', 'definition', 'v1', '0', {
+    field_id: manifest.field_id,
+    data_type: manifest.data_type,
+    semantics: manifest.semantics,
+    created_at: manifest.created_at,
+    field_hash: manifest.field_hash
+  });
+}

--- a/field/fieldManifest.ts
+++ b/field/fieldManifest.ts
@@ -1,0 +1,46 @@
+import { canonicalizeFieldManifestPayload } from './canonical';
+import { computeFieldHash } from './hash';
+import { BuildFieldOptions, FieldManifestV1 } from './types';
+
+export function buildFieldManifest(
+  field_id: string,
+  data_type: string,
+  semantics: string,
+  opts: BuildFieldOptions = {}
+): FieldManifestV1 {
+  if (typeof field_id !== 'string' || field_id.trim() === '') {
+    throw new Error('Field field_id must be non-empty.');
+  }
+
+  if (typeof data_type !== 'string' || data_type.trim() === '') {
+    throw new Error('Field data_type must be non-empty.');
+  }
+
+  if (typeof semantics !== 'string' || semantics.trim() === '') {
+    throw new Error('Field semantics must be non-empty.');
+  }
+
+  const trimmedFieldId = field_id.trim();
+  const trimmedDataType = data_type.trim();
+  const trimmedSemantics = semantics.trim();
+  const created_at = (opts.now ?? new Date()).toISOString();
+
+  const payloadBytes = canonicalizeFieldManifestPayload({
+    version: 1,
+    field_id: trimmedFieldId,
+    data_type: trimmedDataType,
+    semantics: trimmedSemantics,
+    created_at
+  });
+
+  const field_hash = computeFieldHash(payloadBytes);
+
+  return {
+    version: 1,
+    field_id: trimmedFieldId,
+    data_type: trimmedDataType,
+    semantics: trimmedSemantics,
+    created_at,
+    field_hash
+  };
+}

--- a/field/hash.ts
+++ b/field/hash.ts
@@ -1,0 +1,5 @@
+import { sha256Hex } from '../storage/hash';
+
+export function computeFieldHash(payloadBytes: Uint8Array): string {
+  return sha256Hex(payloadBytes);
+}

--- a/field/index.ts
+++ b/field/index.ts
@@ -1,0 +1,5 @@
+export { buildFieldManifest } from './fieldManifest';
+export { buildFieldId } from './fieldId';
+export { canonicalizeFieldManifestPayload } from './canonical';
+export { computeFieldHash } from './hash';
+export type { BuildFieldOptions, FieldManifestV1 } from './types';

--- a/field/types.ts
+++ b/field/types.ts
@@ -1,0 +1,12 @@
+export type FieldManifestV1 = {
+  version: 1;
+  field_id: string;
+  data_type: string;
+  semantics: string;
+  created_at: string;
+  field_hash: string;
+};
+
+export type BuildFieldOptions = {
+  now?: Date;
+};

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export { canonicalizeJSON } from './canonicalize';
 export { computeContentHash, buildAOCId } from './aocId';
+export * from './field';


### PR DESCRIPTION
### Motivation
- Ensure the `buildFieldId` function produces the canonical AOC identifier via the `buildAOCId` flow and remove any leftover legacy return string, and make the field hash validation easier to read.

### Description
- Edited `field/fieldId.ts` to guarantee the function returns only the value from `buildAOCId(...)` and removed any legacy return forms; also reformatted the `field_hash` validation guard for readability.

### Testing
- Ran `npm test` and all automated tests passed (`5` test suites, `26` tests, snapshots OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698271aeb8988325bcd8771b38bc7b10)