### PR TITLE
Add financial capability namespace and registry

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,3 +6,4 @@ export * from './content';
 export * from './field';
 export * from './pack';
 export * from './storage';
+export * from './protocol/capabilities';

--- a/protocol/capabilities/__tests__/financialCapabilities.test.ts
+++ b/protocol/capabilities/__tests__/financialCapabilities.test.ts
@@ -1,0 +1,59 @@
+import {
+  financialCapabilities,
+  financialCapabilitiesById,
+  getFinancialCapability,
+  validateProtocolCapabilityDefinition
+} from '..';
+
+describe('financial capability namespace', () => {
+  it('registers the canonical financial capabilities', () => {
+    expect(financialCapabilities.map((capability) => capability.id)).toEqual([
+      'financial.wallet.balance.read',
+      'financial.wallet.tx.read',
+      'financial.portfolio.snapshot.read',
+      'financial.portfolio.aggregate.read',
+      'financial.insight.read',
+      'financial.insight.write'
+    ]);
+  });
+
+  it('indexes registered capabilities by canonical id', () => {
+    expect(financialCapabilitiesById['financial.insight.write']).toEqual({
+      id: 'financial.insight.write',
+      description:
+        'Write or attach derived financial insights back into an authorized insight resource.',
+      resource_type: 'insight',
+      access_level: 'write',
+      sensitivity_level: 'high',
+      requires_user_consent: true
+    });
+  });
+
+  it('retrieves a specific capability definition by id', () => {
+    expect(getFinancialCapability('financial.wallet.balance.read').resource_type).toBe('wallet');
+    expect(getFinancialCapability('financial.wallet.balance.read').access_level).toBe('read');
+  });
+
+  it('requires user consent for every registered financial capability', () => {
+    expect(financialCapabilities.every((capability) => capability.requires_user_consent)).toBe(true);
+  });
+
+  it('validates the canonical schema fields', () => {
+    for (const capability of financialCapabilities) {
+      expect(() => validateProtocolCapabilityDefinition(capability)).not.toThrow();
+    }
+  });
+
+  it('rejects malformed capability definitions', () => {
+    expect(() =>
+      validateProtocolCapabilityDefinition({
+        id: 'Financial.wallet.balance.read',
+        description: 'bad',
+        resource_type: 'wallet',
+        access_level: 'read',
+        sensitivity_level: 'high',
+        requires_user_consent: true
+      } as any)
+    ).toThrow('Capability definition id must be a lowercase dot-separated canonical identifier.');
+  });
+});

--- a/protocol/capabilities/financial-capability-spec.md
+++ b/protocol/capabilities/financial-capability-spec.md
@@ -1,0 +1,57 @@
+# Financial Capability Namespace Specification
+
+## 1. Purpose
+
+This document defines the canonical `financial.*` capability namespace for
+financial data access within the Architects of Change Protocol. The namespace
+is additive and does not modify the existing Consent Object, Capability Token,
+or enforcement architecture.
+
+## 2. Design Invariants
+
+Implementations using this namespace MUST preserve the following invariants:
+
+- Capability definitions are metadata that describe permitted financial access.
+- A financial capability identifier MUST be represented as a canonical,
+  lowercase, dot-separated string.
+- Registration of a financial capability MUST NOT bypass existing consent,
+  capability derivation, temporal containment, or revocation rules.
+- A capability marked `requires_user_consent: true` MUST only be exercised
+  through the protocol's existing consent and capability-token flow.
+- Additional `financial.*` capabilities MAY be introduced later, provided they
+  preserve canonical identifiers and do not redefine an existing id.
+
+## 3. Canonical Schema
+
+Each financial capability definition MUST expose the following fields:
+
+- `id`
+- `description`
+- `resource_type` (`wallet` | `portfolio` | `insight`)
+- `access_level` (`read` | `write`)
+- `sensitivity_level` (`low` | `medium` | `high`)
+- `requires_user_consent` (`boolean`)
+
+## 4. Registered Financial Capabilities
+
+| id | description | resource_type | access_level | sensitivity_level | requires_user_consent |
+| --- | --- | --- | --- | --- | --- |
+| `financial.wallet.balance.read` | Read the current balance exposed for a wallet account or sub-account. | `wallet` | `read` | `high` | `true` |
+| `financial.wallet.tx.read` | Read wallet transaction history, including inflows, outflows, and transfers. | `wallet` | `read` | `high` | `true` |
+| `financial.portfolio.snapshot.read` | Read point-in-time holdings and valuation snapshots for a portfolio. | `portfolio` | `read` | `high` | `true` |
+| `financial.portfolio.aggregate.read` | Read portfolio-level aggregates such as total allocation, exposure, and summary metrics. | `portfolio` | `read` | `medium` | `true` |
+| `financial.insight.read` | Read derived financial insights generated from wallet or portfolio data. | `insight` | `read` | `medium` | `true` |
+| `financial.insight.write` | Write or attach derived financial insights back into an authorized insight resource. | `insight` | `write` | `high` | `true` |
+
+## 5. Enforcement Guidance
+
+This namespace is intended to be consumed alongside the existing protocol
+permission and scope checks:
+
+- Consent grants continue to define the authorizing subject, grantee, scope,
+  permissions, and time bounds.
+- Capability Tokens continue to attenuate from a parent consent and remain the
+  redeemable enforcement artifact.
+- Financial capability definitions provide canonical ids and metadata so
+  downstream market makers can apply consistent policy, logging, and product
+  interpretation without inventing incompatible capability names.

--- a/protocol/capabilities/financialCapabilities.ts
+++ b/protocol/capabilities/financialCapabilities.ts
@@ -1,0 +1,63 @@
+import { defineCapabilityRegistry, indexCapabilitiesById } from './registry';
+import type { ProtocolCapabilityDefinition } from './types';
+
+export const financialCapabilities = defineCapabilityRegistry([
+  {
+    id: 'financial.wallet.balance.read',
+    description: 'Read the current balance exposed for a wallet account or sub-account.',
+    resource_type: 'wallet',
+    access_level: 'read',
+    sensitivity_level: 'high',
+    requires_user_consent: true
+  },
+  {
+    id: 'financial.wallet.tx.read',
+    description: 'Read wallet transaction history, including inflows, outflows, and transfers.',
+    resource_type: 'wallet',
+    access_level: 'read',
+    sensitivity_level: 'high',
+    requires_user_consent: true
+  },
+  {
+    id: 'financial.portfolio.snapshot.read',
+    description: 'Read point-in-time holdings and valuation snapshots for a portfolio.',
+    resource_type: 'portfolio',
+    access_level: 'read',
+    sensitivity_level: 'high',
+    requires_user_consent: true
+  },
+  {
+    id: 'financial.portfolio.aggregate.read',
+    description: 'Read portfolio-level aggregates such as total allocation, exposure, and summary metrics.',
+    resource_type: 'portfolio',
+    access_level: 'read',
+    sensitivity_level: 'medium',
+    requires_user_consent: true
+  },
+  {
+    id: 'financial.insight.read',
+    description: 'Read derived financial insights generated from wallet or portfolio data.',
+    resource_type: 'insight',
+    access_level: 'read',
+    sensitivity_level: 'medium',
+    requires_user_consent: true
+  },
+  {
+    id: 'financial.insight.write',
+    description: 'Write or attach derived financial insights back into an authorized insight resource.',
+    resource_type: 'insight',
+    access_level: 'write',
+    sensitivity_level: 'high',
+    requires_user_consent: true
+  }
+] as const satisfies readonly ProtocolCapabilityDefinition[]);
+
+export type FinancialCapabilityId = (typeof financialCapabilities)[number]['id'];
+
+export const financialCapabilitiesById = indexCapabilitiesById(financialCapabilities);
+
+export function getFinancialCapability(
+  capabilityId: FinancialCapabilityId
+): (typeof financialCapabilitiesById)[FinancialCapabilityId] {
+  return financialCapabilitiesById[capabilityId];
+}

--- a/protocol/capabilities/index.ts
+++ b/protocol/capabilities/index.ts
@@ -1,0 +1,16 @@
+export {
+  financialCapabilities,
+  financialCapabilitiesById,
+  getFinancialCapability
+} from './financialCapabilities';
+export {
+  defineCapabilityRegistry,
+  indexCapabilitiesById,
+  validateProtocolCapabilityDefinition
+} from './registry';
+export type {
+  CapabilityAccessLevel,
+  CapabilityResourceType,
+  CapabilitySensitivityLevel,
+  ProtocolCapabilityDefinition
+} from './types';

--- a/protocol/capabilities/registry.ts
+++ b/protocol/capabilities/registry.ts
@@ -1,0 +1,91 @@
+import {
+  ProtocolCapabilityDefinition,
+  CapabilityAccessLevel,
+  CapabilityResourceType,
+  CapabilitySensitivityLevel
+} from './types';
+
+const CAPABILITY_ID_PATTERN =
+  /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*){2,}$/;
+
+const VALID_RESOURCE_TYPES: ReadonlySet<CapabilityResourceType> = new Set([
+  'wallet',
+  'portfolio',
+  'insight'
+]);
+const VALID_ACCESS_LEVELS: ReadonlySet<CapabilityAccessLevel> = new Set([
+  'read',
+  'write'
+]);
+const VALID_SENSITIVITY_LEVELS: ReadonlySet<CapabilitySensitivityLevel> = new Set([
+  'low',
+  'medium',
+  'high'
+]);
+
+export function validateProtocolCapabilityDefinition(
+  capability: ProtocolCapabilityDefinition
+): void {
+  if (typeof capability.id !== 'string' || !CAPABILITY_ID_PATTERN.test(capability.id)) {
+    throw new Error(
+      'Capability definition id must be a lowercase dot-separated canonical identifier.'
+    );
+  }
+
+  if (typeof capability.description !== 'string' || capability.description.trim() === '') {
+    throw new Error(`Capability definition ${capability.id} must include a non-empty description.`);
+  }
+
+  if (!VALID_RESOURCE_TYPES.has(capability.resource_type)) {
+    throw new Error(
+      `Capability definition ${capability.id} has unsupported resource_type "${capability.resource_type}".`
+    );
+  }
+
+  if (!VALID_ACCESS_LEVELS.has(capability.access_level)) {
+    throw new Error(
+      `Capability definition ${capability.id} has unsupported access_level "${capability.access_level}".`
+    );
+  }
+
+  if (!VALID_SENSITIVITY_LEVELS.has(capability.sensitivity_level)) {
+    throw new Error(
+      `Capability definition ${capability.id} has unsupported sensitivity_level "${capability.sensitivity_level}".`
+    );
+  }
+
+  if (typeof capability.requires_user_consent !== 'boolean') {
+    throw new Error(
+      `Capability definition ${capability.id} must declare requires_user_consent as a boolean.`
+    );
+  }
+}
+
+export function defineCapabilityRegistry<const T extends readonly ProtocolCapabilityDefinition[]>(
+  capabilities: T
+): T {
+  const seen = new Set<string>();
+
+  for (const capability of capabilities) {
+    validateProtocolCapabilityDefinition(capability);
+
+    if (seen.has(capability.id)) {
+      throw new Error(`Duplicate capability definition id: ${capability.id}`);
+    }
+
+    seen.add(capability.id);
+  }
+
+  return Object.freeze([...capabilities]) as T;
+}
+
+export function indexCapabilitiesById<T extends readonly ProtocolCapabilityDefinition[]>(
+  capabilities: T
+): Readonly<Record<T[number]['id'], T[number]>> {
+  return Object.freeze(
+    capabilities.reduce<Record<string, T[number]>>((acc, capability) => {
+      acc[capability.id] = capability;
+      return acc;
+    }, {})
+  ) as Readonly<Record<T[number]['id'], T[number]>>;
+}

--- a/protocol/capabilities/types.ts
+++ b/protocol/capabilities/types.ts
@@ -1,0 +1,14 @@
+export type CapabilityResourceType = 'wallet' | 'portfolio' | 'insight';
+
+export type CapabilityAccessLevel = 'read' | 'write';
+
+export type CapabilitySensitivityLevel = 'low' | 'medium' | 'high';
+
+export type ProtocolCapabilityDefinition = {
+  id: string;
+  description: string;
+  resource_type: CapabilityResourceType;
+  access_level: CapabilityAccessLevel;
+  sensitivity_level: CapabilitySensitivityLevel;
+  requires_user_consent: boolean;
+};


### PR DESCRIPTION
### Motivation

- Define a canonical, machine-validatable `financial.*` capability namespace to support market-makers that consume wallet, portfolio, and insight data without changing existing consent or capability-token flows.
- Provide a stable, extensible metadata schema so downstream services can apply consistent access control, sensitivity labeling, and consent enforcement.

### Description

- Add a typed protocol capability schema at `protocol/capabilities/types.ts` describing `resource_type`, `access_level`, `sensitivity_level`, and `requires_user_consent` fields.
- Implement a small registry/validation layer in `protocol/capabilities/registry.ts` that enforces canonical dot-separated ids, rejects duplicates, and builds immutable indexed lookups.
- Register the six required financial capability definitions in `protocol/capabilities/financialCapabilities.ts` (`financial.wallet.balance.read`, `financial.wallet.tx.read`, `financial.portfolio.snapshot.read`, `financial.portfolio.aggregate.read`, `financial.insight.read`, `financial.insight.write`) and expose accessors via `protocol/capabilities/index.ts`.
- Add a human-readable spec `protocol/capabilities/financial-capability-spec.md` describing invariants and enforcement guidance and unit tests in `protocol/capabilities/__tests__/financialCapabilities.test.ts` that cover registration, indexing, schema validation, and malformed-definition rejection.
- Export the capability namespace from the repository root by adding `export * from './protocol/capabilities';` to `index.ts` so consumers can import the canonical definitions without breaking existing APIs.

### Testing

- Ran `npx tsc --noEmit` to validate types, which completed without errors.
- Ran `npm test -- --runInBand` and all test suites passed (17 test suites, 305 tests; the new `protocol/capabilities/__tests__/financialCapabilities.test.ts` passed).
- Unit tests exercise registration, schema validation, lookup, and malformed-definition rejection and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd900ef0e883259cc8a3eeb857f8f1)