### PR TITLE
Use TypeScript type-only imports throughout codebase

### DIFF
--- a/capability/types.ts
+++ b/capability/types.ts
@@ -1,6 +1,6 @@
-import { ScopeEntry } from '../consent/types';
+import type { ScopeEntry } from '../consent/types';
 
-export type { ScopeEntry } from '../consent/types';
+export type { ScopeEntry };
 
 export type CapabilityTokenV1 = {
   version: string;

--- a/content/types.ts
+++ b/content/types.ts
@@ -1,4 +1,4 @@
-import { StoragePointer } from '../storage/types';
+import type { StoragePointer } from '../storage/types';
 
 export type ContentManifestV1 = {
   version: 1;

--- a/pack/types.ts
+++ b/pack/types.ts
@@ -1,4 +1,4 @@
-import { StoragePointer } from '../storage/types';
+import type { StoragePointer } from '../storage/types';
 
 export type FieldReference = {
   field_id: string;

--- a/vault/types.ts
+++ b/vault/types.ts
@@ -1,6 +1,6 @@
-import { ConsentObjectV1, ScopeEntry } from '../consent';
-import { CapabilityTokenV1 } from '../capability';
-import { PackManifestV1 } from '../pack';
+import type { ConsentObjectV1, ScopeEntry } from '../consent';
+import type { CapabilityTokenV1 } from '../capability';
+import type { PackManifestV1 } from '../pack';
 
 // --- Error Codes ---
 

--- a/vault/vault.ts
+++ b/vault/vault.ts
@@ -1,14 +1,18 @@
-import { ConsentObjectV1, validateConsentObject } from '../consent';
-import { ScopeEntry } from '../consent/types';
+import type { ConsentObjectV1 } from '../consent';
+import { validateConsentObject } from '../consent';
+import type { ScopeEntry } from '../consent/types';
+
+import type { CapabilityTokenV1 } from '../capability';
 import {
-  CapabilityTokenV1,
   mintCapabilityToken,
   verifyCapabilityToken,
   revokeCapabilityToken as capRevokeToken
 } from '../capability';
-import { PackManifestV1 } from '../pack';
+
+import type { PackManifestV1 } from '../pack';
 import { canonicalizePackManifestPayload, computePackHash } from '../pack';
-import {
+
+import type {
   Vault,
   VaultStore,
   VaultAccessRequest,


### PR DESCRIPTION
## Summary
This PR converts all type imports to use TypeScript's `type` keyword, enabling better tree-shaking and clearer separation between type and value imports across the codebase.

## Key Changes
- **vault/vault.ts**: Separated type imports (`ConsentObjectV1`, `ScopeEntry`, `CapabilityTokenV1`, `PackManifestV1`, `Vault`, `VaultStore`, `VaultAccessRequest`) from value imports, organized imports into logical groups
- **vault/types.ts**: Converted all imports (`ConsentObjectV1`, `ScopeEntry`, `CapabilityTokenV1`, `PackManifestV1`) to type-only imports
- **capability/types.ts**: Changed `ScopeEntry` import to type-only and simplified the re-export to avoid redundant import path
- **content/types.ts**: Converted `StoragePointer` import to type-only
- **pack/types.ts**: Converted `StoragePointer` import to type-only

## Benefits
- Improves tree-shaking by explicitly marking imports that are only used in type annotations
- Prevents accidental runtime dependencies on type-only modules
- Follows TypeScript best practices and improves code clarity
- Reduces bundle size by allowing unused type imports to be eliminated

https://claude.ai/code/session_01C9btyxS4RnxDp93c4DGjRN