### PR TITLE
Standardize Storage Pointer URI format to canonical AOC scheme

### DIFF
--- a/protocol/content/content-object-spec.md
+++ b/protocol/content/content-object-spec.md
@@ -995,8 +995,8 @@ Given the Content Object fields:
 - content_type: `"text/plain"`
 - bytes: `100`
 - storage.backend: `"local"`
-- storage.uri: `"aoc://storage/local/0xabc..."`
-- storage.hash: `"abc..."`
+- storage.uri: `"aoc://storage/local/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`
+- storage.hash: `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`
 - created_at: `1700000000`
 
 The canonical encoding MUST produce keys in this order:
@@ -1044,7 +1044,9 @@ The canonical encoding MUST produce keys in this order:
         },
         "uri": {
           "type": "string",
-          "pattern": "^aoc://storage/[a-z][a-z0-9]*(-[a-z0-9]+)*/0x[a-f0-9]{64}$"
+          "pattern": "^aoc://storage/[a-z][a-z0-9]*(-[a-z0-9]+)*/0x[a-f0-9]{64}$",
+          "minLength": 1,
+          "maxLength": 2048
         },
         "hash": {
           "type": "string",


### PR DESCRIPTION
## Summary
This PR standardizes the Storage Pointer URI format across the AOC Protocol specification by replacing backend-specific URI schemes with a canonical `aoc://storage/` format. This change ensures consistent URI representation regardless of the underlying storage backend.

## Key Changes

- **Backend field pattern**: Updated regex from `^[a-z][a-z0-9-]*$` to `^[a-z][a-z0-9]*(-[a-z0-9]+)*$` to enforce hyphen-separated segments (hyphens cannot be leading, trailing, or consecutive)

- **URI field standardization**: 
  - Changed from backend-specific formats (e.g., `s3://`, `ipfs://`, `file://`) to canonical format: `aoc://storage/{backend}/0x{hash}`
  - Updated format description from "Backend-specific URI" to "AOC Storage URI"
  - Replaced flexible constraints with strict pattern matching: `^aoc://storage/[a-z][a-z0-9]*(-[a-z0-9]+)*/0x[a-f0-9]{64}$`

- **Documentation updates**:
  - Removed the "URI Format by Backend" reference table showing backend-specific schemes
  - Updated URI field description to clarify that URIs are derived deterministically from `backend` and `hash` fields
  - Updated all example Content Objects to use the new canonical URI format

## Implementation Details

The canonical URI format `aoc://storage/{backend}/0x{hash}` provides:
- **Deterministic derivation**: URIs can be reconstructed from the `backend` and `hash` fields
- **Consistency**: Single URI format across all storage backends
- **Validation**: Strict pattern matching ensures well-formed URIs
- **Clarity**: The `0x` prefix explicitly indicates the hash is hexadecimal

All example payloads and test cases have been updated to reflect this new standard.

https://claude.ai/code/session_01JyvcHAisbZH2szmeWMtNwr