### PR TITLE
Add HRKey ↔ AOC Vault integration layer with adapter and tests

### DIFF
--- a/integration/hrkey/ARCHITECTURE.md
+++ b/integration/hrkey/ARCHITECTURE.md
@@ -1,0 +1,161 @@
+# HRKey ↔ AOC Vault Integration Architecture
+
+## System Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         HRKey Application                           │
+│                                                                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────────┐ │
+│  │  Candidate    │  │  Employer    │  │  HRKey Business Logic     │ │
+│  │  Onboarding   │  │  Dashboard   │  │  (scoring, matching, etc) │ │
+│  └──────┬───────┘  └──────┬───────┘  └───────────┬───────────────┘ │
+│         │                 │                       │                  │
+│         ▼                 ▼                       ▼                  │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │              IHRKeyVaultAdapter (contract)                   │   │
+│  │                                                              │   │
+│  │  registerPack()   grantConsent()   mintCapability()          │   │
+│  │  requestAccess()  revokeCapability()                         │   │
+│  └──────────────────────────┬───────────────────────────────────┘   │
+│                             │                                       │
+├─────────────────────────────┼───────────────────────────────────────┤
+│  INTEGRATION BOUNDARY       │  (this layer)                         │
+├─────────────────────────────┼───────────────────────────────────────┤
+│                             ▼                                       │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │              AocVaultAdapter (implementation)                │   │
+│  │                                                              │   │
+│  │  Translates HRKey domain calls → AOC Vault operations.       │   │
+│  │  Holds Vault reference. No business logic.                   │   │
+│  └──────────────────────────┬───────────────────────────────────┘   │
+│                             │                                       │
+├─────────────────────────────┼───────────────────────────────────────┤
+│  AOC PROTOCOL (black box)   │  DO NOT MODIFY                       │
+├─────────────────────────────┼───────────────────────────────────────┤
+│                             ▼                                       │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │                    AOC Vault (in-memory)                     │   │
+│  │                                                              │   │
+│  │  storePack()        storeConsent()      mintCapability()     │   │
+│  │  requestAccess()    registerSdlMapping() revokeCapability()  │   │
+│  │  getStore()                                                  │   │
+│  ├──────────────────────────────────────────────────────────────┤   │
+│  │  Consent Objects │ Capability Tokens │ Pack Manifests │ SDL  │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Integration Contract Summary
+
+| Adapter Method      | AOC Vault Method(s) Called          | HRKey Provides               | AOC Enforces                              |
+|---------------------|-------------------------------------|------------------------------|-------------------------------------------|
+| `registerPack`      | `storePack` + `registerSdlMapping`  | PackManifest, SDL mappings   | Hash integrity, SDL path format           |
+| `grantConsent`      | `buildConsentObject` + `storeConsent`| DIDs, scope, perms, expiry  | DID format, scope/perm validation, hashing|
+| `mintCapability`    | `mintCapability`                    | consent_hash, attenuated scope| Derivation invariants, temporal bounds    |
+| `requestAccess`     | `requestAccess`                     | capability, SDL paths, pack  | Expiry, replay, revocation, scope, resolution |
+| `revokeCapability`  | `revokeCapability`                  | capability_hash              | Revocation registry update                |
+
+## Boundary Clarification
+
+### HRKey is responsible for:
+
+- **User identity**: managing candidate and employer DIDs
+- **Pack construction**: building PackManifestV1 objects from candidate data (using AOC builders)
+- **SDL domain modeling**: deciding which SDL paths map to which field_ids
+- **Business logic**: scoring, ranking, matching, pricing — all outside this adapter
+- **UX flows**: onboarding, consent collection UI, access request UI
+- **Temporal decisions**: choosing when consents/capabilities expire
+- **Scope decisions**: choosing which fields to include in consents and capabilities
+
+### AOC Vault enforces (adapter must NOT re-implement):
+
+- **Hash integrity**: canonical JSON → SHA-256 on all objects
+- **Consent validation**: DID format, scope bounds, permission format, timestamps
+- **Derivation invariants**: capability scope ⊆ consent scope, capability perms ⊆ consent perms
+- **Temporal bounds**: not_before ≤ now ≤ expires_at
+- **Replay protection**: per-execution nonce tracking via token_id
+- **Revocation**: in-memory revocation registry
+- **Scope containment**: field access checked against capability scope
+- **SDL path validation**: format enforcement (`^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)+$`)
+- **Deterministic ordering**: resolved/unresolved fields sorted by sdl_path
+
+### Out of scope (must NOT be added to this integration):
+
+- Tokenomics, payments, credits, billing
+- Persistent storage (database, filesystem) — Vault is in-memory
+- Network transport, API endpoints, HTTP handlers
+- Authentication/authorization beyond AOC capability tokens
+- Key management, signing, encryption
+- Multi-tenancy, rate limiting, quotas
+
+## Reference Flow
+
+```
+Timeline →
+
+Candidate                    HRKey Adapter                    AOC Vault
+    │                             │                               │
+    │  1. Upload references       │                               │
+    │──────────────────────────►  │                               │
+    │                             │  registerPack(pack, mappings) │
+    │                             │──────────────────────────────►│
+    │                             │  ◄── pack_hash ──────────────│
+    │                             │                               │
+    │  2. Grant consent           │                               │
+    │──────────────────────────►  │                               │
+    │                             │  grantConsent(...)            │
+    │                             │──────────────────────────────►│
+    │                             │  ◄── consent_hash ───────────│
+    │                             │                               │
+
+Employer                     HRKey Adapter                    AOC Vault
+    │                             │                               │
+    │  3. Request candidate data  │                               │
+    │──────────────────────────►  │                               │
+    │                             │  mintCapability(...)          │
+    │                             │──────────────────────────────►│
+    │                             │  ◄── capability token ───────│
+    │                             │                               │
+    │                             │  requestAccess(token, paths)  │
+    │                             │──────────────────────────────►│
+    │                             │  ◄── ALLOW + resolved fields │
+    │  ◄── reference data ────────│                               │
+    │                             │                               │
+```
+
+## Future-Proofing Notes
+
+### 1. Vault execution in a user wallet
+
+The adapter accepts a `Vault` instance via constructor injection:
+
+```typescript
+const adapter = createHRKeyAdapter(vault);
+```
+
+Today, `vault` is `createInMemoryVault()`. To move Vault execution to a
+user's wallet (e.g., a WASM module, a local enclave, or a remote agent):
+
+- Implement the `Vault` type interface in the wallet runtime.
+- Pass that implementation to `createHRKeyAdapter()`.
+- No adapter code changes required.
+
+The `Vault` type is a plain object with function properties — no classes,
+no inheritance, no platform coupling.
+
+### 2. Multiple market makers
+
+The adapter is stateless relative to HRKey identity. Multiple market makers
+can each instantiate their own adapter against the same or different Vault:
+
+```typescript
+const hrkey   = createHRKeyAdapter(sharedVault);
+const otherMM = createHRKeyAdapter(sharedVault);
+```
+
+AOC enforces authorization at the consent/capability level, not at the
+adapter level. Two market makers cannot escalate each other's tokens
+because derivation invariants bind tokens to specific consent chains.
+
+No changes to AOC are required to support this.

--- a/integration/hrkey/__tests__/aocVaultAdapter.test.ts
+++ b/integration/hrkey/__tests__/aocVaultAdapter.test.ts
@@ -1,0 +1,374 @@
+/**
+ * HRKey ↔ AOC Vault Adapter — Integration Tests
+ *
+ * These tests exercise the adapter against a real in-memory Vault.
+ * They verify that HRKey's domain operations translate correctly
+ * into AOC Vault operations and that AOC invariants hold.
+ *
+ * Reference flow (test #1):
+ *   1. Candidate registers a data pack (professional references).
+ *   2. Candidate grants consent to an employer.
+ *   3. HRKey mints an attenuated capability (read-only, time-limited).
+ *   4. Employer requests access to specific SDL paths.
+ *   5. Vault returns ALLOW with resolved fields.
+ */
+
+import { createHRKeyAdapter } from '../aocVaultAdapter';
+import type { IHRKeyVaultAdapter } from '../types';
+import { buildPackManifest } from '../../../pack';
+import { buildStoragePointer } from '../../../storage';
+import { resetNonceRegistry, resetRevocationRegistry } from '../../../capability';
+
+// ─── Constants ──────────────────────────────────────────────────────
+
+const CANDIDATE = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const EMPLOYER  = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+
+const CONTENT_REFSCORE = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const CONTENT_JOBTITLE = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const CONTENT_TENURE   = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+const STORAGE_A = '1111111111111111111111111111111111111111111111111111111111111111';
+const STORAGE_B = '2222222222222222222222222222222222222222222222222222222222222222';
+const STORAGE_C = '3333333333333333333333333333333333333333333333333333333333333333';
+
+const T_CONSENT = new Date('2025-01-15T14:30:00Z');
+const T_MINT    = new Date('2025-06-15T10:00:00Z');
+const T_ACCESS  = new Date('2025-08-01T00:00:00Z');
+const CONSENT_EXPIRES = '2026-01-15T14:30:00Z';
+const TOKEN_EXPIRES   = '2025-12-31T23:59:59Z';
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function makeCandidatePack() {
+  return buildPackManifest(CANDIDATE, [
+    {
+      field_id: 'reference-score',
+      content_id: CONTENT_REFSCORE,
+      storage: buildStoragePointer('local', STORAGE_A),
+      bytes: 64,
+    },
+    {
+      field_id: 'job-title',
+      content_id: CONTENT_JOBTITLE,
+      storage: buildStoragePointer('local', STORAGE_B),
+      bytes: 128,
+    },
+    {
+      field_id: 'tenure-months',
+      content_id: CONTENT_TENURE,
+      storage: buildStoragePointer('local', STORAGE_C),
+      bytes: 16,
+    },
+  ], { now: T_CONSENT });
+}
+
+const SDL_MAPPINGS = [
+  { sdl_path: 'work.reference.score',    field_id: 'reference-score' },
+  { sdl_path: 'work.position.title',     field_id: 'job-title' },
+  { sdl_path: 'work.tenure.months',      field_id: 'tenure-months' },
+];
+
+const FULL_SCOPE = [
+  { type: 'content' as const, ref: CONTENT_REFSCORE },
+  { type: 'content' as const, ref: CONTENT_JOBTITLE },
+  { type: 'content' as const, ref: CONTENT_TENURE },
+];
+
+// ─── Reset global registries between tests ──────────────────────────
+
+beforeEach(() => {
+  resetNonceRegistry();
+  resetRevocationRegistry();
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 1. REFERENCE FLOW: Full happy path
+// ════════════════════════════════════════════════════════════════════
+
+describe('HRKey reference flow: candidate → consent → capability → access', () => {
+  it('completes the full flow with ALLOW', () => {
+    const adapter = createHRKeyAdapter();
+
+    // Step 1: Candidate registers their professional reference pack.
+    const pack = makeCandidatePack();
+    const packResult = adapter.registerPack({
+      pack,
+      sdl_mappings: SDL_MAPPINGS,
+    });
+    expect(packResult.pack_hash).toBe(pack.pack_hash);
+    expect(packResult.sdl_paths_registered).toBe(3);
+
+    // Step 2: Candidate grants consent to the employer.
+    const consentResult = adapter.grantConsent({
+      candidate: CANDIDATE,
+      employer: EMPLOYER,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: CONSENT_EXPIRES,
+    }, { now: T_CONSENT });
+    expect(consentResult.consent_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(consentResult.consent.subject).toBe(CANDIDATE);
+    expect(consentResult.consent.grantee).toBe(EMPLOYER);
+    expect(consentResult.consent.action).toBe('grant');
+
+    // Step 3: HRKey mints a limited capability (read-only, subset could be used).
+    const capResult = adapter.mintCapability({
+      consent_hash: consentResult.consent_hash,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: TOKEN_EXPIRES,
+    }, { now: T_MINT });
+    expect(capResult.capability_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(capResult.capability.consent_ref).toBe(consentResult.consent_hash);
+
+    // Step 4: Employer requests access to specific SDL paths.
+    const accessResult = adapter.requestAccess({
+      capability: capResult.capability,
+      sdl_paths: ['work.reference.score', 'work.position.title'],
+      pack_hash: packResult.pack_hash,
+    }, { now: T_ACCESS });
+
+    // Step 5: Vault returns ALLOW with resolved fields.
+    expect(accessResult.policy.decision).toBe('ALLOW');
+    expect(accessResult.policy.reason_codes).toEqual([]);
+    expect(accessResult.resolved_fields).toHaveLength(2);
+    expect(accessResult.unresolved_fields).toHaveLength(0);
+
+    // Verify deterministic ordering (sorted by sdl_path).
+    expect(accessResult.resolved_fields[0].sdl_path).toBe('work.position.title');
+    expect(accessResult.resolved_fields[0].field_id).toBe('job-title');
+    expect(accessResult.resolved_fields[0].content_id).toBe(CONTENT_JOBTITLE);
+
+    expect(accessResult.resolved_fields[1].sdl_path).toBe('work.reference.score');
+    expect(accessResult.resolved_fields[1].field_id).toBe('reference-score');
+    expect(accessResult.resolved_fields[1].content_id).toBe(CONTENT_REFSCORE);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 2. ATTENUATED SCOPE: employer only gets what consent allows
+// ════════════════════════════════════════════════════════════════════
+
+describe('HRKey attenuated capability: scope containment enforced', () => {
+  it('DENY when employer requests fields outside attenuated scope', () => {
+    const adapter = createHRKeyAdapter();
+    const pack = makeCandidatePack();
+
+    adapter.registerPack({ pack, sdl_mappings: SDL_MAPPINGS });
+
+    // Consent covers only reference-score (CONTENT_REFSCORE).
+    const limitedScope = [{ type: 'content' as const, ref: CONTENT_REFSCORE }];
+
+    const consentResult = adapter.grantConsent({
+      candidate: CANDIDATE,
+      employer: EMPLOYER,
+      scope: limitedScope,
+      permissions: ['read'],
+      expires_at: CONSENT_EXPIRES,
+    }, { now: T_CONSENT });
+
+    const capResult = adapter.mintCapability({
+      consent_hash: consentResult.consent_hash,
+      scope: limitedScope,
+      permissions: ['read'],
+      expires_at: TOKEN_EXPIRES,
+    }, { now: T_MINT });
+
+    // Employer tries to access job-title (outside scope).
+    const result = adapter.requestAccess({
+      capability: capResult.capability,
+      sdl_paths: ['work.position.title'],
+      pack_hash: pack.pack_hash,
+    }, { now: T_ACCESS });
+
+    expect(result.policy.decision).toBe('DENY');
+    expect(result.policy.reason_codes).toContain('SCOPE_ESCALATION');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 3. EXPIRY: expired capability → DENY
+// ════════════════════════════════════════════════════════════════════
+
+describe('HRKey capability expiry enforcement', () => {
+  it('DENY when capability token has expired', () => {
+    const adapter = createHRKeyAdapter();
+    const pack = makeCandidatePack();
+
+    adapter.registerPack({ pack, sdl_mappings: SDL_MAPPINGS });
+
+    const consentResult = adapter.grantConsent({
+      candidate: CANDIDATE,
+      employer: EMPLOYER,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: CONSENT_EXPIRES,
+    }, { now: T_CONSENT });
+
+    const shortExpiry = '2025-07-01T00:00:00Z';
+    const capResult = adapter.mintCapability({
+      consent_hash: consentResult.consent_hash,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: shortExpiry,
+    }, { now: T_MINT });
+
+    // Access AFTER expiry.
+    const result = adapter.requestAccess({
+      capability: capResult.capability,
+      sdl_paths: ['work.reference.score'],
+      pack_hash: pack.pack_hash,
+    }, { now: new Date('2025-08-01T00:00:00Z') });
+
+    expect(result.policy.decision).toBe('DENY');
+    expect(result.policy.reason_codes).toContain('EXPIRED');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 4. REVOCATION: revoked capability → DENY
+// ════════════════════════════════════════════════════════════════════
+
+describe('HRKey capability revocation', () => {
+  it('DENY after capability is revoked', () => {
+    const adapter = createHRKeyAdapter();
+    const pack = makeCandidatePack();
+
+    adapter.registerPack({ pack, sdl_mappings: SDL_MAPPINGS });
+
+    const consentResult = adapter.grantConsent({
+      candidate: CANDIDATE,
+      employer: EMPLOYER,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: CONSENT_EXPIRES,
+    }, { now: T_CONSENT });
+
+    const capResult = adapter.mintCapability({
+      consent_hash: consentResult.consent_hash,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: TOKEN_EXPIRES,
+    }, { now: T_MINT });
+
+    // Revoke.
+    adapter.revokeCapability(capResult.capability_hash);
+
+    // Access after revocation.
+    const result = adapter.requestAccess({
+      capability: capResult.capability,
+      sdl_paths: ['work.reference.score'],
+      pack_hash: pack.pack_hash,
+    }, { now: T_ACCESS });
+
+    expect(result.policy.decision).toBe('DENY');
+    expect(result.policy.reason_codes).toContain('REVOKED');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 5. REPLAY: same token used twice → DENY
+// ════════════════════════════════════════════════════════════════════
+
+describe('HRKey replay protection', () => {
+  it('DENY on second presentation of the same token', () => {
+    const adapter = createHRKeyAdapter();
+    const pack = makeCandidatePack();
+
+    adapter.registerPack({ pack, sdl_mappings: SDL_MAPPINGS });
+
+    const consentResult = adapter.grantConsent({
+      candidate: CANDIDATE,
+      employer: EMPLOYER,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: CONSENT_EXPIRES,
+    }, { now: T_CONSENT });
+
+    const capResult = adapter.mintCapability({
+      consent_hash: consentResult.consent_hash,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: TOKEN_EXPIRES,
+    }, { now: T_MINT });
+
+    // First access — ALLOW.
+    const r1 = adapter.requestAccess({
+      capability: capResult.capability,
+      sdl_paths: ['work.reference.score'],
+      pack_hash: pack.pack_hash,
+    }, { now: T_ACCESS });
+    expect(r1.policy.decision).toBe('ALLOW');
+
+    // Second access with same token — DENY (replay).
+    const r2 = adapter.requestAccess({
+      capability: capResult.capability,
+      sdl_paths: ['work.reference.score'],
+      pack_hash: pack.pack_hash,
+    }, { now: new Date('2025-08-01T00:00:01Z') });
+    expect(r2.policy.decision).toBe('DENY');
+    expect(r2.policy.reason_codes).toContain('REPLAY');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 6. MIXED RESOLUTION: some paths resolve, some don't
+// ════════════════════════════════════════════════════════════════════
+
+describe('HRKey partial resolution', () => {
+  it('ALLOW with both resolved and unresolved fields', () => {
+    const adapter = createHRKeyAdapter();
+    const pack = makeCandidatePack();
+
+    adapter.registerPack({ pack, sdl_mappings: SDL_MAPPINGS });
+
+    const consentResult = adapter.grantConsent({
+      candidate: CANDIDATE,
+      employer: EMPLOYER,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: CONSENT_EXPIRES,
+    }, { now: T_CONSENT });
+
+    const capResult = adapter.mintCapability({
+      consent_hash: consentResult.consent_hash,
+      scope: FULL_SCOPE,
+      permissions: ['read'],
+      expires_at: TOKEN_EXPIRES,
+    }, { now: T_MINT });
+
+    // Request with one valid + one unmapped path.
+    const result = adapter.requestAccess({
+      capability: capResult.capability,
+      sdl_paths: ['work.reference.score', 'work.skills.primary'],
+      pack_hash: pack.pack_hash,
+    }, { now: T_ACCESS });
+
+    expect(result.policy.decision).toBe('ALLOW');
+    expect(result.resolved_fields).toHaveLength(1);
+    expect(result.resolved_fields[0].sdl_path).toBe('work.reference.score');
+    expect(result.unresolved_fields).toHaveLength(1);
+    expect(result.unresolved_fields[0].sdl_path).toBe('work.skills.primary');
+    expect(result.unresolved_fields[0].error.code).toBe('UNRESOLVED_FIELD');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// 7. ERROR: mint with unknown consent → CONSENT_NOT_FOUND
+// ════════════════════════════════════════════════════════════════════
+
+describe('HRKey error: unknown consent', () => {
+  it('throws CONSENT_NOT_FOUND when minting with non-existent consent', () => {
+    const adapter = createHRKeyAdapter();
+
+    expect(() =>
+      adapter.mintCapability({
+        consent_hash: 'f'.repeat(64),
+        scope: FULL_SCOPE,
+        permissions: ['read'],
+        expires_at: TOKEN_EXPIRES,
+      }, { now: T_MINT }),
+    ).toThrow('Consent not found');
+  });
+});

--- a/integration/hrkey/aocVaultAdapter.ts
+++ b/integration/hrkey/aocVaultAdapter.ts
@@ -1,0 +1,163 @@
+/**
+ * AocVaultAdapter — HRKey's thin integration layer over AOC Vault.
+ *
+ * Responsibilities:
+ *   - Instantiate and hold a reference to an AOC Vault.
+ *   - Translate HRKey domain calls into AOC Vault operations.
+ *   - Expose ONLY the IHRKeyVaultAdapter interface to HRKey code.
+ *
+ * Non-responsibilities:
+ *   - No business logic (scoring, pricing, matching).
+ *   - No persistence (Vault is in-memory; adapter adds nothing).
+ *   - No modification of AOC invariants.
+ *
+ * This module treats createInMemoryVault as a black-box factory.
+ */
+
+import { createInMemoryVault } from '../../vault';
+import type { Vault } from '../../vault';
+import { buildConsentObject } from '../../consent';
+
+import type {
+  IHRKeyVaultAdapter,
+  RegisterPackInput,
+  RegisterPackResult,
+  GrantConsentInput,
+  GrantConsentResult,
+  MintCapabilityInput,
+  MintCapabilityResult,
+  AccessRequestInput,
+} from './types';
+
+import type { VaultAccessResult } from '../../vault';
+
+// ─── Factory ────────────────────────────────────────────────────────
+
+/**
+ * Create an HRKey vault adapter backed by an in-memory AOC Vault.
+ *
+ * Usage:
+ *   const adapter = createHRKeyAdapter();
+ *   adapter.registerPack({ pack, sdl_mappings });
+ *   adapter.grantConsent({ candidate, employer, scope, permissions, expires_at });
+ *   // ...
+ *
+ * For testing, pass an existing Vault instance to share state
+ * across test helpers without exposing Vault internals to HRKey code.
+ */
+export function createHRKeyAdapter(vault?: Vault): IHRKeyVaultAdapter {
+  const v: Vault = vault ?? createInMemoryVault();
+
+  // ── registerPack ────────────────────────────────────────────────
+
+  function registerPack(input: RegisterPackInput): RegisterPackResult {
+    const { pack, sdl_mappings } = input;
+
+    // Store the pack (Vault verifies hash integrity).
+    const pack_hash = v.storePack(pack);
+
+    // Register each SDL path → field_id mapping.
+    // Vault validates SDL path format; throws on invalid paths.
+    for (const mapping of sdl_mappings) {
+      v.registerSdlMapping(mapping.sdl_path, mapping.field_id);
+    }
+
+    return {
+      pack_hash,
+      sdl_paths_registered: sdl_mappings.length,
+    };
+  }
+
+  // ── grantConsent ────────────────────────────────────────────────
+
+  function grantConsent(
+    input: GrantConsentInput,
+    opts?: { now?: Date },
+  ): GrantConsentResult {
+    const { candidate, employer, scope, permissions, expires_at } = input;
+
+    // Build the consent object (AOC validates all invariants).
+    const consent = buildConsentObject(
+      candidate,
+      employer,
+      'grant',
+      scope,
+      permissions,
+      {
+        now: opts?.now,
+        expires_at,
+      },
+    );
+
+    // Store in Vault (Vault validates structure).
+    const consent_hash = v.storeConsent(consent);
+
+    return { consent_hash, consent };
+  }
+
+  // ── mintCapability ──────────────────────────────────────────────
+
+  function mintCapability(
+    input: MintCapabilityInput,
+    opts?: { now?: Date },
+  ): MintCapabilityResult {
+    const { consent_hash, scope, permissions, expires_at, not_before } = input;
+
+    // Vault looks up parent consent, validates derivation invariants,
+    // generates token_id, and stores the token.
+    const capability = v.mintCapability(
+      consent_hash,
+      scope,
+      permissions,
+      expires_at,
+      {
+        now: opts?.now,
+        not_before: not_before ?? null,
+      },
+    );
+
+    return {
+      capability_hash: capability.capability_hash,
+      capability,
+    };
+  }
+
+  // ── requestAccess ───────────────────────────────────────────────
+
+  function requestAccess(
+    input: AccessRequestInput,
+    opts?: { now?: Date },
+  ): VaultAccessResult {
+    const { capability, sdl_paths, pack_hash } = input;
+
+    // Direct pass-through. The Vault enforces:
+    //   - Token verification (expiry, replay, revocation, derivation)
+    //   - SDL path validation and resolution
+    //   - Scope containment checks
+    //   - Deterministic ordering of results
+    return v.requestAccess(
+      {
+        capability_token: capability,
+        sdl_paths,
+        pack_ref: pack_hash,
+      },
+      opts,
+    );
+  }
+
+  // ── revokeCapability ────────────────────────────────────────────
+
+  function revokeCapability(capability_hash: string): void {
+    v.revokeCapability(capability_hash);
+  }
+
+  // ── Public interface ────────────────────────────────────────────
+
+  return {
+    registerPack,
+    grantConsent,
+    mintCapability,
+    requestAccess,
+    revokeCapability,
+  };
+}

--- a/integration/hrkey/index.ts
+++ b/integration/hrkey/index.ts
@@ -1,0 +1,28 @@
+export { createHRKeyAdapter } from './aocVaultAdapter';
+export type {
+  IHRKeyVaultAdapter,
+  RegisterPackInput,
+  RegisterPackResult,
+  GrantConsentInput,
+  GrantConsentResult,
+  MintCapabilityInput,
+  MintCapabilityResult,
+  AccessRequestInput,
+  CandidateDID,
+  EmployerDID,
+  HRKeySDLPath,
+} from './types';
+
+// Re-export AOC types that HRKey needs to construct inputs.
+export type {
+  ScopeEntry,
+  ConsentObjectV1,
+  CapabilityTokenV1,
+  PackManifestV1,
+  FieldReference,
+  VaultAccessResult,
+  VaultPolicyDecision,
+  VaultErrorCode,
+  ResolvedField,
+  UnresolvedField,
+} from './types';

--- a/integration/hrkey/types.ts
+++ b/integration/hrkey/types.ts
@@ -1,0 +1,160 @@
+/**
+ * HRKey ↔ AOC Vault Integration Contract
+ *
+ * This file defines the EXACT interface surface HRKey relies on.
+ * HRKey MUST NOT import from AOC core modules directly.
+ * All AOC interaction flows through the adapter defined here.
+ *
+ * Invariants:
+ *   - All inputs/outputs are plain serializable objects (no classes).
+ *   - All hashes are lowercase 64-char hex (SHA-256).
+ *   - All timestamps are ISO 8601 UTC (YYYY-MM-DDTHH:MM:SSZ).
+ *   - DIDs follow pattern: did:<method>:<id>
+ *   - Deterministic: same inputs → same outputs, always.
+ */
+
+// ─── Re-export AOC types that cross the boundary ────────────────────
+
+// These are type-only re-exports. HRKey code references these types
+// but never constructs AOC internals directly.
+export type {
+  ConsentObjectV1,
+  ScopeEntry,
+} from '../../consent';
+
+export type {
+  CapabilityTokenV1,
+} from '../../capability';
+
+export type {
+  PackManifestV1,
+  FieldReference,
+} from '../../pack';
+
+export type {
+  VaultAccessResult,
+  VaultPolicyDecision,
+  VaultErrorCode,
+  ResolvedField,
+  UnresolvedField,
+} from '../../vault';
+
+// ─── HRKey Domain Types ─────────────────────────────────────────────
+
+/** Identifies a candidate in HRKey's domain. Must be a valid DID. */
+export type CandidateDID = string;
+
+/** Identifies an employer (or any grantee) in HRKey's domain. Must be a valid DID. */
+export type EmployerDID = string;
+
+/** HRKey-specific SDL paths for professional reference data. */
+export type HRKeySDLPath = string;
+
+// ─── Adapter Input Types ────────────────────────────────────────────
+
+/** Input for registering a candidate's data pack through HRKey. */
+export type RegisterPackInput = {
+  /** The pre-built PackManifestV1 from the candidate's wallet. */
+  pack: PackManifestV1;
+  /** SDL path → field_id mappings for this pack's fields. */
+  sdl_mappings: ReadonlyArray<{ sdl_path: string; field_id: string }>;
+};
+
+/** Input for a candidate granting consent to an employer via HRKey. */
+export type GrantConsentInput = {
+  candidate: CandidateDID;
+  employer: EmployerDID;
+  scope: ScopeEntry[];
+  permissions: string[];
+  expires_at: string | null;
+};
+
+/** Input for minting an attenuated capability token. */
+export type MintCapabilityInput = {
+  consent_hash: string;
+  scope: ScopeEntry[];
+  permissions: string[];
+  expires_at: string;
+  not_before?: string | null;
+};
+
+/** Input for an employer requesting access to candidate data. */
+export type AccessRequestInput = {
+  capability: CapabilityTokenV1;
+  sdl_paths: string[];
+  pack_hash: string;
+};
+
+// ─── Adapter Result Types ───────────────────────────────────────────
+
+/** Result of registering a pack. */
+export type RegisterPackResult = {
+  pack_hash: string;
+  sdl_paths_registered: number;
+};
+
+/** Result of granting consent. */
+export type GrantConsentResult = {
+  consent_hash: string;
+  consent: ConsentObjectV1;
+};
+
+/** Result of minting a capability. */
+export type MintCapabilityResult = {
+  capability_hash: string;
+  capability: CapabilityTokenV1;
+};
+
+// VaultAccessResult is used directly for access results (no wrapping needed).
+
+// ─── Adapter Interface ──────────────────────────────────────────────
+
+/**
+ * The contract HRKey code programs against.
+ *
+ * This is the ONLY surface HRKey should touch.
+ * Implementation is provided by AocVaultAdapter.
+ */
+export interface IHRKeyVaultAdapter {
+  /**
+   * Register a candidate's data pack and its SDL mappings.
+   * Vault stores the pack; SDL mappings are registered for resolution.
+   *
+   * @throws if pack hash integrity fails
+   * @throws if any SDL path is invalid
+   */
+  registerPack(input: RegisterPackInput): RegisterPackResult;
+
+  /**
+   * Record a candidate's consent grant for an employer.
+   * Builds a ConsentObjectV1 and stores it in the Vault.
+   *
+   * @throws if DID format is invalid
+   * @throws if scope/permissions are empty or malformed
+   */
+  grantConsent(input: GrantConsentInput, opts?: { now?: Date }): GrantConsentResult;
+
+  /**
+   * Mint an attenuated capability token from an existing consent.
+   * Token scope/permissions must be subsets of parent consent.
+   *
+   * @throws CONSENT_NOT_FOUND if consent_hash is not in the Vault
+   * @throws if scope or permissions escalate beyond consent
+   */
+  mintCapability(input: MintCapabilityInput, opts?: { now?: Date }): MintCapabilityResult;
+
+  /**
+   * Validate an employer's access request against the Vault.
+   * Returns ALLOW/DENY with resolved and unresolved fields.
+   *
+   * Deterministic: identical inputs produce identical outputs.
+   * Replay-protected: same token cannot be presented twice.
+   */
+  requestAccess(input: AccessRequestInput, opts?: { now?: Date }): VaultAccessResult;
+
+  /**
+   * Revoke a previously minted capability token.
+   * Subsequent requestAccess calls with this token will return DENY(REVOKED).
+   */
+  revokeCapability(capability_hash: string): void;
+}


### PR DESCRIPTION
## Summary

This PR introduces the HRKey integration layer over the AOC Vault protocol. It provides a clean, type-safe adapter that translates HRKey's domain operations (candidate onboarding, consent management, capability minting) into AOC Vault operations, while maintaining strict separation of concerns and enforcing AOC's cryptographic invariants.

## Key Changes

- **ARCHITECTURE.md**: Comprehensive system design document covering:
  - System diagram showing HRKey → Adapter → AOC Vault layers
  - Integration contract summary (which adapter methods call which Vault methods)
  - Clear boundary definitions (what HRKey owns vs. what AOC enforces)
  - Reference flow diagrams for the happy path
  - Future-proofing notes for wallet execution and multi-market-maker scenarios

- **aocVaultAdapter.ts**: Thin integration layer implementing `IHRKeyVaultAdapter`:
  - `registerPack()`: Store candidate data pack and SDL path mappings
  - `grantConsent()`: Build and store consent objects from HRKey domain inputs
  - `mintCapability()`: Derive attenuated capability tokens with scope/permission containment
  - `requestAccess()`: Direct pass-through to Vault for access validation
  - `revokeCapability()`: Revoke previously minted tokens
  - Accepts optional `Vault` instance for testing; defaults to in-memory Vault
  - Zero business logic; pure translation layer

- **types.ts**: Integration contract types:
  - `IHRKeyVaultAdapter` interface (the only surface HRKey touches)
  - Input/output types for all adapter methods
  - Domain types: `CandidateDID`, `EmployerDID`, `HRKeySDLPath`
  - Re-exports of AOC types that cross the boundary (ConsentObjectV1, CapabilityTokenV1, etc.)
  - All types are plain serializable objects (no classes)

- **aocVaultAdapter.test.ts**: Comprehensive integration tests (374 lines):
  - **Reference flow**: Full happy path (register → consent → mint → access)
  - **Attenuated scope**: Verify scope containment enforcement (DENY on escalation)
  - **Expiry enforcement**: DENY when capability token expires
  - **Revocation**: DENY after capability is revoked
  - **Replay protection**: DENY on second presentation of same token
  - **Partial resolution**: ALLOW with both resolved and unresolved fields
  - **Error handling**: CONSENT_NOT_FOUND when minting with unknown consent
  - Uses real in-memory Vault; resets nonce/revocation registries between tests

## Notable Implementation Details

1. **Stateless adapter**: No HRKey identity baked in; multiple market makers can instantiate their own adapters against the same Vault without escalation risk (AOC enforces authorization at token level).

2. **Deterministic hashing**: All objects (packs, consents, capabilities) are hashed deterministically; same inputs always produce same outputs.

3. **Temporal options**: All methods accept optional `{ now?: Date }` for testing time-dependent logic without mocking Date.

4. **Vault as black box**: Adapter treats `createInMemoryVault()` as a factory; no coupling to Vault internals. Future wallet execution requires only implementing the `Vault` interface.

5. **Boundary enforcement**: HRKey owns user identity, pack construction, SDL modeling, business logic, and temporal decisions. AOC owns hash integrity, consent validation, derivation invariants, replay protection, revocation, and scope containment.

## Testing

All 7 test suites pass:
- ✓ Reference flow (happy path)
- ✓ Attenuated scope containment
- ✓ Expiry enforcement
- ✓ Revocation
- ✓ Replay protection
- ✓ Partial resolution
- ✓ Error handling (unknown consent)

https://claude.ai/code/session_01ANw1SmsBU2jAh9VdAuktoG