### PR TITLE
Fix content module signatures, validation, ID builder, and tests

### DIFF
--- a/content/__tests__/content.test.ts
+++ b/content/__tests__/content.test.ts
@@ -14,15 +14,15 @@ describe('content manifest', () => {
     const manifestA = buildContentManifest(
       'subject',
       'text/plain',
-      baseStorage(),
       128,
+      baseStorage(),
       { now: new Date('2024-01-01T00:00:00Z') }
     );
     const manifestB = buildContentManifest(
       'subject',
       'text/plain',
-      baseStorage(),
       128,
+      baseStorage(),
       { now: new Date('2024-01-01T00:00:00Z') }
     );
 
@@ -33,63 +33,81 @@ describe('content manifest', () => {
     const base = buildContentManifest(
       'subject',
       'text/plain',
-      baseStorage(),
       128,
+      baseStorage(),
+      { now: new Date('2024-01-01T00:00:00Z') }
+    );
+
+    const subjectChanged = buildContentManifest(
+      'subject-changed',
+      'text/plain',
+      128,
+      baseStorage(),
       { now: new Date('2024-01-01T00:00:00Z') }
     );
 
     const bytesChanged = buildContentManifest(
       'subject',
       'text/plain',
-      baseStorage(),
       256,
+      baseStorage(),
       { now: new Date('2024-01-01T00:00:00Z') }
     );
 
     const typeChanged = buildContentManifest(
       'subject',
       'application/json',
-      baseStorage(),
       128,
+      baseStorage(),
       { now: new Date('2024-01-01T00:00:00Z') }
     );
 
     const storageChanged = buildContentManifest(
       'subject',
       'text/plain',
+      128,
       {
         backend: 'local',
         hash: 'b'.repeat(64),
         uri: `aoc://storage/local/0x${'b'.repeat(64)}`
       },
-      128,
       { now: new Date('2024-01-01T00:00:00Z') }
     );
 
+    const createdAtChanged = buildContentManifest(
+      'subject',
+      'text/plain',
+      128,
+      baseStorage(),
+      { now: new Date('2024-01-01T01:00:00Z') }
+    );
+
+    expect(base.content_hash).not.toBe(subjectChanged.content_hash);
     expect(base.content_hash).not.toBe(bytesChanged.content_hash);
     expect(base.content_hash).not.toBe(typeChanged.content_hash);
     expect(base.content_hash).not.toBe(storageChanged.content_hash);
+    expect(base.content_hash).not.toBe(createdAtChanged.content_hash);
   });
 
   it('rejects invalid inputs', () => {
     expect(() =>
-      buildContentManifest('', 'text/plain', baseStorage(), 128)
+      buildContentManifest('', 'text/plain', 128, baseStorage())
     ).toThrow('Content subject must be non-empty.');
 
     expect(() =>
-      buildContentManifest('subject', '', baseStorage(), 128)
+      buildContentManifest('subject', '', 128, baseStorage())
     ).toThrow('Content content_type must be non-empty.');
 
     expect(() =>
-      buildContentManifest('subject', 'text/plain', {
+      buildContentManifest('subject', 'text/plain', 128, {
         backend: 'local',
         hash: 'INVALID',
         uri: 'aoc://storage/local/0xINVALID'
-      }, 128)
+      })
     ).toThrow('Content storage hash must be 64 lowercase hex characters.');
 
     expect(() =>
-      buildContentManifest('subject', 'text/plain', baseStorage(), 0)
+      buildContentManifest('subject', 'text/plain', 0, baseStorage())
     ).toThrow('Content bytes must be a positive integer.');
   });
 
@@ -98,7 +116,7 @@ describe('content manifest', () => {
     storage.uri = `aoc://storage/${storage.backend}/0x${'b'.repeat(64)}`;
 
     expect(() =>
-      buildContentManifest('subject', 'text/plain', storage, 128)
+      buildContentManifest('subject', 'text/plain', 128, storage)
     ).toThrow('Content storage uri must match backend and hash.');
   });
 });
@@ -108,25 +126,25 @@ describe('content id', () => {
     const manifest = buildContentManifest(
       'subject',
       'text/plain',
+      128,
       {
         backend: 'local',
         hash: 'a'.repeat(64),
         uri: `aoc://storage/local/0x${'a'.repeat(64)}`
       },
-      128,
       { now: new Date('2024-01-01T00:00:00Z') }
     );
 
     const contentId = buildContentId(manifest);
-    expect(contentId).toMatch(/^aoc:\/\/content\/blob\/v1\/0\/0x[0-9a-f]{64}$/);
+    expect(contentId).toMatch(/^aoc:\/\/content\/object\/v1\/0\/0x[0-9a-f]{64}$/);
   });
 
   it('rejects invalid content hash', () => {
     const manifest = buildContentManifest(
       'subject',
       'text/plain',
-      baseStorage(),
       128,
+      baseStorage(),
       { now: new Date('2024-01-01T00:00:00Z') }
     );
     manifest.content_hash = 'INVALID';

--- a/content/contentId.ts
+++ b/content/contentId.ts
@@ -6,11 +6,24 @@ export function buildContentId(manifest: ContentManifestV1): string {
     throw new Error('Content subject must be non-empty.');
   }
 
+  if (typeof manifest.content_type !== 'string' || manifest.content_type.trim() === '') {
+    throw new Error('Content content_type must be non-empty.');
+  }
+
+  if (!Number.isInteger(manifest.bytes) || manifest.bytes <= 0) {
+    throw new Error('Content bytes must be a positive integer.');
+  }
+
+  if (typeof manifest.created_at !== 'string' || manifest.created_at.trim() === '') {
+    throw new Error('Content created_at must be non-empty.');
+  }
+
   if (typeof manifest.content_hash !== 'string' || !/^[0-9a-f]{64}$/.test(manifest.content_hash)) {
     throw new Error('Content hash must be 64 lowercase hex characters.');
   }
 
-  return buildAOCId('content', 'blob', 'v1', '0', {
+  return buildAOCId('content', 'object', 'v1', '0', {
+    version: manifest.version,
     subject: manifest.subject,
     content_type: manifest.content_type,
     bytes: manifest.bytes,

--- a/content/contentManifest.ts
+++ b/content/contentManifest.ts
@@ -6,8 +6,8 @@ import { StoragePointer } from '../storage/types';
 export function buildContentManifest(
   subject: string,
   content_type: string,
-  storage: StoragePointer,
   bytes: number,
+  storage: StoragePointer,
   opts: BuildContentOptions = {}
 ): ContentManifestV1 {
   if (typeof subject !== 'string' || subject.trim() === '') {
@@ -16,6 +16,10 @@ export function buildContentManifest(
 
   if (typeof content_type !== 'string' || content_type.trim() === '') {
     throw new Error('Content content_type must be non-empty.');
+  }
+
+  if (!Number.isInteger(bytes) || bytes <= 0) {
+    throw new Error('Content bytes must be a positive integer.');
   }
 
   if (typeof storage.backend !== 'string' || storage.backend.trim() === '') {
@@ -29,10 +33,6 @@ export function buildContentManifest(
   const expectedUri = `aoc://storage/${storage.backend}/0x${storage.hash}`;
   if (storage.uri !== expectedUri) {
     throw new Error('Content storage uri must match backend and hash.');
-  }
-
-  if (!Number.isInteger(bytes) || bytes <= 0) {
-    throw new Error('Content bytes must be a positive integer.');
   }
 
   const trimmedSubject = subject.trim();

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
 export { canonicalizeJSON } from './canonicalize';
 export { computeContentHash, buildAOCId } from './aocId';
+export * from './content';
 export * from './field';


### PR DESCRIPTION
### Motivation
- Align the content manifest and ID builders with the normative content-object spec to ensure deterministic manifests and IDs. 
- Eliminate broken function signatures, leftover return/blob references, and corrupted tests that prevented correct validation and ID construction.

### Description
- Corrected `buildContentManifest` signature and parameter ordering to `subject, content_type, bytes, storage, opts?` and added precise validations for `subject`, `content_type`, `bytes`, `storage.backend`, `storage.hash`, and `storage.uri` in `content/contentManifest.ts`.
- Ensured canonical payload shape is `{ version, subject, content_type, bytes, storage, created_at }` and computed `content_hash` via `computeContentHash` on the canonical bytes in `content/contentManifest.ts`.
- Fixed `buildContentId` in `content/contentId.ts` to validate `subject`, `content_type`, `bytes`, `created_at`, and `content_hash`, to include `version` in the ID payload, and to emit an `object` content ID via `buildAOCId('content','object','v1','0', ...)`.
- Cleaned and repaired tests in `content/__tests__/content.test.ts` to remove corrupted/unused lines, fix argument ordering, and assert the ID regex `^aoc:\/\/content\/object\/v1\/0\/0x[0-9a-f]{64}$`.
- Exported the content module from the root `index.ts` to keep module exports consistent.

### Testing
- Ran the full test suite with `npm test` and all automated tests passed (Test Suites: 5 passed, Tests: 26 passed, Snapshots: 1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982c92588cc8325b53e883e8fa4fd33)