### PR TITLE
Introduce marketMakerId binding for Consent and Capability tokens with validation and enforcement

### DIFF
--- a/capability/__tests__/capability.test.ts
+++ b/capability/__tests__/capability.test.ts
@@ -60,6 +60,19 @@ beforeEach(() => {
 });
 
 describe('capability token minting', () => {
+  it('allows unbound parent consent to mint an unbound capability', () => {
+    const consent = buildBaseConsent({ expires_at: consentExpires });
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      tokenExpires,
+      { now: tokenNow }
+    );
+
+    expect(token.marketMakerId).toBeUndefined();
+  });
+
   it('mints a valid capability token from a grant consent', () => {
     const consent = buildBaseConsent();
     const token = mintCapabilityToken(
@@ -79,6 +92,7 @@ describe('capability token minting', () => {
     expect(token.issued_at).toBe('2025-06-15T10:00:00Z');
     expect(token.not_before).toBeNull();
     expect(token.expires_at).toBe(tokenExpires);
+    expect(token.marketMakerId).toBeUndefined();
     expect(token.token_id).toMatch(/^[a-f0-9]{64}$/);
     expect(token.capability_hash).toMatch(/^[a-f0-9]{64}$/);
   });
@@ -109,6 +123,58 @@ describe('capability token minting', () => {
     const expectedHash = computeCapabilityHash(payloadBytes);
 
     expect(token.capability_hash).toBe(expectedHash);
+  });
+
+  it('changes the capability hash when marketMakerId is added to the same payload', () => {
+    const commonPayload = {
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      consent_ref: 'd'.repeat(64),
+      scope: baseScope,
+      permissions: basePermissions,
+      issued_at: '2025-06-15T10:00:00Z',
+      not_before: null,
+      expires_at: tokenExpires,
+      token_id: 'e'.repeat(64)
+    } as const;
+
+    const unboundHash = computeCapabilityHash(
+      canonicalizeCapabilityPayload(commonPayload)
+    );
+    const boundHash = computeCapabilityHash(
+      canonicalizeCapabilityPayload({
+        ...commonPayload,
+        marketMakerId: 'hrkey-v1'
+      })
+    );
+
+    expect(boundHash).not.toBe(unboundHash);
+  });
+
+  it('produces the same capability hash for identical payloads with the same marketMakerId', () => {
+    const boundPayload = {
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      consent_ref: 'd'.repeat(64),
+      scope: baseScope,
+      permissions: basePermissions,
+      marketMakerId: 'hrkey-v1',
+      issued_at: '2025-06-15T10:00:00Z',
+      not_before: null,
+      expires_at: tokenExpires,
+      token_id: 'e'.repeat(64)
+    } as const;
+
+    const hashA = computeCapabilityHash(
+      canonicalizeCapabilityPayload(boundPayload)
+    );
+    const hashB = computeCapabilityHash(
+      canonicalizeCapabilityPayload(boundPayload)
+    );
+
+    expect(hashA).toBe(hashB);
   });
 
   it('produces unique token_ids across mints', () => {
@@ -201,6 +267,31 @@ describe('capability token minting', () => {
     );
 
     expect(token.expires_at).toBe('2099-12-31T23:59:59Z');
+  });
+
+  it('preserves parent consent marketMakerId when minting a capability', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      multiScope,
+      multiPermissions,
+      {
+        now: consentNow,
+        expires_at: consentExpires,
+        marketMakerId: 'hrkey-v1'
+      }
+    );
+
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      tokenExpires,
+      { now: tokenNow, marketMakerId: 'hrkey-v1' }
+    );
+
+    expect(token.marketMakerId).toBe('hrkey-v1');
   });
 
   it('accepts did:aoc:public as grantee', () => {
@@ -322,6 +413,70 @@ describe('capability token minting — rejection paths', () => {
     ).toThrow('Capability not_before must be before expires_at.');
   });
 
+  it('rejects overriding a parent consent marketMakerId', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      multiScope,
+      multiPermissions,
+      {
+        now: consentNow,
+        expires_at: consentExpires,
+        marketMakerId: 'hrkey-v1'
+      }
+    );
+
+    expect(() =>
+      mintCapabilityToken(
+        consent,
+        baseScope,
+        basePermissions,
+        tokenExpires,
+        { now: tokenNow, marketMakerId: 'other-maker' }
+      )
+    ).toThrow('Capability marketMakerId must match parent consent marketMakerId.');
+  });
+
+  it('rejects introducing a marketMakerId when parent consent is unbound', () => {
+    const consent = buildBaseConsent();
+
+    expect(() =>
+      mintCapabilityToken(
+        consent,
+        baseScope,
+        basePermissions,
+        tokenExpires,
+        { now: tokenNow, marketMakerId: 'hrkey-v1' }
+      )
+    ).toThrow('Capability marketMakerId cannot be introduced when parent consent is unbound.');
+  });
+
+  it('rejects malformed marketMakerId values during minting', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      multiScope,
+      multiPermissions,
+      {
+        now: consentNow,
+        expires_at: consentExpires,
+        marketMakerId: 'hrkey-v1'
+      }
+    );
+
+    expect(() =>
+      mintCapabilityToken(
+        consent,
+        baseScope,
+        basePermissions,
+        tokenExpires,
+        { now: tokenNow, marketMakerId: 'Bad Value' as any }
+      )
+    ).toThrow('Capability marketMakerId must contain only lowercase letters, numbers, dots, underscores, or hyphens and be at most 128 characters.');
+  });
+
   it('rejects not_before before consent issued_at', () => {
     const consent = buildBaseConsent();
 
@@ -438,6 +593,57 @@ describe('capability token minting — rejection paths', () => {
 });
 
 describe('capability token validation (structural)', () => {
+  it('accepts a structurally valid capability with marketMakerId', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      multiScope,
+      multiPermissions,
+      {
+        now: consentNow,
+        expires_at: consentExpires,
+        marketMakerId: 'hrkey-v1'
+      }
+    );
+
+    const token = mintCapabilityToken(
+      consent,
+      baseScope,
+      basePermissions,
+      tokenExpires,
+      { now: tokenNow }
+    );
+
+    expect(() => validateCapabilityToken(token)).not.toThrow();
+  });
+
+  it('rejects malformed capability marketMakerId values', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      multiScope,
+      multiPermissions,
+      {
+        now: consentNow,
+        expires_at: consentExpires,
+        marketMakerId: 'hrkey-v1'
+      }
+    );
+
+    const token = {
+      ...mintCapabilityToken(consent, baseScope, basePermissions, tokenExpires, {
+        now: tokenNow
+      }),
+      marketMakerId: 'Bad Value'
+    };
+
+    expect(() => validateCapabilityToken(token as any)).toThrow(
+      'Capability marketMakerId must contain only lowercase letters, numbers, dots, underscores, or hyphens and be at most 128 characters.'
+    );
+  });
+
   it('validates a correctly minted token', () => {
     const consent = buildBaseConsent();
     const token = mintCapabilityToken(
@@ -497,6 +703,48 @@ describe('capability token validation (structural)', () => {
 });
 
 describe('capability token verification', () => {
+  it('rejects parent/child marketMakerId mismatches', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      multiScope,
+      multiPermissions,
+      {
+        now: consentNow,
+        expires_at: consentExpires,
+        marketMakerId: 'hrkey-v1'
+      }
+    );
+
+    const mintedToken = mintCapabilityToken(consent, baseScope, basePermissions, tokenExpires, {
+      now: tokenNow
+    });
+    const token = {
+      ...mintedToken,
+      marketMakerId: 'other-maker'
+    };
+    token.capability_hash = computeCapabilityHash(
+      canonicalizeCapabilityPayload({
+        version: token.version,
+        subject: token.subject,
+        grantee: token.grantee,
+        consent_ref: token.consent_ref,
+        scope: token.scope,
+        permissions: token.permissions,
+        marketMakerId: token.marketMakerId,
+        issued_at: token.issued_at,
+        not_before: token.not_before,
+        expires_at: token.expires_at,
+        token_id: token.token_id
+      })
+    );
+
+    expect(() => verifyCapabilityToken(token as any, consent, { now: tokenNow })).toThrow(
+      'Capability marketMakerId does not match parent consent marketMakerId.'
+    );
+  });
+
   it('verifies a valid token against its parent consent', () => {
     const consent = buildBaseConsent();
     const token = mintCapabilityToken(

--- a/capability/canonical.ts
+++ b/capability/canonical.ts
@@ -22,8 +22,8 @@ function canonicalizeScopeEntry(entry: ScopeEntry): object {
  * - Sorts scope array by (type, ref) in ascending lexicographic order
  * - Sorts permissions array in ascending lexicographic order
  * - Top-level keys in alphabetical order:
- *   consent_ref, expires_at, grantee, issued_at, not_before,
- *   permissions, scope, subject, token_id, version
+ *   consent_ref, expires_at, grantee, issued_at, marketMakerId,
+ *   not_before, permissions, scope, subject, token_id, version
  * - Scope entry keys in alphabetical order: ref, type
  * - Null values are included in the canonical payload
  */
@@ -46,6 +46,11 @@ export function canonicalizeCapabilityPayload(
     expires_at: payload.expires_at,
     grantee: payload.grantee,
     issued_at: payload.issued_at,
+    ...(payload.marketMakerId !== undefined
+      ? {
+        marketMakerId: payload.marketMakerId
+      }
+      : {}),
     not_before: payload.not_before,
     permissions: sortedPermissions,
     scope: sortedScope.map(canonicalizeScopeEntry),

--- a/capability/capabilityToken.ts
+++ b/capability/capabilityToken.ts
@@ -3,6 +3,7 @@ import { ConsentObjectV1, ScopeEntry } from '../consent/types';
 import { canonicalizeCapabilityPayload } from './canonical';
 import { computeCapabilityHash } from './hash';
 import { isRevoked } from './revocation';
+import { validateMarketMakerId } from '../shared/marketMakerId';
 import type { NonceRegistry } from './registries/NonceRegistry';
 import type { RevocationRegistry } from './registries/RevocationRegistry';
 import { InMemoryNonceRegistry } from './registries/InMemoryNonceRegistry';
@@ -230,6 +231,8 @@ export function mintCapabilityToken(
     .toISOString()
     .replace(/\.\d{3}Z$/, 'Z');
   const not_before = opts.not_before ?? null;
+  const requestedMarketMakerId = opts.marketMakerId;
+  const parentMarketMakerId = consent.marketMakerId;
   const token_id = generateTokenId();
 
   // Structural validation
@@ -242,9 +245,28 @@ export function mintCapabilityToken(
   validateTimestamp(issued_at, 'issued_at');
   validateTimestamp(expires_at, 'expires_at');
   validateTokenId(token_id);
+  validateMarketMakerId(requestedMarketMakerId, 'Capability marketMakerId');
+  validateMarketMakerId(parentMarketMakerId, 'Parent consent marketMakerId');
 
   if (not_before !== null) {
     validateTimestamp(not_before, 'not_before');
+  }
+
+  let marketMakerId: string | undefined;
+  if (parentMarketMakerId !== undefined) {
+    if (
+      requestedMarketMakerId !== undefined &&
+      requestedMarketMakerId !== parentMarketMakerId
+    ) {
+      throw new Error(
+        'Capability marketMakerId must match parent consent marketMakerId.'
+      );
+    }
+    marketMakerId = parentMarketMakerId;
+  } else if (requestedMarketMakerId !== undefined) {
+    throw new Error(
+      'Capability marketMakerId cannot be introduced when parent consent is unbound.'
+    );
   }
 
   // Semantic: expires_at must be after issued_at
@@ -299,6 +321,7 @@ export function mintCapabilityToken(
     consent_ref,
     scope,
     permissions,
+    ...(marketMakerId !== undefined ? { marketMakerId } : {}),
     issued_at,
     not_before,
     expires_at,
@@ -314,6 +337,7 @@ export function mintCapabilityToken(
     consent_ref,
     scope,
     permissions,
+    ...(marketMakerId !== undefined ? { marketMakerId } : {}),
     issued_at,
     not_before,
     expires_at,
@@ -339,6 +363,7 @@ export function validateCapabilityToken(token: CapabilityTokenV1): void {
   validateTimestamp(token.issued_at, 'issued_at');
   validateTimestamp(token.expires_at, 'expires_at');
   validateTokenId(token.token_id);
+  validateMarketMakerId(token.marketMakerId, 'Capability marketMakerId');
 
   if (token.not_before !== null) {
     validateTimestamp(token.not_before, 'not_before');
@@ -378,6 +403,9 @@ export function validateCapabilityToken(token: CapabilityTokenV1): void {
     consent_ref: token.consent_ref,
     scope: token.scope,
     permissions: token.permissions,
+    ...(token.marketMakerId !== undefined
+      ? { marketMakerId: token.marketMakerId }
+      : {}),
     issued_at: token.issued_at,
     not_before: token.not_before,
     expires_at: token.expires_at,
@@ -440,6 +468,13 @@ export function verifyCapabilityToken(
   if (token.grantee !== consent.grantee) {
     throw new Error(
       'Capability grantee does not match parent consent grantee.'
+    );
+  }
+
+  validateMarketMakerId(consent.marketMakerId, 'Parent consent marketMakerId');
+  if (consent.marketMakerId !== token.marketMakerId) {
+    throw new Error(
+      'Capability marketMakerId does not match parent consent marketMakerId.'
     );
   }
 

--- a/capability/types.ts
+++ b/capability/types.ts
@@ -9,6 +9,7 @@ export type CapabilityTokenV1 = {
   consent_ref: string;
   scope: ScopeEntry[];
   permissions: string[];
+  marketMakerId?: string;
   issued_at: string;
   not_before: string | null;
   expires_at: string;
@@ -19,4 +20,5 @@ export type CapabilityTokenV1 = {
 export type MintCapabilityOptions = {
   now?: Date;
   not_before?: string | null;
+  marketMakerId?: string;
 };

--- a/consent/__tests__/consent.test.ts
+++ b/consent/__tests__/consent.test.ts
@@ -163,6 +163,15 @@ describe('consent object builder', () => {
     expect(consent.expires_at).toBe('2026-01-15T14:30:00Z');
   });
 
+  it('accepts a valid marketMakerId on a grant consent', () => {
+    const consent = buildConsentObject(
+      SUBJECT, GRANTEE, 'grant', baseScope, basePermissions,
+      { now: baseNow, marketMakerId: 'hrkey-v1' }
+    );
+
+    expect(consent.marketMakerId).toBe('hrkey-v1');
+  });
+
   it('builds a valid revocation (prior_consent optional)', () => {
     const grant = buildConsentObject(
       SUBJECT, GRANTEE, 'grant', baseScope, basePermissions,
@@ -246,6 +255,38 @@ describe('consent object validation', () => {
     expect(() =>
       buildConsentObject('', GRANTEE, 'grant', baseScope, basePermissions, { now: baseNow })
     ).toThrow('Consent subject must be non-empty.');
+  });
+
+  it('rejects malformed marketMakerId values', () => {
+    expect(() =>
+      buildConsentObject(
+        SUBJECT,
+        GRANTEE,
+        'grant',
+        baseScope,
+        basePermissions,
+        { now: baseNow, marketMakerId: 'Bad Value' as any }
+      )
+    ).toThrow(
+      'Consent marketMakerId must contain only lowercase letters, numbers, dots, underscores, or hyphens and be at most 128 characters.'
+    );
+  });
+
+  it('rejects revoke consent with marketMakerId', () => {
+    expect(() =>
+      buildConsentObject(
+        SUBJECT,
+        GRANTEE,
+        'revoke',
+        [],
+        [],
+        {
+          now: baseNow,
+          revoke_target: { capability_hash: REF_A },
+          marketMakerId: 'hrkey-v1'
+        }
+      )
+    ).toThrow('Consent revoke actions must not include marketMakerId.');
   });
 
   it('rejects invalid subject DID', () => {

--- a/consent/canonical.ts
+++ b/consent/canonical.ts
@@ -22,7 +22,8 @@ function canonicalizeScopeEntry(entry: ScopeEntry): object {
  * - Sorts scope array by (type, ref) in ascending lexicographic order
  * - Sorts permissions array in ascending lexicographic order
  * - Top-level keys in alphabetical order:
- *   action, expires_at, grantee, issued_at, permissions, prior_consent, scope, subject, version
+ *   action, expires_at, grantee, issued_at, marketMakerId, permissions,
+ *   prior_consent, scope, subject, version
  * - Scope entry keys in alphabetical order: ref, type
  * - Null values are included in the canonical payload
  */
@@ -45,6 +46,11 @@ export function canonicalizeConsentPayload(
     expires_at: payload.expires_at,
     grantee: payload.grantee,
     issued_at: payload.issued_at,
+    ...(payload.marketMakerId !== undefined
+      ? {
+        marketMakerId: payload.marketMakerId
+      }
+      : {}),
     permissions: sortedPermissions,
     prior_consent: payload.prior_consent,
     ...(payload.revoke_target !== undefined

--- a/consent/consentObject.ts
+++ b/consent/consentObject.ts
@@ -1,6 +1,7 @@
 import { canonicalizeConsentPayload } from './canonical';
 import { computeConsentHash } from './hash';
 import { BuildConsentOptions, ConsentObjectV1, ScopeEntry } from './types';
+import { validateMarketMakerId } from '../shared/marketMakerId';
 
 const VERSION_PATTERN = /^[0-9]+\.[0-9]+$/;
 const DID_PATTERN = /^did:[a-z0-9]+:[a-zA-Z0-9._%-]+$/;
@@ -170,14 +171,19 @@ export function buildConsentObject(
   const expires_at = opts.expires_at ?? null;
   const prior_consent = opts.prior_consent ?? null;
   const revoke_target = opts.revoke_target;
+  const marketMakerId = opts.marketMakerId;
 
   validateVersion(version);
   validateDID(subject, 'subject');
   validateDID(grantee, 'grantee');
   validateAction(action);
   validateIssuedAt(issued_at);
+  validateMarketMakerId(marketMakerId, 'Consent marketMakerId');
 
   if (action === 'revoke') {
+    if (marketMakerId !== undefined) {
+      throw new Error('Consent revoke actions must not include marketMakerId.');
+    }
     validateRevokeTarget(revoke_target);
 
     if (scope.length > 0) {
@@ -205,6 +211,7 @@ export function buildConsentObject(
     action,
     scope,
     permissions,
+    ...(marketMakerId !== undefined ? { marketMakerId } : {}),
     issued_at,
     expires_at,
     prior_consent,
@@ -224,6 +231,7 @@ export function buildConsentObject(
     action,
     scope,
     permissions,
+    ...(marketMakerId !== undefined ? { marketMakerId } : {}),
     issued_at,
     expires_at,
     prior_consent,
@@ -238,8 +246,12 @@ export function validateConsentObject(consent: ConsentObjectV1): void {
   validateDID(consent.grantee, 'grantee');
   validateAction(consent.action);
   validateIssuedAt(consent.issued_at);
+  validateMarketMakerId(consent.marketMakerId, 'Consent marketMakerId');
 
   if (consent.action === 'revoke') {
+    if (consent.marketMakerId !== undefined) {
+      throw new Error('Consent revoke actions must not include marketMakerId.');
+    }
     validateRevokeTarget(consent.revoke_target);
 
     if (consent.scope !== undefined && consent.scope.length > 0) {
@@ -274,6 +286,9 @@ export function validateConsentObject(consent: ConsentObjectV1): void {
     action: consent.action,
     scope: consent.scope,
     permissions: consent.permissions,
+    ...(consent.marketMakerId !== undefined
+      ? { marketMakerId: consent.marketMakerId }
+      : {}),
     issued_at: consent.issued_at,
     expires_at: consent.expires_at,
     prior_consent: consent.prior_consent,

--- a/consent/types.ts
+++ b/consent/types.ts
@@ -10,6 +10,7 @@ export type ConsentObjectV1 = {
   action: 'grant' | 'revoke';
   scope: ScopeEntry[];
   permissions: string[];
+  marketMakerId?: string;
   revoke_target?: {
     capability_hash: string;
   };
@@ -26,4 +27,5 @@ export type BuildConsentOptions = {
   revoke_target?: {
     capability_hash: string;
   };
+  marketMakerId?: string;
 };

--- a/enforcement/__tests__/evaluateCapabilityAccess.test.ts
+++ b/enforcement/__tests__/evaluateCapabilityAccess.test.ts
@@ -1,5 +1,9 @@
 import { buildConsentObject } from '../../consent';
-import { mintCapabilityToken } from '../../capability';
+import {
+  canonicalizeCapabilityPayload,
+  computeCapabilityHash,
+  mintCapabilityToken
+} from '../../capability';
 import {
   capabilityAccessReasonCodes,
   evaluateCapabilityAccess
@@ -14,7 +18,7 @@ const TOKEN_NOW = new Date('2025-06-15T10:00:00Z');
 const CONSENT_EXPIRES = '2026-01-15T14:30:00Z';
 const TOKEN_EXPIRES = '2025-12-31T23:59:59Z';
 
-function buildConsent() {
+function buildConsent(marketMakerId?: string) {
   return buildConsentObject(
     SUBJECT,
     GRANTEE,
@@ -24,12 +28,18 @@ function buildConsent() {
       { type: 'pack', ref: PACK_REF }
     ],
     ['read', 'store'],
-    { now: CONSENT_NOW, expires_at: CONSENT_EXPIRES }
+    {
+      now: CONSENT_NOW,
+      expires_at: CONSENT_EXPIRES,
+      ...(marketMakerId !== undefined ? { marketMakerId } : {})
+    }
   );
 }
 
 function buildCapability(overrides: Record<string, unknown> = {}) {
-  const consent = buildConsent();
+  const consentMarketMakerId =
+    typeof overrides.marketMakerId === 'string' ? overrides.marketMakerId : undefined;
+  const consent = buildConsent(consentMarketMakerId);
   const capability = mintCapabilityToken(
     consent,
     [
@@ -219,6 +229,89 @@ describe('evaluateCapabilityAccess', () => {
     });
 
     expect(decision.reasonCode).toBe(capabilityAccessReasonCodes.MARKET_MAKER_MISMATCH);
+  });
+
+  it('denies when consent and capability marketMakerId bindings mismatch', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: CONTENT_REF }],
+      ['read'],
+      {
+        now: CONSENT_NOW,
+        expires_at: CONSENT_EXPIRES,
+        marketMakerId: 'hrkey-v1'
+      }
+    );
+    const capability = {
+      ...mintCapabilityToken(
+        consent,
+        [{ type: 'content', ref: CONTENT_REF }],
+        ['read'],
+        TOKEN_EXPIRES,
+        { now: TOKEN_NOW }
+      ),
+      marketMakerId: 'other-maker'
+    };
+    capability.capability_hash = computeCapabilityHash(
+      canonicalizeCapabilityPayload({
+        version: capability.version,
+        subject: capability.subject,
+        grantee: capability.grantee,
+        consent_ref: capability.consent_ref,
+        scope: capability.scope,
+        permissions: capability.permissions,
+        marketMakerId: capability.marketMakerId,
+        issued_at: capability.issued_at,
+        not_before: capability.not_before,
+        expires_at: capability.expires_at,
+        token_id: capability.token_id
+      })
+    );
+
+    const decision = evaluateCapabilityAccess({
+      capability,
+      consent,
+      action: 'read',
+      resource: `content:${CONTENT_REF}`,
+      marketMakerId: 'hrkey-v1',
+      now: '2025-08-01T00:00:00Z'
+    });
+
+    expect(decision.reasonCode).toBe(capabilityAccessReasonCodes.CONSENT_MISMATCH);
+  });
+
+  it('denies with CONSENT_MISMATCH when capability subject mismatches the parent consent', () => {
+    const { consent, capability } = buildCapability();
+    const mismatchedCapability: any = {
+      ...capability,
+      subject: 'did:key:z6MkDifferentSubject1234567890abc'
+    };
+    mismatchedCapability.capability_hash = computeCapabilityHash(
+      canonicalizeCapabilityPayload({
+        version: mismatchedCapability.version as string,
+        subject: mismatchedCapability.subject as string,
+        grantee: mismatchedCapability.grantee as string,
+        consent_ref: mismatchedCapability.consent_ref as string,
+        scope: mismatchedCapability.scope as any,
+        permissions: mismatchedCapability.permissions as any,
+        issued_at: mismatchedCapability.issued_at as string,
+        not_before: mismatchedCapability.not_before as string | null,
+        expires_at: mismatchedCapability.expires_at as string,
+        token_id: mismatchedCapability.token_id as string
+      })
+    );
+
+    const decision = evaluateCapabilityAccess({
+      capability: mismatchedCapability,
+      consent,
+      action: 'read',
+      resource: `content:${CONTENT_REF}`,
+      now: '2025-08-01T00:00:00Z'
+    });
+
+    expect(decision.reasonCode).toBe(capabilityAccessReasonCodes.CONSENT_MISMATCH);
   });
 
   it('denies malformed timestamps fail-closed', () => {

--- a/enforcement/evaluateCapabilityAccess.ts
+++ b/enforcement/evaluateCapabilityAccess.ts
@@ -63,6 +63,52 @@ function evaluateConsentBinding(
     );
   }
 
+  const rawCapability = input.capability.raw as Record<string, unknown>;
+
+  if (rawCapability.subject !== input.consent.subject) {
+    return denyDecision(
+      input.evaluatedAt,
+      capabilityAccessReasonCodes.CONSENT_MISMATCH,
+      'Capability subject does not match the supplied parent consent.',
+      makeChecks(),
+      {
+        failureStage: 'integrity',
+        capabilityHash: input.capability.capabilityHash,
+        consentRef: input.capability.consentRef
+      }
+    );
+  }
+
+  if (rawCapability.grantee !== input.consent.grantee) {
+    return denyDecision(
+      input.evaluatedAt,
+      capabilityAccessReasonCodes.CONSENT_MISMATCH,
+      'Capability grantee does not match the supplied parent consent.',
+      makeChecks(),
+      {
+        failureStage: 'integrity',
+        capabilityHash: input.capability.capabilityHash,
+        consentRef: input.capability.consentRef
+      }
+    );
+  }
+
+  if (input.capability.marketMakerId !== (input.consent.marketMakerId ?? null)) {
+    return denyDecision(
+      input.evaluatedAt,
+      capabilityAccessReasonCodes.CONSENT_MISMATCH,
+      'Capability marketMakerId does not match the supplied parent consent.',
+      makeChecks(),
+      {
+        failureStage: 'integrity',
+        capabilityHash: input.capability.capabilityHash,
+        consentRef: input.capability.consentRef,
+        boundMarketMakerId: input.capability.marketMakerId ?? undefined,
+        consentMarketMakerId: input.consent.marketMakerId
+      }
+    );
+  }
+
   return null;
 }
 

--- a/integration/hrkey/__tests__/capabilityEnforcement.test.ts
+++ b/integration/hrkey/__tests__/capabilityEnforcement.test.ts
@@ -13,19 +13,20 @@ function buildHrKeyCapability() {
     'grant',
     [{ type: 'content', ref: CONTENT_REF }],
     ['read'],
-    { now: new Date('2025-01-15T14:30:00Z'), expires_at: '2026-01-15T14:30:00Z' }
+    {
+      now: new Date('2025-01-15T14:30:00Z'),
+      expires_at: '2026-01-15T14:30:00Z',
+      marketMakerId: 'hrkey-v1'
+    }
   );
 
-  const capability = {
-    ...mintCapabilityToken(
-      consent,
-      [{ type: 'content', ref: CONTENT_REF }],
-      ['read'],
-      '2025-12-31T23:59:59Z',
-      { now: new Date('2025-06-15T10:00:00Z') }
-    ),
-    marketMakerId: 'hrkey-v1'
-  };
+  const capability = mintCapabilityToken(
+    consent,
+    [{ type: 'content', ref: CONTENT_REF }],
+    ['read'],
+    '2025-12-31T23:59:59Z',
+    { now: new Date('2025-06-15T10:00:00Z') }
+  );
 
   return { consent, capability };
 }

--- a/protocol/capabilities/__tests__/capabilityEnforcer.test.ts
+++ b/protocol/capabilities/__tests__/capabilityEnforcer.test.ts
@@ -9,19 +9,25 @@ const CONTENT_REF = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 const CONSENT_EXPIRES = '2026-01-15T14:30:00Z';
 const NOW = new Date('2025-08-01T00:00:00Z');
 
-function buildConsent() {
+function buildConsent(marketMakerId?: string) {
   return buildConsentObject(
     SUBJECT,
     GRANTEE,
     'grant',
     [{ type: 'content', ref: CONTENT_REF }],
     ['read'],
-    { now: new Date('2025-01-15T14:30:00Z'), expires_at: CONSENT_EXPIRES }
+    {
+      now: new Date('2025-01-15T14:30:00Z'),
+      expires_at: CONSENT_EXPIRES,
+      ...(marketMakerId !== undefined ? { marketMakerId } : {})
+    }
   );
 }
 
 function buildToken(overrides: Record<string, unknown> = {}) {
-  const consent = buildConsent();
+  const consent = buildConsent(
+    typeof overrides.marketMakerId === 'string' ? overrides.marketMakerId : undefined
+  );
 
   return {
     consent,

--- a/protocol/capabilities/capabilityEnforcer.ts
+++ b/protocol/capabilities/capabilityEnforcer.ts
@@ -128,6 +128,13 @@ function verifyAgainstConsent(
     );
   }
 
+  if (token.marketMakerId !== consent.marketMakerId) {
+    throw new LegacyBridgeValidationError(
+      'CONSENT_MISMATCH',
+      'Capability marketMakerId does not match parent consent marketMakerId.'
+    );
+  }
+
   const consentScope = new Set(
     consent.scope.map((entry) => `${entry.type}:${entry.ref}`)
   );

--- a/protocol/consent/capability-token-spec.md
+++ b/protocol/consent/capability-token-spec.md
@@ -39,6 +39,7 @@ CapabilityToken := {
   consent_ref,      // Hash of the parent Consent Object
   scope,            // Array of scope entries (subset of consent scope)
   permissions,      // Array of permitted operations (subset of consent permissions)
+  marketMakerId,    // Optional market-maker binding copied from parent consent
   issued_at,        // Timestamp of token issuance
   not_before,       // Earliest validity time (optional)
   expires_at,       // Expiration timestamp (required, non-null)
@@ -155,6 +156,7 @@ CapabilityToken := {
 | `consent_ref` | string | REQUIRED | Hash of the parent Consent Object |
 | `scope` | array | REQUIRED | Scope entries authorized by this token |
 | `permissions` | array | REQUIRED | Operations permitted by this token |
+| `marketMakerId` | string | OPTIONAL | Canonical market-maker binding copied from parent consent |
 | `issued_at` | string | REQUIRED | ISO 8601 UTC timestamp of token issuance |
 | `not_before` | string or null | OPTIONAL | ISO 8601 UTC timestamp of earliest validity |
 | `expires_at` | string | REQUIRED | ISO 8601 UTC timestamp of token expiration |
@@ -263,6 +265,24 @@ CapabilityToken := {
 
 See [Section 5: Attenuation Model](#5-attenuation-model) for subset constraints.
 
+#### 3.2.7 marketMakerId
+
+| Property | Value |
+|----------|-------|
+| **Name** | `marketMakerId` |
+| **Type** | string |
+| **Required** | OPTIONAL |
+| **Format** | lowercase identifier |
+| **Constraints** | Pattern: `^[a-z0-9][a-z0-9._-]{0,127}$` |
+
+**Description:** Optional binding to a specific market maker. `marketMakerId` is the canonical capability field name; compatibility aliases such as `market_maker_id` MAY be normalized by enforcement code but MUST NOT be emitted as the canonical protocol representation.
+
+**Semantic Rules:**
+
+1. If the parent Consent Object includes `marketMakerId`, the Capability Token MUST include the same value.
+2. If the parent Consent Object omits `marketMakerId`, the Capability Token MUST also omit it.
+3. Derivation MUST fail closed on any parent/child mismatch.
+
 #### 3.2.6 permissions
 
 | Property | Value |
@@ -282,7 +302,7 @@ See [Section 5: Attenuation Model](#5-attenuation-model) for subset constraints.
 3. Permission strings MUST be lowercase alphanumeric with hyphens.
 4. Permissions MUST NOT contain duplicates within a single token.
 
-#### 3.2.7 issued_at
+#### 3.2.8 issued_at
 
 | Property | Value |
 |----------|-------|
@@ -303,7 +323,7 @@ See [Section 5: Attenuation Model](#5-attenuation-model) for subset constraints.
 
 **Example:** `"2025-06-15T10:00:00Z"`
 
-#### 3.2.8 not_before
+#### 3.2.9 not_before
 
 | Property | Value |
 |----------|-------|
@@ -325,7 +345,7 @@ See [Section 5: Attenuation Model](#5-attenuation-model) for subset constraints.
 
 **Example:** `"2025-07-01T00:00:00Z"`
 
-#### 3.2.9 expires_at
+#### 3.2.10 expires_at
 
 | Property | Value |
 |----------|-------|
@@ -348,7 +368,7 @@ See [Section 5: Attenuation Model](#5-attenuation-model) for subset constraints.
 
 **Example:** `"2025-07-15T10:00:00Z"`
 
-#### 3.2.10 token_id
+#### 3.2.11 token_id
 
 | Property | Value |
 |----------|-------|
@@ -367,7 +387,7 @@ See [Section 5: Attenuation Model](#5-attenuation-model) for subset constraints.
 3. The `token_id` MUST NOT be derived from the `capability_hash` or any other field of the token.
 4. Implementations SHOULD generate `token_id` values with sufficient entropy to make collision computationally infeasible.
 
-#### 3.2.11 capability_hash
+#### 3.2.12 capability_hash
 
 | Property | Value |
 |----------|-------|
@@ -407,8 +427,9 @@ A Capability Token MUST be derived from exactly one Consent Object. The `consent
 |-------|------------|
 | `subject` | MUST be identical to the parent Consent Object's `subject` |
 | `grantee` | MUST be identical to the parent Consent Object's `grantee` |
+| `marketMakerId` | MUST be identical to the parent Consent Object's `marketMakerId` when present; otherwise omitted |
 
-Identity fields MUST NOT be altered during derivation. A Capability Token cannot redirect authorization to a different subject or grantee.
+Identity and market-maker binding fields MUST NOT be altered during derivation. A Capability Token cannot redirect authorization to a different subject, grantee, or market maker.
 
 ### 4.3 Scope Binding
 
@@ -447,7 +468,7 @@ The token's validity window MUST be contained within the parent consent's tempor
 
 ### 5.1 Attenuation Principle
 
-A Capability Token represents an **equal or narrower** grant of authorization compared to its parent Consent Object. Attenuation MAY occur along three independent dimensions: scope, permissions, and time. Attenuation along one dimension does not require attenuation along others.
+A Capability Token represents an **equal or narrower** grant of authorization compared to its parent Consent Object. Attenuation MAY occur along three independent dimensions: scope, permissions, and time. `marketMakerId` is not an attenuation axis: it is a provenance binding that MUST be copied exactly when present and omitted when absent. Attenuation along one dimension does not require attenuation along others.
 
 ### 5.2 Scope Attenuation
 

--- a/protocol/consent/consent-object-spec.md
+++ b/protocol/consent/consent-object-spec.md
@@ -42,6 +42,7 @@ ConsentObject := {
   action,         // "grant" or "revoke"
   scope,          // Array of scope entries
   permissions,    // Array of permitted operations
+  marketMakerId,  // Optional market-maker binding for derived capabilities
   issued_at,      // Timestamp of consent issuance
   expires_at,     // Expiration timestamp (optional)
   prior_consent,  // Reference to superseded consent (optional)
@@ -142,6 +143,7 @@ ConsentObject := {
 | `action` | string | REQUIRED | Authorization action type |
 | `scope` | array | REQUIRED | Objects covered by this consent |
 | `permissions` | array | REQUIRED | Permitted operations |
+| `marketMakerId` | string | OPTIONAL | Canonical market-maker binding inherited by derived capabilities |
 | `issued_at` | string | REQUIRED | ISO 8601 UTC timestamp |
 | `expires_at` | string | OPTIONAL | ISO 8601 UTC timestamp or null |
 | `prior_consent` | string | OPTIONAL | Hash of superseded consent or null |
@@ -251,6 +253,25 @@ ConsentObject := {
 
 See [Section 4: Consent Scope Model](#4-consent-scope-model) for scope entry structure.
 
+#### 3.2.7 marketMakerId
+
+| Property | Value |
+|----------|-------|
+| **Name** | `marketMakerId` |
+| **Type** | string |
+| **Required** | OPTIONAL |
+| **Format** | lowercase identifier |
+| **Constraints** | Pattern: `^[a-z0-9][a-z0-9._-]{0,127}$` |
+
+**Description:** Optional binding to a specific market maker. This field lives on grant consents and, when present, becomes part of the derivation boundary for every child Capability Token.
+
+**Semantic Rules:**
+
+1. `marketMakerId` is the canonical consent/grant field name for market-maker binding.
+2. Grant consents MAY omit `marketMakerId`; omitted means unbound and remains backward-compatible.
+3. If present on a grant consent, every derived Capability Token MUST preserve the exact same value.
+4. Revoke consents MUST NOT include `marketMakerId`.
+
 #### 3.2.6 permissions
 
 | Property | Value |
@@ -282,7 +303,7 @@ See [Section 4: Consent Scope Model](#4-consent-scope-model) for scope entry str
 | `derive` | Create derivative objects referencing original |
 | `aggregate` | Include object in aggregate computations |
 
-#### 3.2.7 issued_at
+#### 3.2.8 issued_at
 
 | Property | Value |
 |----------|-------|
@@ -303,7 +324,7 @@ See [Section 4: Consent Scope Model](#4-consent-scope-model) for scope entry str
 
 **Example:** `"2025-01-15T14:30:00Z"`
 
-#### 3.2.8 expires_at
+#### 3.2.9 expires_at
 
 | Property | Value |
 |----------|-------|
@@ -325,7 +346,7 @@ See [Section 4: Consent Scope Model](#4-consent-scope-model) for scope entry str
 
 **Example:** `"2026-01-15T14:30:00Z"`
 
-#### 3.2.9 prior_consent
+#### 3.2.10 prior_consent
 
 | Property | Value |
 |----------|-------|
@@ -345,7 +366,7 @@ See [Section 4: Consent Scope Model](#4-consent-scope-model) for scope entry str
 3. A `null` value indicates this is an original grant with no predecessor; `null` is invalid for revocations.
 4. The referenced consent MUST have the same subject and grantee.
 
-#### 3.2.10 consent_hash
+#### 3.2.11 consent_hash
 
 | Property | Value |
 |----------|-------|

--- a/shared/marketMakerId.ts
+++ b/shared/marketMakerId.ts
@@ -1,0 +1,20 @@
+const MARKET_MAKER_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+
+export function validateMarketMakerId(
+  marketMakerId: string | undefined,
+  fieldName: string
+): void {
+  if (marketMakerId === undefined) {
+    return;
+  }
+
+  if (typeof marketMakerId !== 'string' || marketMakerId.trim() === '') {
+    throw new Error(`${fieldName} must be a non-empty string when provided.`);
+  }
+
+  if (!MARKET_MAKER_ID_PATTERN.test(marketMakerId)) {
+    throw new Error(
+      `${fieldName} must contain only lowercase letters, numbers, dots, underscores, or hyphens and be at most 128 characters.`
+    );
+  }
+}


### PR DESCRIPTION
### Motivation

- Add explicit market-maker provenance binding so grant consents can optionally lock derived capabilities to a specific market maker.
- Ensure capability derivation preserves and enforces this binding to avoid introducing or overriding a `marketMakerId` during minting or verification.
- Make canonicalization and hashing account for `marketMakerId` so hashes change when the binding is part of the payload.

### Description

- Add optional `marketMakerId?: string` to consent and capability `types` and propagate it through `buildConsentObject`, `mintCapabilityToken`, `validate*`, and `verify*` code paths.
- Implement `validateMarketMakerId` in `shared/marketMakerId.ts` and use it to validate values on consent creation, capability minting, and token validation.
- Extend canonicalization (`consent/canonical.ts`, `capability/canonical.ts`) to include `marketMakerId` (when present) so `capability_hash`/`consent_hash` reflect the binding.
- Enforce derivation rules so a capability must preserve the parent's `marketMakerId` (cannot introduce or override it), and update enforcement layers (`evaluateCapabilityAccess`, legacy bridge `capabilityEnforcer`) and protocol docs to reflect the new semantic.

### Testing

- Added and updated unit tests in `capability/__tests__`, `consent/__tests__`, `enforcement/__tests__`, `protocol/*`, and `integration/hrkey` that cover valid bindings, mismatches, malformed values, and hash semantics for `marketMakerId` and all tests were executed successfully.
- Specific test scenarios added include minting/validation with and without `marketMakerId`, rejection paths for overrides or introductions of `marketMakerId`, canonical hash parity checks, and enforcement decisions mapping to `CONSENT_MISMATCH` or market-maker reason codes; all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16d3a403c832587364f74e7f76dd5)