### PR TITLE
Add Capability Token runtime module (v0.1) with authorization semantics

### DIFF
--- a/capability/__tests__/capability.test.ts
+++ b/capability/__tests__/capability.test.ts
@@ -1,0 +1,1085 @@
+import { buildConsentObject } from '../../consent/consentObject';
+import { ScopeEntry } from '../../consent/types';
+import {
+  mintCapabilityToken,
+  validateCapabilityToken,
+  verifyCapabilityToken,
+  resetNonceRegistry
+} from '../capabilityToken';
+import { buildCapabilityId } from '../capabilityId';
+import { canonicalizeCapabilityPayload } from '../canonical';
+import { computeCapabilityHash } from '../hash';
+import {
+  revokeCapabilityToken,
+  isRevoked,
+  resetRevocationRegistry
+} from '../revocation';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const REF_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const REF_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const REF_C = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+const baseScope: ScopeEntry[] = [{ type: 'content', ref: REF_A }];
+const multiScope: ScopeEntry[] = [
+  { type: 'content', ref: REF_A },
+  { type: 'content', ref: REF_B },
+  { type: 'pack', ref: REF_C }
+];
+const basePermissions = ['read'];
+const multiPermissions = ['read', 'store'];
+
+const consentNow = new Date('2025-01-15T14:30:00Z');
+const tokenNow = new Date('2025-06-15T10:00:00Z');
+const tokenExpires = '2025-12-31T23:59:59Z';
+const consentExpires = '2026-01-15T14:30:00Z';
+
+function buildBaseConsent(opts: {
+  scope?: ScopeEntry[];
+  permissions?: string[];
+  expires_at?: string | null;
+} = {}) {
+  return buildConsentObject(
+    SUBJECT,
+    GRANTEE,
+    'grant',
+    opts.scope ?? multiScope,
+    opts.permissions ?? multiPermissions,
+    {
+      now: consentNow,
+      expires_at: 'expires_at' in opts ? opts.expires_at : consentExpires
+    }
+  );
+}
+
+// Reset in-memory registries between tests
+beforeEach(() => {
+  resetNonceRegistry();
+  resetRevocationRegistry();
+});
+
+describe('capability token minting', () => {
+  it('mints a valid capability token from a grant consent', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      tokenExpires,
+      { now: tokenNow }
+    );
+
+    expect(token.version).toBe('1.0');
+    expect(token.subject).toBe(SUBJECT);
+    expect(token.grantee).toBe(GRANTEE);
+    expect(token.consent_ref).toBe(consent.consent_hash);
+    expect(token.scope).toEqual(baseScope);
+    expect(token.permissions).toEqual(basePermissions);
+    expect(token.issued_at).toBe('2025-06-15T10:00:00Z');
+    expect(token.not_before).toBeNull();
+    expect(token.expires_at).toBe(tokenExpires);
+    expect(token.token_id).toMatch(/^[a-f0-9]{64}$/);
+    expect(token.capability_hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces deterministic hashes for identical payloads (same token_id)', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      tokenExpires,
+      { now: tokenNow }
+    );
+
+    // Recompute hash from the token's payload
+    const payloadBytes = canonicalizeCapabilityPayload({
+      version: token.version,
+      subject: token.subject,
+      grantee: token.grantee,
+      consent_ref: token.consent_ref,
+      scope: token.scope,
+      permissions: token.permissions,
+      issued_at: token.issued_at,
+      not_before: token.not_before,
+      expires_at: token.expires_at,
+      token_id: token.token_id
+    });
+    const expectedHash = computeCapabilityHash(payloadBytes);
+
+    expect(token.capability_hash).toBe(expectedHash);
+  });
+
+  it('produces unique token_ids across mints', () => {
+    const consent = buildBaseConsent();
+    const token1 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    const token2 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(token1.token_id).not.toBe(token2.token_id);
+    expect(token1.capability_hash).not.toBe(token2.capability_hash);
+  });
+
+  it('mints with not_before set', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      tokenExpires,
+      { now: tokenNow, not_before: '2025-07-01T00:00:00Z' }
+    );
+
+    expect(token.not_before).toBe('2025-07-01T00:00:00Z');
+  });
+
+  it('mints with full consent scope and permissions (no attenuation)', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent,
+      multiScope,
+      multiPermissions,
+      tokenExpires,
+      { now: tokenNow }
+    );
+
+    expect(token.scope).toEqual(multiScope);
+    expect(token.permissions).toEqual(multiPermissions);
+  });
+
+  it('mints with attenuated scope', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent,
+      [{ type: 'content', ref: REF_A }],
+      multiPermissions,
+      tokenExpires,
+      { now: tokenNow }
+    );
+
+    expect(token.scope).toHaveLength(1);
+  });
+
+  it('mints with attenuated permissions', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent,
+      multiScope,
+      ['read'],
+      tokenExpires,
+      { now: tokenNow }
+    );
+
+    expect(token.permissions).toEqual(['read']);
+  });
+
+  it('mints with temporal attenuation (earlier expires_at)', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      '2025-09-01T00:00:00Z',
+      { now: tokenNow }
+    );
+
+    expect(token.expires_at).toBe('2025-09-01T00:00:00Z');
+  });
+
+  it('mints when parent consent has null expires_at', () => {
+    const consent = buildBaseConsent({ expires_at: null });
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      '2099-12-31T23:59:59Z',
+      { now: tokenNow }
+    );
+
+    expect(token.expires_at).toBe('2099-12-31T23:59:59Z');
+  });
+
+  it('accepts did:aoc:public as grantee', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      'did:aoc:public',
+      'grant',
+      multiScope,
+      multiPermissions,
+      { now: consentNow, expires_at: consentExpires }
+    );
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(token.grantee).toBe('did:aoc:public');
+  });
+});
+
+describe('capability token minting — rejection paths', () => {
+  it('rejects minting from a revoke consent', () => {
+    const grant = buildBaseConsent();
+    const revoke = buildConsentObject(
+      SUBJECT, GRANTEE, 'revoke', multiScope, multiPermissions,
+      { now: tokenNow, prior_consent: grant.consent_hash }
+    );
+
+    expect(() =>
+      mintCapabilityToken(revoke, baseScope, basePermissions, tokenExpires, { now: tokenNow })
+    ).toThrow('Capability token can only be derived from a consent with action "grant".');
+  });
+
+  it('rejects scope escalation (scope entry not in consent)', () => {
+    const consent = buildBaseConsent({ scope: baseScope });
+    const extraScope: ScopeEntry[] = [
+      { type: 'content', ref: REF_A },
+      { type: 'pack', ref: REF_C }
+    ];
+
+    expect(() =>
+      mintCapabilityToken(consent, extraScope, basePermissions, tokenExpires, { now: tokenNow })
+    ).toThrow('Scope escalation');
+  });
+
+  it('rejects permission escalation (permission not in consent)', () => {
+    const consent = buildBaseConsent({ permissions: ['read'] });
+
+    expect(() =>
+      mintCapabilityToken(consent, baseScope, ['read', 'store'], tokenExpires, { now: tokenNow })
+    ).toThrow('Permission escalation');
+  });
+
+  it('rejects expires_at before issued_at', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions,
+        '2025-01-01T00:00:00Z',
+        { now: tokenNow }
+      )
+    ).toThrow('Capability expires_at must be after issued_at.');
+  });
+
+  it('rejects expires_at equal to issued_at', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions,
+        '2025-06-15T10:00:00Z',
+        { now: tokenNow }
+      )
+    ).toThrow('Capability expires_at must be after issued_at.');
+  });
+
+  it('rejects expires_at beyond consent expires_at', () => {
+    const consent = buildBaseConsent({ expires_at: '2025-12-01T00:00:00Z' });
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions,
+        '2026-01-01T00:00:00Z',
+        { now: tokenNow }
+      )
+    ).toThrow('Capability expires_at must not exceed parent consent expires_at.');
+  });
+
+  it('rejects issued_at before consent issued_at', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions, tokenExpires,
+        { now: new Date('2025-01-01T00:00:00Z') }
+      )
+    ).toThrow('Capability issued_at must be at or after parent consent issued_at.');
+  });
+
+  it('rejects not_before before issued_at', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions, tokenExpires,
+        { now: tokenNow, not_before: '2025-01-01T00:00:00Z' }
+      )
+    ).toThrow('Capability not_before must be at or after issued_at.');
+  });
+
+  it('rejects not_before at or after expires_at', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions, tokenExpires,
+        { now: tokenNow, not_before: tokenExpires }
+      )
+    ).toThrow('Capability not_before must be before expires_at.');
+  });
+
+  it('rejects not_before before consent issued_at', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions, tokenExpires,
+        { now: tokenNow, not_before: '2025-01-01T00:00:00Z' }
+      )
+    ).toThrow('Capability not_before must be at or after issued_at.');
+  });
+
+  it('rejects empty scope', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(consent, [], basePermissions, tokenExpires, { now: tokenNow })
+    ).toThrow('Capability scope must be a non-empty array.');
+  });
+
+  it('rejects empty permissions', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(consent, baseScope, [], tokenExpires, { now: tokenNow })
+    ).toThrow('Capability permissions must be a non-empty array.');
+  });
+
+  it('rejects duplicate scope entries', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent,
+        [{ type: 'content', ref: REF_A }, { type: 'content', ref: REF_A }],
+        basePermissions,
+        tokenExpires,
+        { now: tokenNow }
+      )
+    ).toThrow('Capability scope contains duplicate entry');
+  });
+
+  it('rejects duplicate permissions', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent,
+        baseScope,
+        ['read', 'read'],
+        tokenExpires,
+        { now: tokenNow }
+      )
+    ).toThrow('Capability permissions contain duplicate');
+  });
+
+  it('rejects invalid scope type', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent,
+        [{ type: 'invalid' as any, ref: REF_A }],
+        basePermissions,
+        tokenExpires,
+        { now: tokenNow }
+      )
+    ).toThrow('Scope entry 0: type must be "field", "content", or "pack".');
+  });
+
+  it('rejects invalid scope ref', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent,
+        [{ type: 'content', ref: 'INVALID' }],
+        basePermissions,
+        tokenExpires,
+        { now: tokenNow }
+      )
+    ).toThrow('Scope entry 0: ref must be 64 lowercase hex characters.');
+  });
+
+  it('rejects invalid permission format', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, ['Read'], tokenExpires, { now: tokenNow }
+      )
+    ).toThrow('Capability permission 0: must be lowercase alphanumeric with hyphens.');
+  });
+
+  it('rejects invalid expires_at format', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions, '2025-12-31', { now: tokenNow }
+      )
+    ).toThrow('Capability expires_at must be ISO 8601 UTC format');
+  });
+
+  it('rejects invalid not_before format', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent, baseScope, basePermissions, tokenExpires,
+        { now: tokenNow, not_before: 'bad-date' }
+      )
+    ).toThrow('Capability not_before must be ISO 8601 UTC format');
+  });
+});
+
+describe('capability token validation (structural)', () => {
+  it('validates a correctly minted token', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(() => validateCapabilityToken(token)).not.toThrow();
+  });
+
+  it('rejects a token with tampered capability_hash', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    token.capability_hash = 'a'.repeat(64);
+
+    expect(() => validateCapabilityToken(token)).toThrow(
+      'Capability capability_hash does not match canonical payload hash.'
+    );
+  });
+
+  it('rejects a token with tampered subject', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    token.subject = 'did:key:z6MkTamperedSubject123456789abcdef';
+
+    expect(() => validateCapabilityToken(token)).toThrow(
+      'Capability capability_hash does not match canonical payload hash.'
+    );
+  });
+
+  it('rejects a token with tampered consent_ref', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    token.consent_ref = 'b'.repeat(64);
+
+    expect(() => validateCapabilityToken(token)).toThrow(
+      'Capability capability_hash does not match canonical payload hash.'
+    );
+  });
+
+  it('rejects a token with invalid capability_hash format', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    token.capability_hash = 'INVALID';
+
+    expect(() => validateCapabilityToken(token)).toThrow(
+      'Capability capability_hash must be 64 lowercase hex characters.'
+    );
+  });
+});
+
+describe('capability token verification', () => {
+  it('verifies a valid token against its parent consent', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).not.toThrow();
+  });
+
+  it('rejects verification when consent_ref does not match', () => {
+    const consent = buildBaseConsent();
+    const differentConsent = buildConsentObject(
+      SUBJECT, GRANTEE, 'grant', multiScope, multiPermissions,
+      { now: new Date('2025-02-01T00:00:00Z'), expires_at: consentExpires }
+    );
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(() =>
+      verifyCapabilityToken(token, differentConsent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Capability consent_ref does not match parent consent consent_hash.');
+  });
+
+  it('rejects verification when parent consent is a revoke', () => {
+    const grant = buildBaseConsent();
+    const token = mintCapabilityToken(
+      grant, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    // Construct a revoke consent that happens to have the same hash
+    // (in practice we just pass the wrong consent)
+    const revoke = buildConsentObject(
+      SUBJECT, GRANTEE, 'revoke', multiScope, multiPermissions,
+      { now: tokenNow, prior_consent: grant.consent_hash }
+    );
+
+    // The consent_ref won't match, but the action check comes after
+    // We need to manually test the action rejection path:
+    // Force the consent_hash to match the token's consent_ref
+    const fakeConsent = { ...revoke, consent_hash: token.consent_ref };
+
+    expect(() =>
+      verifyCapabilityToken(token, fakeConsent as any, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Parent consent action must be "grant".');
+  });
+
+  it('rejects verification when subject does not match', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const mismatchConsent = { ...consent, subject: 'did:key:z6MkDifferentSubject1234567890abc' };
+
+    expect(() =>
+      verifyCapabilityToken(token, mismatchConsent as any, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Capability subject does not match parent consent subject.');
+  });
+
+  it('rejects verification when grantee does not match', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const mismatchConsent = { ...consent, grantee: 'did:key:z6MkDifferentGrantee1234567890abc' };
+
+    expect(() =>
+      verifyCapabilityToken(token, mismatchConsent as any, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Capability grantee does not match parent consent grantee.');
+  });
+});
+
+describe('capability token — expired token rejection', () => {
+  it('rejects an expired token', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, '2025-07-01T00:00:00Z',
+      { now: tokenNow }
+    );
+
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Capability token has expired.');
+  });
+
+  it('accepts a token at exactly its expires_at', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, '2025-07-01T00:00:00Z',
+      { now: tokenNow }
+    );
+
+    // At exactly expires_at, now === expires_at, so now > expires_at is false
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-07-01T00:00:00Z') })
+    ).not.toThrow();
+  });
+
+  it('rejects a token before its not_before', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires,
+      { now: tokenNow, not_before: '2025-09-01T00:00:00Z' }
+    );
+
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Capability token is not yet valid (before not_before).');
+  });
+
+  it('accepts a token at exactly its not_before', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires,
+      { now: tokenNow, not_before: '2025-09-01T00:00:00Z' }
+    );
+
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-09-01T00:00:00Z') })
+    ).not.toThrow();
+  });
+});
+
+describe('capability token — scope escalation rejection', () => {
+  it('rejects verification when token has scope entries outside consent scope', () => {
+    const consent = buildBaseConsent({ scope: baseScope });
+    // Manually create a token with extra scope (bypassing mint validation)
+    const validToken = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    // Tamper with scope to add an escalated entry
+    const tampered = {
+      ...validToken,
+      scope: [
+        ...baseScope,
+        { type: 'pack' as const, ref: REF_C }
+      ]
+    };
+    // Recompute hash for the tampered payload (so structural validation passes)
+    const payloadBytes = canonicalizeCapabilityPayload({
+      version: tampered.version,
+      subject: tampered.subject,
+      grantee: tampered.grantee,
+      consent_ref: tampered.consent_ref,
+      scope: tampered.scope,
+      permissions: tampered.permissions,
+      issued_at: tampered.issued_at,
+      not_before: tampered.not_before,
+      expires_at: tampered.expires_at,
+      token_id: tampered.token_id
+    });
+    tampered.capability_hash = computeCapabilityHash(payloadBytes);
+
+    expect(() =>
+      verifyCapabilityToken(tampered as any, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Scope escalation');
+  });
+
+  it('rejects verification when token has permissions outside consent permissions', () => {
+    const consent = buildBaseConsent({ permissions: ['read'] });
+    const validToken = mintCapabilityToken(
+      consent, baseScope, ['read'], tokenExpires, { now: tokenNow }
+    );
+    // Tamper with permissions
+    const tampered = {
+      ...validToken,
+      permissions: ['read', 'store']
+    };
+    const payloadBytes = canonicalizeCapabilityPayload({
+      version: tampered.version,
+      subject: tampered.subject,
+      grantee: tampered.grantee,
+      consent_ref: tampered.consent_ref,
+      scope: tampered.scope,
+      permissions: tampered.permissions,
+      issued_at: tampered.issued_at,
+      not_before: tampered.not_before,
+      expires_at: tampered.expires_at,
+      token_id: tampered.token_id
+    });
+    tampered.capability_hash = computeCapabilityHash(payloadBytes);
+
+    expect(() =>
+      verifyCapabilityToken(tampered as any, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Permission escalation');
+  });
+});
+
+describe('capability token — replay rejection via nonce reuse', () => {
+  it('rejects a token presented a second time (same token_id)', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    // First presentation succeeds
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).not.toThrow();
+
+    // Second presentation fails (replay)
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-08-01T00:00:01Z') })
+    ).toThrow('Capability token_id has already been presented (replay detected).');
+  });
+
+  it('allows different tokens to be verified independently', () => {
+    const consent = buildBaseConsent();
+    const token1 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    const token2 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(() =>
+      verifyCapabilityToken(token1, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).not.toThrow();
+
+    expect(() =>
+      verifyCapabilityToken(token2, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).not.toThrow();
+  });
+});
+
+describe('capability token — revoked token rejection', () => {
+  it('rejects a revoked token', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    revokeCapabilityToken(token.capability_hash);
+    expect(isRevoked(token.capability_hash)).toBe(true);
+
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).toThrow('Capability token has been revoked.');
+  });
+
+  it('allows a non-revoked token to verify', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(isRevoked(token.capability_hash)).toBe(false);
+
+    expect(() =>
+      verifyCapabilityToken(token, consent, { now: new Date('2025-08-01T00:00:00Z') })
+    ).not.toThrow();
+  });
+
+  it('revocation of one token does not affect others', () => {
+    const consent = buildBaseConsent();
+    const token1 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    const token2 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    revokeCapabilityToken(token1.capability_hash);
+
+    expect(isRevoked(token1.capability_hash)).toBe(true);
+    expect(isRevoked(token2.capability_hash)).toBe(false);
+  });
+
+  it('rejects revocation with invalid hash format', () => {
+    expect(() => revokeCapabilityToken('INVALID')).toThrow(
+      'Revocation target must be a valid capability_hash (64 lowercase hex characters).'
+    );
+  });
+});
+
+describe('capability token canonicalization', () => {
+  it('produces canonical JSON with no whitespace', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const bytes = canonicalizeCapabilityPayload({
+      version: token.version,
+      subject: token.subject,
+      grantee: token.grantee,
+      consent_ref: token.consent_ref,
+      scope: token.scope,
+      permissions: token.permissions,
+      issued_at: token.issued_at,
+      not_before: token.not_before,
+      expires_at: token.expires_at,
+      token_id: token.token_id
+    });
+    const json = Buffer.from(bytes).toString();
+
+    expect(json).not.toContain(' ');
+    expect(json).not.toContain('\n');
+    expect(json).not.toContain('\t');
+  });
+
+  it('has top-level keys in alphabetical order', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const bytes = canonicalizeCapabilityPayload({
+      version: token.version,
+      subject: token.subject,
+      grantee: token.grantee,
+      consent_ref: token.consent_ref,
+      scope: token.scope,
+      permissions: token.permissions,
+      issued_at: token.issued_at,
+      not_before: token.not_before,
+      expires_at: token.expires_at,
+      token_id: token.token_id
+    });
+    const json = Buffer.from(bytes).toString();
+
+    const consentRefPos = json.indexOf('"consent_ref"');
+    const expiresPos = json.indexOf('"expires_at"');
+    const granteePos = json.indexOf('"grantee"');
+    const issuedPos = json.indexOf('"issued_at"');
+    const notBeforePos = json.indexOf('"not_before"');
+    const permissionsPos = json.indexOf('"permissions"');
+    const scopePos = json.indexOf('"scope"');
+    const subjectPos = json.indexOf('"subject"');
+    const tokenIdPos = json.indexOf('"token_id"');
+    const versionPos = json.indexOf('"version"');
+
+    expect(consentRefPos).toBeLessThan(expiresPos);
+    expect(expiresPos).toBeLessThan(granteePos);
+    expect(granteePos).toBeLessThan(issuedPos);
+    expect(issuedPos).toBeLessThan(notBeforePos);
+    expect(notBeforePos).toBeLessThan(permissionsPos);
+    expect(permissionsPos).toBeLessThan(scopePos);
+    expect(scopePos).toBeLessThan(subjectPos);
+    expect(subjectPos).toBeLessThan(tokenIdPos);
+    expect(tokenIdPos).toBeLessThan(versionPos);
+  });
+
+  it('excludes capability_hash from canonical payload', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const bytes = canonicalizeCapabilityPayload({
+      version: token.version,
+      subject: token.subject,
+      grantee: token.grantee,
+      consent_ref: token.consent_ref,
+      scope: token.scope,
+      permissions: token.permissions,
+      issued_at: token.issued_at,
+      not_before: token.not_before,
+      expires_at: token.expires_at,
+      token_id: token.token_id
+    });
+    const json = Buffer.from(bytes).toString();
+
+    expect(json).not.toContain('capability_hash');
+  });
+
+  it('includes null not_before in canonical payload', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const bytes = canonicalizeCapabilityPayload({
+      version: token.version,
+      subject: token.subject,
+      grantee: token.grantee,
+      consent_ref: token.consent_ref,
+      scope: token.scope,
+      permissions: token.permissions,
+      issued_at: token.issued_at,
+      not_before: null,
+      expires_at: token.expires_at,
+      token_id: token.token_id
+    });
+    const json = Buffer.from(bytes).toString();
+
+    expect(json).toContain('"not_before":null');
+  });
+
+  it('sorts scope entries by (type, ref)', () => {
+    const scope: ScopeEntry[] = [
+      { type: 'pack', ref: REF_C },
+      { type: 'content', ref: REF_B },
+      { type: 'content', ref: REF_A }
+    ];
+
+    const bytes = canonicalizeCapabilityPayload({
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      consent_ref: 'a'.repeat(64),
+      scope,
+      permissions: ['read'],
+      issued_at: '2025-06-15T10:00:00Z',
+      not_before: null,
+      expires_at: '2025-12-31T23:59:59Z',
+      token_id: 'b'.repeat(64)
+    });
+    const json = Buffer.from(bytes).toString();
+
+    // Order should be: content/REF_A, content/REF_B, pack/REF_C
+    const contentAPos = json.indexOf(REF_A);
+    const contentBPos = json.indexOf(REF_B);
+    const packCPos = json.indexOf(REF_C);
+
+    expect(contentAPos).toBeLessThan(contentBPos);
+    expect(contentBPos).toBeLessThan(packCPos);
+  });
+
+  it('sorts permissions alphabetically', () => {
+    const bytes = canonicalizeCapabilityPayload({
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      consent_ref: 'a'.repeat(64),
+      scope: baseScope,
+      permissions: ['store', 'read', 'derive'],
+      issued_at: '2025-06-15T10:00:00Z',
+      not_before: null,
+      expires_at: '2025-12-31T23:59:59Z',
+      token_id: 'b'.repeat(64)
+    });
+    const json = Buffer.from(bytes).toString();
+
+    const derivePos = json.indexOf('"derive"');
+    const readPos = json.indexOf('"read"');
+    const storePos = json.indexOf('"store"');
+
+    expect(derivePos).toBeLessThan(readPos);
+    expect(readPos).toBeLessThan(storePos);
+  });
+
+  it('produces deterministic output regardless of scope input order', () => {
+    const scopeABC: ScopeEntry[] = [
+      { type: 'content', ref: REF_A },
+      { type: 'content', ref: REF_B },
+      { type: 'pack', ref: REF_C }
+    ];
+    const scopeCBA: ScopeEntry[] = [
+      { type: 'pack', ref: REF_C },
+      { type: 'content', ref: REF_B },
+      { type: 'content', ref: REF_A }
+    ];
+
+    const base = {
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      consent_ref: 'a'.repeat(64),
+      permissions: ['read'],
+      issued_at: '2025-06-15T10:00:00Z',
+      not_before: null as string | null,
+      expires_at: '2025-12-31T23:59:59Z',
+      token_id: 'b'.repeat(64)
+    };
+
+    const bytes1 = canonicalizeCapabilityPayload({ ...base, scope: scopeABC });
+    const bytes2 = canonicalizeCapabilityPayload({ ...base, scope: scopeCBA });
+
+    expect(Buffer.from(bytes1).toString()).toBe(Buffer.from(bytes2).toString());
+  });
+
+  it('produces deterministic output regardless of permission input order', () => {
+    const base = {
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      consent_ref: 'a'.repeat(64),
+      scope: baseScope,
+      issued_at: '2025-06-15T10:00:00Z',
+      not_before: null as string | null,
+      expires_at: '2025-12-31T23:59:59Z',
+      token_id: 'b'.repeat(64)
+    };
+
+    const bytes1 = canonicalizeCapabilityPayload({ ...base, permissions: ['read', 'store'] });
+    const bytes2 = canonicalizeCapabilityPayload({ ...base, permissions: ['store', 'read'] });
+
+    expect(Buffer.from(bytes1).toString()).toBe(Buffer.from(bytes2).toString());
+  });
+});
+
+describe('capability id', () => {
+  it('builds a valid capability id', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const capId = buildCapabilityId(token);
+    expect(capId).toMatch(/^aoc:\/\/capability\/v1\/0\/0x[0-9a-f]{64}$/);
+  });
+
+  it('includes the capability_hash in the URI', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const capId = buildCapabilityId(token);
+    expect(capId).toContain(token.capability_hash);
+  });
+
+  it('rejects invalid capability hash', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    token.capability_hash = 'INVALID';
+
+    expect(() => buildCapabilityId(token)).toThrow(
+      'Capability hash must be 64 lowercase hex characters.'
+    );
+  });
+});
+
+describe('cross-object consistency', () => {
+  it('capability hash is consistent with canonical encoding', () => {
+    const consent = buildBaseConsent();
+    const token = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    const { sha256Hex } = require('../../storage/hash');
+    const payloadBytes = canonicalizeCapabilityPayload({
+      version: token.version,
+      subject: token.subject,
+      grantee: token.grantee,
+      consent_ref: token.consent_ref,
+      scope: token.scope,
+      permissions: token.permissions,
+      issued_at: token.issued_at,
+      not_before: token.not_before,
+      expires_at: token.expires_at,
+      token_id: token.token_id
+    });
+    const expectedHash = sha256Hex(payloadBytes);
+
+    expect(token.capability_hash).toBe(expectedHash);
+  });
+
+  it('different token_ids produce different capability hashes', () => {
+    const consent = buildBaseConsent();
+    const token1 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    const token2 = mintCapabilityToken(
+      consent, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(token1.token_id).not.toBe(token2.token_id);
+    expect(token1.capability_hash).not.toBe(token2.capability_hash);
+  });
+
+  it('tokens from different consents produce different capability hashes', () => {
+    const consent1 = buildBaseConsent();
+    const consent2 = buildConsentObject(
+      SUBJECT, GRANTEE, 'grant', multiScope, multiPermissions,
+      { now: new Date('2025-02-01T00:00:00Z'), expires_at: consentExpires }
+    );
+
+    const token1 = mintCapabilityToken(
+      consent1, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+    const token2 = mintCapabilityToken(
+      consent2, baseScope, basePermissions, tokenExpires, { now: tokenNow }
+    );
+
+    expect(token1.consent_ref).not.toBe(token2.consent_ref);
+    expect(token1.capability_hash).not.toBe(token2.capability_hash);
+  });
+});

--- a/capability/canonical.ts
+++ b/capability/canonical.ts
@@ -1,0 +1,59 @@
+import { canonicalizeJSON } from '../canonicalize';
+import { CapabilityTokenV1, ScopeEntry } from './types';
+
+export type CapabilityPayload = Omit<CapabilityTokenV1, 'capability_hash'>;
+
+/**
+ * Canonicalizes a single ScopeEntry for deterministic encoding.
+ * Keys are sorted alphabetically: ref, type.
+ */
+function canonicalizeScopeEntry(entry: ScopeEntry): object {
+  return {
+    ref: entry.ref,
+    type: entry.type
+  };
+}
+
+/**
+ * Canonicalizes the capability token payload for hashing.
+ *
+ * Per capability-token-spec.md Section 7:
+ * - Excludes capability_hash (self-referential)
+ * - Sorts scope array by (type, ref) in ascending lexicographic order
+ * - Sorts permissions array in ascending lexicographic order
+ * - Top-level keys in alphabetical order:
+ *   consent_ref, expires_at, grantee, issued_at, not_before,
+ *   permissions, scope, subject, token_id, version
+ * - Scope entry keys in alphabetical order: ref, type
+ * - Null values are included in the canonical payload
+ */
+export function canonicalizeCapabilityPayload(
+  payload: CapabilityPayload
+): Uint8Array {
+  // Sort scope entries by (type, ref) in ascending lexicographic order
+  const sortedScope = [...payload.scope].sort((a, b) => {
+    const typeCmp = a.type.localeCompare(b.type);
+    if (typeCmp !== 0) return typeCmp;
+    return a.ref.localeCompare(b.ref);
+  });
+
+  // Sort permissions in ascending lexicographic order
+  const sortedPermissions = [...payload.permissions].sort();
+
+  // Build canonical payload with keys in alphabetical order
+  const canonicalPayload = {
+    consent_ref: payload.consent_ref,
+    expires_at: payload.expires_at,
+    grantee: payload.grantee,
+    issued_at: payload.issued_at,
+    not_before: payload.not_before,
+    permissions: sortedPermissions,
+    scope: sortedScope.map(canonicalizeScopeEntry),
+    subject: payload.subject,
+    token_id: payload.token_id,
+    version: payload.version
+  };
+
+  const canonical = canonicalizeJSON(canonicalPayload);
+  return new TextEncoder().encode(canonical);
+}

--- a/capability/capabilityId.ts
+++ b/capability/capabilityId.ts
@@ -1,0 +1,32 @@
+import { CapabilityTokenV1 } from './types';
+
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+$/;
+const HASH_HEX_PATTERN = /^[a-f0-9]{64}$/;
+
+/**
+ * Builds a capability token URI identifier per capability-token-spec.md Section 9.
+ *
+ * Format: aoc://capability/v{major}/{minor}/0x{capability_hash}
+ * Example: aoc://capability/v1/0/0xa1b2c3...
+ */
+export function buildCapabilityId(token: CapabilityTokenV1): string {
+  if (
+    typeof token.version !== 'string' ||
+    !VERSION_PATTERN.test(token.version)
+  ) {
+    throw new Error(
+      'Capability version must match pattern MAJOR.MINOR (e.g., "1.0").'
+    );
+  }
+  if (
+    typeof token.capability_hash !== 'string' ||
+    !HASH_HEX_PATTERN.test(token.capability_hash)
+  ) {
+    throw new Error(
+      'Capability hash must be 64 lowercase hex characters.'
+    );
+  }
+
+  const [major, minor] = token.version.split('.');
+  return `aoc://capability/v${major}/${minor}/0x${token.capability_hash}`;
+}

--- a/capability/capabilityToken.ts
+++ b/capability/capabilityToken.ts
@@ -1,0 +1,492 @@
+import crypto from 'crypto';
+import { ConsentObjectV1, ScopeEntry } from '../consent/types';
+import { canonicalizeCapabilityPayload } from './canonical';
+import { computeCapabilityHash } from './hash';
+import { isRevoked } from './revocation';
+import { CapabilityTokenV1, MintCapabilityOptions } from './types';
+
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+$/;
+const DID_PATTERN = /^did:[a-z0-9]+:[a-zA-Z0-9._%-]+$/;
+const HASH_HEX_PATTERN = /^[a-f0-9]{64}$/;
+const ISO8601_UTC_PATTERN =
+  /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
+const PERMISSION_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+const MIN_DID_LENGTH = 8;
+const MAX_DID_LENGTH = 2048;
+const MAX_SCOPE_ENTRIES = 10000;
+const MAX_PERMISSIONS = 100;
+const CLOCK_SKEW_SECONDS = 300;
+
+const VALID_SCOPE_TYPES: ReadonlyArray<string> = ['field', 'content', 'pack'];
+
+// --- In-memory nonce registry for replay protection ---
+
+const seenNonces = new Set<string>();
+
+/**
+ * Resets the nonce registry. Intended for testing only.
+ */
+export function resetNonceRegistry(): void {
+  seenNonces.clear();
+}
+
+// --- Validation helpers ---
+
+function validateVersion(version: string): void {
+  if (typeof version !== 'string' || !VERSION_PATTERN.test(version)) {
+    throw new Error(
+      'Capability version must match pattern MAJOR.MINOR (e.g., "1.0").'
+    );
+  }
+}
+
+function validateDID(value: string, fieldName: string): void {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Capability ${fieldName} must be non-empty.`);
+  }
+  if (value.length < MIN_DID_LENGTH) {
+    throw new Error(
+      `Capability ${fieldName} must be at least ${MIN_DID_LENGTH} characters.`
+    );
+  }
+  if (value.length > MAX_DID_LENGTH) {
+    throw new Error(
+      `Capability ${fieldName} must be at most ${MAX_DID_LENGTH} characters.`
+    );
+  }
+  if (!DID_PATTERN.test(value)) {
+    throw new Error(`Capability ${fieldName} must be a valid DID.`);
+  }
+}
+
+function validateConsentRef(consent_ref: string): void {
+  if (
+    typeof consent_ref !== 'string' ||
+    !HASH_HEX_PATTERN.test(consent_ref)
+  ) {
+    throw new Error(
+      'Capability consent_ref must be 64 lowercase hex characters.'
+    );
+  }
+}
+
+function validateScopeEntry(entry: ScopeEntry, index: number): void {
+  if (!VALID_SCOPE_TYPES.includes(entry.type)) {
+    throw new Error(
+      `Scope entry ${index}: type must be "field", "content", or "pack".`
+    );
+  }
+  if (typeof entry.ref !== 'string' || !HASH_HEX_PATTERN.test(entry.ref)) {
+    throw new Error(
+      `Scope entry ${index}: ref must be 64 lowercase hex characters.`
+    );
+  }
+}
+
+function validateScope(scope: ScopeEntry[]): void {
+  if (!Array.isArray(scope) || scope.length === 0) {
+    throw new Error('Capability scope must be a non-empty array.');
+  }
+  if (scope.length > MAX_SCOPE_ENTRIES) {
+    throw new Error(
+      `Capability scope must not exceed ${MAX_SCOPE_ENTRIES} entries.`
+    );
+  }
+
+  const seen = new Set<string>();
+  for (let i = 0; i < scope.length; i++) {
+    validateScopeEntry(scope[i], i);
+    const key = `${scope[i].type}:${scope[i].ref}`;
+    if (seen.has(key)) {
+      throw new Error(
+        `Capability scope contains duplicate entry: (${scope[i].type}, ${scope[i].ref}).`
+      );
+    }
+    seen.add(key);
+  }
+}
+
+function validatePermissions(permissions: string[]): void {
+  if (!Array.isArray(permissions) || permissions.length === 0) {
+    throw new Error('Capability permissions must be a non-empty array.');
+  }
+  if (permissions.length > MAX_PERMISSIONS) {
+    throw new Error(
+      `Capability permissions must not exceed ${MAX_PERMISSIONS} entries.`
+    );
+  }
+
+  const seen = new Set<string>();
+  for (let i = 0; i < permissions.length; i++) {
+    if (
+      typeof permissions[i] !== 'string' ||
+      !PERMISSION_PATTERN.test(permissions[i])
+    ) {
+      throw new Error(
+        `Capability permission ${i}: must be lowercase alphanumeric with hyphens.`
+      );
+    }
+    if (seen.has(permissions[i])) {
+      throw new Error(
+        `Capability permissions contain duplicate: "${permissions[i]}".`
+      );
+    }
+    seen.add(permissions[i]);
+  }
+}
+
+function validateTimestamp(value: string, fieldName: string): void {
+  if (typeof value !== 'string' || !ISO8601_UTC_PATTERN.test(value)) {
+    throw new Error(
+      `Capability ${fieldName} must be ISO 8601 UTC format (e.g., "2025-06-15T10:00:00Z").`
+    );
+  }
+}
+
+function validateTokenId(token_id: string): void {
+  if (typeof token_id !== 'string' || !HASH_HEX_PATTERN.test(token_id)) {
+    throw new Error(
+      'Capability token_id must be 64 lowercase hex characters.'
+    );
+  }
+}
+
+// --- Scope containment check ---
+
+function scopeKey(entry: ScopeEntry): string {
+  return `${entry.type}:${entry.ref}`;
+}
+
+function assertScopeContainment(
+  tokenScope: ScopeEntry[],
+  consentScope: ScopeEntry[]
+): void {
+  const allowed = new Set(consentScope.map(scopeKey));
+  for (const entry of tokenScope) {
+    if (!allowed.has(scopeKey(entry))) {
+      throw new Error(
+        `Scope escalation: token scope entry (${entry.type}, ${entry.ref}) not found in parent consent scope.`
+      );
+    }
+  }
+}
+
+function assertPermissionContainment(
+  tokenPermissions: string[],
+  consentPermissions: string[]
+): void {
+  const allowed = new Set(consentPermissions);
+  for (const perm of tokenPermissions) {
+    if (!allowed.has(perm)) {
+      throw new Error(
+        `Permission escalation: token permission "${perm}" not found in parent consent permissions.`
+      );
+    }
+  }
+}
+
+// --- Generate token_id with 256-bit entropy ---
+
+function generateTokenId(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+// --- Public API ---
+
+/**
+ * Mints a new Capability Token derived from a parent Consent Object.
+ *
+ * Enforces all derivation invariants from capability-token-spec.md Section 4:
+ * - Parent consent must have action "grant"
+ * - Subject and grantee must match
+ * - Token scope must be a subset of consent scope
+ * - Token permissions must be a subset of consent permissions
+ * - Temporal bounds must be contained within consent bounds
+ * - Token must have a finite expires_at
+ */
+export function mintCapabilityToken(
+  consent: ConsentObjectV1,
+  scope: ScopeEntry[],
+  permissions: string[],
+  expires_at: string,
+  opts: MintCapabilityOptions = {}
+): CapabilityTokenV1 {
+  // Derivation: parent consent must be a grant
+  if (consent.action !== 'grant') {
+    throw new Error(
+      'Capability token can only be derived from a consent with action "grant".'
+    );
+  }
+
+  const version = '1.0';
+  const subject = consent.subject;
+  const grantee = consent.grantee;
+  const consent_ref = consent.consent_hash;
+  const issued_at = (opts.now ?? new Date())
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z');
+  const not_before = opts.not_before ?? null;
+  const token_id = generateTokenId();
+
+  // Structural validation
+  validateVersion(version);
+  validateDID(subject, 'subject');
+  validateDID(grantee, 'grantee');
+  validateConsentRef(consent_ref);
+  validateScope(scope);
+  validatePermissions(permissions);
+  validateTimestamp(issued_at, 'issued_at');
+  validateTimestamp(expires_at, 'expires_at');
+  validateTokenId(token_id);
+
+  if (not_before !== null) {
+    validateTimestamp(not_before, 'not_before');
+  }
+
+  // Semantic: expires_at must be after issued_at
+  if (expires_at <= issued_at) {
+    throw new Error('Capability expires_at must be after issued_at.');
+  }
+
+  // Semantic: not_before constraints
+  if (not_before !== null) {
+    if (not_before < issued_at) {
+      throw new Error(
+        'Capability not_before must be at or after issued_at.'
+      );
+    }
+    if (not_before >= expires_at) {
+      throw new Error('Capability not_before must be before expires_at.');
+    }
+  }
+
+  // Derivation: issued_at must be at or after consent issued_at
+  if (issued_at < consent.issued_at) {
+    throw new Error(
+      'Capability issued_at must be at or after parent consent issued_at.'
+    );
+  }
+
+  // Derivation: if consent has a finite expires_at, token must expire at or before
+  if (consent.expires_at !== null && expires_at > consent.expires_at) {
+    throw new Error(
+      'Capability expires_at must not exceed parent consent expires_at.'
+    );
+  }
+
+  // Derivation: not_before must be at or after consent issued_at
+  if (not_before !== null && not_before < consent.issued_at) {
+    throw new Error(
+      'Capability not_before must be at or after parent consent issued_at.'
+    );
+  }
+
+  // Derivation: scope containment
+  assertScopeContainment(scope, consent.scope);
+
+  // Derivation: permission containment
+  assertPermissionContainment(permissions, consent.permissions);
+
+  // Compute capability_hash
+  const payloadBytes = canonicalizeCapabilityPayload({
+    version,
+    subject,
+    grantee,
+    consent_ref,
+    scope,
+    permissions,
+    issued_at,
+    not_before,
+    expires_at,
+    token_id
+  });
+
+  const capability_hash = computeCapabilityHash(payloadBytes);
+
+  return {
+    version,
+    subject,
+    grantee,
+    consent_ref,
+    scope,
+    permissions,
+    issued_at,
+    not_before,
+    expires_at,
+    token_id,
+    capability_hash
+  };
+}
+
+/**
+ * Validates the structural integrity of a Capability Token.
+ *
+ * Checks all structural and semantic invariants, then recomputes the
+ * capability_hash to detect tampering. Does NOT check derivation
+ * invariants against the parent consent (use verifyCapabilityToken for that).
+ */
+export function validateCapabilityToken(token: CapabilityTokenV1): void {
+  validateVersion(token.version);
+  validateDID(token.subject, 'subject');
+  validateDID(token.grantee, 'grantee');
+  validateConsentRef(token.consent_ref);
+  validateScope(token.scope);
+  validatePermissions(token.permissions);
+  validateTimestamp(token.issued_at, 'issued_at');
+  validateTimestamp(token.expires_at, 'expires_at');
+  validateTokenId(token.token_id);
+
+  if (token.not_before !== null) {
+    validateTimestamp(token.not_before, 'not_before');
+  }
+
+  // Semantic: expires_at > issued_at
+  if (token.expires_at <= token.issued_at) {
+    throw new Error('Capability expires_at must be after issued_at.');
+  }
+
+  // Semantic: not_before constraints
+  if (token.not_before !== null) {
+    if (token.not_before < token.issued_at) {
+      throw new Error(
+        'Capability not_before must be at or after issued_at.'
+      );
+    }
+    if (token.not_before >= token.expires_at) {
+      throw new Error('Capability not_before must be before expires_at.');
+    }
+  }
+
+  // Hash integrity
+  if (
+    typeof token.capability_hash !== 'string' ||
+    !HASH_HEX_PATTERN.test(token.capability_hash)
+  ) {
+    throw new Error(
+      'Capability capability_hash must be 64 lowercase hex characters.'
+    );
+  }
+
+  const payloadBytes = canonicalizeCapabilityPayload({
+    version: token.version,
+    subject: token.subject,
+    grantee: token.grantee,
+    consent_ref: token.consent_ref,
+    scope: token.scope,
+    permissions: token.permissions,
+    issued_at: token.issued_at,
+    not_before: token.not_before,
+    expires_at: token.expires_at,
+    token_id: token.token_id
+  });
+
+  const expectedHash = computeCapabilityHash(payloadBytes);
+  if (token.capability_hash !== expectedHash) {
+    throw new Error(
+      'Capability capability_hash does not match canonical payload hash.'
+    );
+  }
+}
+
+/**
+ * Verifies a Capability Token against its parent Consent Object and
+ * enforces runtime authorization checks.
+ *
+ * Verification checks (all must pass):
+ * 1. Structural integrity (via validateCapabilityToken)
+ * 2. consent_ref matches parent consent_hash
+ * 3. Subject and grantee match parent consent
+ * 4. Scope containment (token scope ⊆ consent scope)
+ * 5. Permission containment (token permissions ⊆ consent permissions)
+ * 6. Temporal derivation bounds
+ * 7. Expiry check (token must not be expired at evaluation time)
+ * 8. not_before check (evaluation time must be at or after effective start)
+ * 9. Replay rejection (nonce must not have been seen before)
+ * 10. Revocation check
+ */
+export function verifyCapabilityToken(
+  token: CapabilityTokenV1,
+  consent: ConsentObjectV1,
+  opts: { now?: Date } = {}
+): void {
+  // 1. Structural integrity
+  validateCapabilityToken(token);
+
+  // 2. Consent ref must match
+  if (token.consent_ref !== consent.consent_hash) {
+    throw new Error(
+      'Capability consent_ref does not match parent consent consent_hash.'
+    );
+  }
+
+  // 3. Parent consent must be a grant
+  if (consent.action !== 'grant') {
+    throw new Error(
+      'Parent consent action must be "grant".'
+    );
+  }
+
+  // 4. Identity binding
+  if (token.subject !== consent.subject) {
+    throw new Error(
+      'Capability subject does not match parent consent subject.'
+    );
+  }
+  if (token.grantee !== consent.grantee) {
+    throw new Error(
+      'Capability grantee does not match parent consent grantee.'
+    );
+  }
+
+  // 5. Scope containment
+  assertScopeContainment(token.scope, consent.scope);
+
+  // 6. Permission containment
+  assertPermissionContainment(token.permissions, consent.permissions);
+
+  // 7. Temporal derivation bounds
+  if (token.issued_at < consent.issued_at) {
+    throw new Error(
+      'Capability issued_at must be at or after parent consent issued_at.'
+    );
+  }
+  if (consent.expires_at !== null && token.expires_at > consent.expires_at) {
+    throw new Error(
+      'Capability expires_at must not exceed parent consent expires_at.'
+    );
+  }
+  if (token.not_before !== null && token.not_before < consent.issued_at) {
+    throw new Error(
+      'Capability not_before must be at or after parent consent issued_at.'
+    );
+  }
+
+  // 8. Expiry check
+  const now = (opts.now ?? new Date())
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z');
+
+  if (now > token.expires_at) {
+    throw new Error('Capability token has expired.');
+  }
+
+  // 9. not_before check
+  const effectiveStart = token.not_before ?? token.issued_at;
+  if (now < effectiveStart) {
+    throw new Error('Capability token is not yet valid (before not_before).');
+  }
+
+  // 10. Revocation check
+  if (isRevoked(token.capability_hash)) {
+    throw new Error('Capability token has been revoked.');
+  }
+
+  // 11. Replay rejection (nonce/token_id uniqueness)
+  if (seenNonces.has(token.token_id)) {
+    throw new Error(
+      'Capability token_id has already been presented (replay detected).'
+    );
+  }
+  seenNonces.add(token.token_id);
+}

--- a/capability/hash.ts
+++ b/capability/hash.ts
@@ -1,0 +1,5 @@
+import { sha256Hex } from '../storage/hash';
+
+export function computeCapabilityHash(payloadBytes: Uint8Array): string {
+  return sha256Hex(payloadBytes);
+}

--- a/capability/index.ts
+++ b/capability/index.ts
@@ -1,0 +1,20 @@
+export {
+  mintCapabilityToken,
+  validateCapabilityToken,
+  verifyCapabilityToken,
+  resetNonceRegistry
+} from './capabilityToken';
+export { buildCapabilityId } from './capabilityId';
+export { canonicalizeCapabilityPayload } from './canonical';
+export type { CapabilityPayload } from './canonical';
+export { computeCapabilityHash } from './hash';
+export {
+  revokeCapabilityToken,
+  isRevoked,
+  resetRevocationRegistry
+} from './revocation';
+export type {
+  CapabilityTokenV1,
+  MintCapabilityOptions,
+  ScopeEntry
+} from './types';

--- a/capability/revocation.ts
+++ b/capability/revocation.ts
@@ -1,0 +1,40 @@
+const HASH_HEX_PATTERN = /^[a-f0-9]{64}$/;
+
+// In-memory revocation registry (v0.1 — no persistence layer)
+const revokedTokens = new Set<string>();
+
+/**
+ * Revokes a capability token by its capability_hash.
+ * Once revoked, verification of the token will fail.
+ *
+ * @param capabilityHash - The capability_hash of the token to revoke
+ * @throws If the hash is not a valid 64-character lowercase hex string
+ */
+export function revokeCapabilityToken(capabilityHash: string): void {
+  if (
+    typeof capabilityHash !== 'string' ||
+    !HASH_HEX_PATTERN.test(capabilityHash)
+  ) {
+    throw new Error(
+      'Revocation target must be a valid capability_hash (64 lowercase hex characters).'
+    );
+  }
+  revokedTokens.add(capabilityHash);
+}
+
+/**
+ * Checks whether a capability token has been revoked.
+ *
+ * @param capabilityHash - The capability_hash to check
+ * @returns true if the token has been revoked
+ */
+export function isRevoked(capabilityHash: string): boolean {
+  return revokedTokens.has(capabilityHash);
+}
+
+/**
+ * Resets the revocation registry. Intended for testing only.
+ */
+export function resetRevocationRegistry(): void {
+  revokedTokens.clear();
+}

--- a/capability/types.ts
+++ b/capability/types.ts
@@ -1,0 +1,22 @@
+import { ScopeEntry } from '../consent/types';
+
+export type { ScopeEntry } from '../consent/types';
+
+export type CapabilityTokenV1 = {
+  version: string;
+  subject: string;
+  grantee: string;
+  consent_ref: string;
+  scope: ScopeEntry[];
+  permissions: string[];
+  issued_at: string;
+  not_before: string | null;
+  expires_at: string;
+  token_id: string;
+  capability_hash: string;
+};
+
+export type MintCapabilityOptions = {
+  now?: Date;
+  not_before?: string | null;
+};

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export { canonicalizeJSON } from './canonicalize';
 export { computeContentHash, buildAOCId } from './aocId';
+export * from './capability';
 export * from './consent';
 export * from './content';
 export * from './field';


### PR DESCRIPTION
Implements the capability-based authorization layer bound to Consent Objects:

- capability/types.ts: CapabilityTokenV1 type definitions
- capability/canonical.ts: deterministic canonicalization (sorted keys, scope, permissions)
- capability/hash.ts: SHA-256 hashing reusing storage/hash utilities
- capability/capabilityToken.ts: mint, validate, verify with full derivation enforcement
- capability/revocation.ts: in-memory revocation registry (v0.1)
- capability/capabilityId.ts: AOC URI construction (aoc://capability/v{major}/{minor}/0x{hash})
- capability/index.ts: public exports for downstream consumers

Authorization enforcement:
- Consent hash binding (exactly one parent consent)
- Scope containment (token scope ⊆ consent scope)
- Permission containment (token permissions ⊆ consent permissions)
- Temporal bounds (mandatory expiry, not_before support)
- Replay rejection (in-memory nonce/token_id registry)
- Revocation interface (in-memory, no persistence)

Tests: 65 tests covering happy paths and all rejection paths
(expired, scope escalation, permission escalation, replay, revocation)

https://claude.ai/code/session_01Pgeqxo8GSQKzQChZfokspr