### PR TITLE
feat(identity): add identity-lite ed25519 signing and signature enforcement gate

### DIFF
--- a/capability/types.ts
+++ b/capability/types.ts
@@ -1,3 +1,5 @@
+import type { SignatureEnvelope } from '../identity/types';
+
 import type { ScopeEntry } from '../consent/types';
 
 export type { ScopeEntry };
@@ -14,6 +16,7 @@ export type CapabilityTokenV1 = {
   expires_at: string;
   token_id: string;
   capability_hash: string;
+  signature?: SignatureEnvelope;
 };
 
 export type MintCapabilityOptions = {

--- a/consent/types.ts
+++ b/consent/types.ts
@@ -1,3 +1,5 @@
+import type { SignatureEnvelope } from '../identity/types';
+
 export type ScopeEntry = {
   type: 'field' | 'content' | 'pack';
   ref: string;
@@ -14,6 +16,7 @@ export type ConsentObjectV1 = {
   expires_at: string | null;
   prior_consent: string | null;
   consent_hash: string;
+  signature?: SignatureEnvelope;
 };
 
 export type BuildConsentOptions = {

--- a/enforcement/__tests__/signature.test.ts
+++ b/enforcement/__tests__/signature.test.ts
@@ -1,0 +1,37 @@
+import { enforceSignatureValid } from '../signature';
+import { encode, generateKeypair, signBytes } from '../../identity';
+
+describe('enforceSignatureValid', () => {
+  it('allows missing signature fields for backward compatibility', () => {
+    const decision = enforceSignatureValid({ bytes: new Uint8Array(Buffer.from('hello')) });
+    expect(decision).toEqual({ decision: 'ALLOW', reason_codes: [] });
+  });
+
+  it('denies when one signature field is missing', () => {
+    const decision = enforceSignatureValid({ bytes: new Uint8Array(Buffer.from('hello')), publicKey: 'abc' });
+    expect(decision.decision).toBe('DENY');
+    expect(decision.reason_codes).toContain('SIGNATURE_MISSING');
+  });
+
+  it('allows valid signatures and denies invalid signatures', () => {
+    const bytes = new Uint8Array(Buffer.from('hello'));
+    const { privateKey, publicKey } = generateKeypair();
+    const signature = signBytes(privateKey, bytes);
+
+    const valid = enforceSignatureValid({
+      bytes,
+      publicKey: encode(publicKey),
+      signature: encode(signature)
+    });
+
+    const invalid = enforceSignatureValid({
+      bytes,
+      publicKey: encode(publicKey),
+      signature: encode(new Uint8Array(Buffer.from('not-a-valid-signature')))
+    });
+
+    expect(valid.decision).toBe('ALLOW');
+    expect(invalid.decision).toBe('DENY');
+    expect(invalid.reason_codes).toContain('SIGNATURE_INVALID');
+  });
+});

--- a/enforcement/index.ts
+++ b/enforcement/index.ts
@@ -7,3 +7,5 @@ export {
   enforcePathAccess,
   enforceStorageIntegrity
 } from './sem';
+
+export { enforceSignatureValid } from './signature';

--- a/enforcement/signature.ts
+++ b/enforcement/signature.ts
@@ -1,0 +1,34 @@
+import type { SemDecision } from './sem';
+import { decode } from '../identity/keys';
+import { verifyBytes } from '../identity/sign';
+
+type EnforceSignatureValidInput = {
+  bytes: Uint8Array;
+  publicKey?: string;
+  signature?: string;
+};
+
+function allow(): SemDecision {
+  return { decision: 'ALLOW', reason_codes: [] };
+}
+
+function deny(code: string): SemDecision {
+  return { decision: 'DENY', reason_codes: [code] };
+}
+
+export function enforceSignatureValid(input: EnforceSignatureValidInput): SemDecision {
+  // Backward compatible: if caller provides neither field, allow
+  if (!input.signature && !input.publicKey) return allow();
+
+  // If one is missing, deny
+  if (!input.signature || !input.publicKey) return deny('SIGNATURE_MISSING');
+
+  try {
+    const publicKeyBytes = decode(input.publicKey);
+    const signatureBytes = decode(input.signature);
+    const valid = verifyBytes(publicKeyBytes, input.bytes, signatureBytes);
+    return valid ? allow() : deny('SIGNATURE_INVALID');
+  } catch {
+    return deny('SIGNATURE_INVALID');
+  }
+}

--- a/identity/__tests__/sign.test.ts
+++ b/identity/__tests__/sign.test.ts
@@ -1,0 +1,36 @@
+import {
+  decode,
+  encode,
+  generateKeypair,
+  publicKeyFromPrivate,
+  signBytes,
+  verifyBytes
+} from '..';
+
+describe('identity-lite signing', () => {
+  it('roundtrips key encode/decode', () => {
+    const { privateKey, publicKey } = generateKeypair();
+    expect(decode(encode(privateKey))).toEqual(privateKey);
+    expect(decode(encode(publicKey))).toEqual(publicKey);
+  });
+
+  it('derives public key from private key', () => {
+    const { privateKey, publicKey } = generateKeypair();
+    expect(publicKeyFromPrivate(privateKey)).toEqual(publicKey);
+  });
+
+  it('accepts valid signatures', () => {
+    const { privateKey, publicKey } = generateKeypair();
+    const bytes = new Uint8Array(Buffer.from('aoc-signature-test', 'utf8'));
+    const signature = signBytes(privateKey, bytes);
+    expect(verifyBytes(publicKey, bytes, signature)).toBe(true);
+  });
+
+  it('rejects tampered payload signatures', () => {
+    const { privateKey, publicKey } = generateKeypair();
+    const bytes = new Uint8Array(Buffer.from('aoc-signature-test', 'utf8'));
+    const tampered = new Uint8Array(Buffer.from('aoc-signature-test-tampered', 'utf8'));
+    const signature = signBytes(privateKey, bytes);
+    expect(verifyBytes(publicKey, tampered, signature)).toBe(false);
+  });
+});

--- a/identity/index.ts
+++ b/identity/index.ts
@@ -1,0 +1,3 @@
+export { generateKeypair, publicKeyFromPrivate, encode, decode } from './keys';
+export { signBytes, verifyBytes } from './sign';
+export type { SignatureEnvelope } from './types';

--- a/identity/keys.ts
+++ b/identity/keys.ts
@@ -1,0 +1,35 @@
+import crypto from 'crypto';
+
+export type Ed25519Keypair = {
+  privateKey: Uint8Array;
+  publicKey: Uint8Array;
+};
+
+export function encode(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+export function decode(value: string): Uint8Array {
+  return new Uint8Array(Buffer.from(value, 'base64url'));
+}
+
+export function generateKeypair(): Ed25519Keypair {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+
+  return {
+    privateKey: new Uint8Array(privateKey.export({ format: 'der', type: 'pkcs8' })),
+    publicKey: new Uint8Array(publicKey.export({ format: 'der', type: 'spki' })),
+  };
+}
+
+export function publicKeyFromPrivate(privateKey: Uint8Array): Uint8Array {
+  const privateKeyObject = crypto.createPrivateKey({
+    key: Buffer.from(privateKey),
+    format: 'der',
+    type: 'pkcs8',
+  });
+
+  return new Uint8Array(
+    crypto.createPublicKey(privateKeyObject).export({ format: 'der', type: 'spki' })
+  );
+}

--- a/identity/sign.ts
+++ b/identity/sign.ts
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+
+export function signBytes(privateKey: Uint8Array, bytes: Uint8Array): Uint8Array {
+  const privateKeyObject = crypto.createPrivateKey({
+    key: Buffer.from(privateKey),
+    format: 'der',
+    type: 'pkcs8',
+  });
+
+  return new Uint8Array(crypto.sign(null, Buffer.from(bytes), privateKeyObject));
+}
+
+export function verifyBytes(
+  publicKey: Uint8Array,
+  bytes: Uint8Array,
+  signature: Uint8Array
+): boolean {
+  const publicKeyObject = crypto.createPublicKey({
+    key: Buffer.from(publicKey),
+    format: 'der',
+    type: 'spki',
+  });
+
+  return crypto.verify(null, Buffer.from(bytes), publicKeyObject, Buffer.from(signature));
+}

--- a/identity/types.ts
+++ b/identity/types.ts
@@ -1,0 +1,4 @@
+export type SignatureEnvelope = {
+  public_key: string;
+  signature: string;
+};

--- a/index.ts
+++ b/index.ts
@@ -6,3 +6,5 @@ export * from './content';
 export * from './field';
 export * from './pack';
 export * from './storage';
+
+export * from './identity';


### PR DESCRIPTION
Adds identity-lite (ed25519 keygen/sign/verify), signature envelope type, and enforcement gate enforceSignatureValid with tests. Backward compatible (allows missing signature fields).