### PR TITLE
Add per-consent usage metering for capability consumption

### DIFF
--- a/protocol/capabilities/__tests__/consumeCapabilityAccess.test.ts
+++ b/protocol/capabilities/__tests__/consumeCapabilityAccess.test.ts
@@ -6,7 +6,9 @@ import { MarketMakerRegistry } from '../../../shared/marketMakerRegistry';
 import { capabilityAccessReasonCodes } from '../../../enforcement';
 import {
   capabilityConsumptionReasonCodes,
-  consumeCapabilityAccess
+  consumeCapabilityAccess,
+  InMemoryConsentUsageRegistry,
+  type ConsentUsageRegistry
 } from '../consumeCapabilityAccess';
 import { enforceCapability } from '../capabilityEnforcer';
 
@@ -33,6 +35,17 @@ function buildConsent(marketMakerId?: string, expiresAt: string = CONSENT_EXPIRE
       ...(marketMakerId !== undefined ? { marketMakerId } : {})
     }
   );
+}
+
+
+class ThrowingConsentUsageRegistry implements ConsentUsageRegistry {
+  get(): undefined {
+    return undefined;
+  }
+
+  record(): never {
+    throw new Error('usage metering unavailable');
+  }
 }
 
 function buildToken(overrides: Record<string, unknown> = {}) {
@@ -140,6 +153,108 @@ describe('consumeCapabilityAccess', () => {
     expect(decision.consumed).toBe(false);
   });
 
+  it('records first-time successful usage per consent and returns usage state', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const { token, consent } = buildToken();
+
+    const decision = consumeCapabilityAccess({
+      capability: token,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      registries: {
+        nonceRegistry: new InMemoryNonceRegistry(),
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: usageRegistry
+      }
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.usage).toEqual({
+      usageCount: 1,
+      lastAccessedAt: '2025-06-15T10:00:00Z',
+      lastAccessResult: 'allow'
+    });
+    expect(usageRegistry.get(token.consent_ref)).toEqual({
+      consentRef: token.consent_ref,
+      usageCount: 1,
+      lastAccessedAt: '2025-06-15T10:00:00Z',
+      lastAccessResult: 'allow'
+    });
+  });
+
+  it('records denied usage attempts without incrementing usageCount', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const { token, consent } = buildToken();
+
+    const decision = consumeCapabilityAccess({
+      capability: token,
+      consent,
+      action: 'share',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      registries: {
+        nonceRegistry: new InMemoryNonceRegistry(),
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: usageRegistry
+      }
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.usage).toEqual({
+      usageCount: 0,
+      lastAccessedAt: '2025-06-15T10:00:00Z',
+      lastAccessResult: 'deny'
+    });
+    expect(usageRegistry.get(token.consent_ref)).toEqual({
+      consentRef: token.consent_ref,
+      usageCount: 0,
+      lastAccessedAt: '2025-06-15T10:00:00Z',
+      lastAccessResult: 'deny'
+    });
+  });
+
+  it('accumulates usageCount across multiple allowed calls for the same consent', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const first = buildToken();
+    const second = buildToken();
+
+    const firstDecision = consumeCapabilityAccess({
+      capability: first.token,
+      consent: first.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      consume: false,
+      registries: {
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: usageRegistry
+      }
+    });
+
+    const secondDecision = consumeCapabilityAccess({
+      capability: second.token,
+      consent: second.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: new Date('2025-06-15T10:00:30Z'),
+      consume: false,
+      registries: {
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: usageRegistry
+      }
+    });
+
+    expect(firstDecision.usage?.usageCount).toBe(1);
+    expect(secondDecision.usage).toEqual({
+      usageCount: 2,
+      lastAccessedAt: '2025-06-15T10:00:30Z',
+      lastAccessResult: 'allow'
+    });
+    expect(usageRegistry.get(first.token.consent_ref)?.usageCount).toBe(2);
+  });
+
   it('treats consume=false as a non-marking presentation even when allowed', () => {
     const nonceRegistry = new InMemoryNonceRegistry();
     const { token, consent } = buildToken();
@@ -157,6 +272,75 @@ describe('consumeCapabilityAccess', () => {
     expect(decision.allowed).toBe(true);
     expect(decision.consumed).toBe(false);
     expect(nonceRegistry.hasSeen(token.token_id, NOW)).toBe(false);
+  });
+
+  it('records usage even when consume=false', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const nonceRegistry = new InMemoryNonceRegistry();
+    const { token, consent } = buildToken();
+
+    const decision = consumeCapabilityAccess({
+      capability: token,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      consume: false,
+      registries: {
+        nonceRegistry,
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: usageRegistry
+      }
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.consumed).toBe(false);
+    expect(decision.usage).toEqual({
+      usageCount: 1,
+      lastAccessedAt: '2025-06-15T10:00:00Z',
+      lastAccessResult: 'allow'
+    });
+    expect(nonceRegistry.hasSeen(token.token_id, NOW)).toBe(false);
+  });
+
+  it('ignores usage metering failures and preserves the original decision', () => {
+    const { token, consent } = buildToken();
+
+    const decision = consumeCapabilityAccess({
+      capability: token,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      registries: {
+        nonceRegistry: new InMemoryNonceRegistry(),
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: new ThrowingConsentUsageRegistry()
+      }
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reasonCode).toBe(capabilityAccessReasonCodes.ACCESS_ALLOWED);
+    expect(decision.usage).toBeUndefined();
+  });
+
+  it('keeps the decision shape backward-compatible when no usage registry is provided', () => {
+    const { token, consent } = buildToken();
+
+    const decision = consumeCapabilityAccess({
+      capability: token,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      registries: {
+        nonceRegistry: new InMemoryNonceRegistry(),
+        revocationRegistry: new InMemoryRevocationRegistry()
+      }
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect('usage' in decision).toBe(false);
   });
 
   it('does not mark replay state on deny', () => {

--- a/protocol/capabilities/consumeCapabilityAccess.ts
+++ b/protocol/capabilities/consumeCapabilityAccess.ts
@@ -49,6 +49,50 @@ export type CapabilityConsumptionChecks = CapabilityAccessChecks & {
   replay: CapabilityConsumptionCheckState;
 };
 
+export type ConsentUsageResult = 'allow' | 'deny';
+
+export type ConsentUsageState = {
+  consentRef: string;
+  usageCount: number;
+  lastAccessedAt: string;
+  lastAccessResult: ConsentUsageResult;
+};
+
+export interface ConsentUsageRegistry {
+  get(consentRef: string): ConsentUsageState | undefined;
+  record(
+    consentRef: string,
+    result: ConsentUsageResult,
+    timestamp: string
+  ): ConsentUsageState;
+}
+
+export class InMemoryConsentUsageRegistry implements ConsentUsageRegistry {
+  private readonly states = new Map<string, ConsentUsageState>();
+
+  get(consentRef: string): ConsentUsageState | undefined {
+    const state = this.states.get(consentRef);
+    return state ? { ...state } : undefined;
+  }
+
+  record(
+    consentRef: string,
+    result: ConsentUsageResult,
+    timestamp: string
+  ): ConsentUsageState {
+    const current = this.states.get(consentRef);
+    const next: ConsentUsageState = {
+      consentRef,
+      usageCount: (current?.usageCount ?? 0) + (result === 'allow' ? 1 : 0),
+      lastAccessedAt: timestamp,
+      lastAccessResult: result
+    };
+
+    this.states.set(consentRef, next);
+    return { ...next };
+  }
+}
+
 export type CapabilityConsumptionRequest = {
   capability: CapabilityAccessRequest['capability'];
   consent?: ConsentObjectV1 | null;
@@ -64,6 +108,7 @@ export type CapabilityConsumptionRequest = {
   registries?: {
     nonceRegistry?: NonceRegistry;
     revocationRegistry?: RevocationRegistry;
+    consentUsageRegistry?: ConsentUsageRegistry;
   };
   consume?: boolean;
   requireReplayProtection?: boolean;
@@ -80,6 +125,7 @@ export type CapabilityConsumptionDecision = {
   consumed: boolean;
   replayChecked: boolean;
   revocationChecked: boolean;
+  usage?: Pick<ConsentUsageState, 'usageCount' | 'lastAccessedAt' | 'lastAccessResult'>;
 };
 
 function normalizeNow(now?: string | number | Date): Date {
@@ -245,6 +291,36 @@ function sanitizeMetadata(base: {
   };
 }
 
+function toUsageOutput(
+  state: ConsentUsageState
+): Pick<ConsentUsageState, 'usageCount' | 'lastAccessedAt' | 'lastAccessResult'> {
+  return {
+    usageCount: state.usageCount,
+    lastAccessedAt: state.lastAccessedAt,
+    lastAccessResult: state.lastAccessResult
+  };
+}
+
+function recordUsage(
+  request: CapabilityConsumptionRequest,
+  capability: CapabilityTokenV1 | null | undefined,
+  result: ConsentUsageResult,
+  evaluatedAt: string
+): Pick<ConsentUsageState, 'usageCount' | 'lastAccessedAt' | 'lastAccessResult'> | undefined {
+  const registry = request.registries?.consentUsageRegistry;
+  const consentRef = capability?.consent_ref;
+
+  if (!registry || typeof consentRef !== 'string' || consentRef.length === 0) {
+    return undefined;
+  }
+
+  try {
+    return toUsageOutput(registry.record(consentRef, result, evaluatedAt));
+  } catch {
+    return undefined;
+  }
+}
+
 function deny(
   evaluatedAt: string,
   reasonCode: CapabilityConsumptionReasonCode,
@@ -252,7 +328,8 @@ function deny(
   checks: CapabilityConsumptionChecks,
   metadata: Record<string, unknown>,
   replayChecked: boolean,
-  revocationChecked: boolean
+  revocationChecked: boolean,
+  usage?: Pick<ConsentUsageState, 'usageCount' | 'lastAccessedAt' | 'lastAccessResult'>
 ): CapabilityConsumptionDecision {
   return {
     allowed: false,
@@ -264,7 +341,8 @@ function deny(
     metadata,
     consumed: false,
     replayChecked,
-    revocationChecked
+    revocationChecked,
+    ...(usage ? { usage } : {})
   };
 }
 
@@ -297,6 +375,7 @@ export function consumeCapabilityAccess(
   const now = normalizeNow(request.now);
   const evaluatedAt = normalizeEvaluatedAt(now);
   const checks = makeChecks();
+  let capabilityForUsage: CapabilityTokenV1 | undefined;
 
   try {
     const normalizedCapability = cloneCapability(request.capability);
@@ -310,6 +389,7 @@ export function consumeCapabilityAccess(
     checks.resource = 'pass';
 
     const capability = normalizedCapability as CapabilityTokenV1;
+    capabilityForUsage = capability;
     const metadata = sanitizeMetadata({
       capabilityHash: capability.capability_hash,
       tokenId: capability.token_id
@@ -333,7 +413,8 @@ export function consumeCapabilityAccess(
         checks,
         sanitizeMetadata({ ...metadata, failureStage: 'temporal' }),
         false,
-        false
+        false,
+        recordUsage(request, capability, 'deny', evaluatedAt)
       );
     }
 
@@ -347,7 +428,8 @@ export function consumeCapabilityAccess(
         checks,
         sanitizeMetadata({ ...metadata, failureStage: 'revocation' }),
         false,
-        true
+        true,
+        recordUsage(request, capability, 'deny', evaluatedAt)
       );
     }
 
@@ -366,7 +448,8 @@ export function consumeCapabilityAccess(
           checks,
           sanitizeMetadata({ ...metadata, failureStage: 'replay' }),
           true,
-          true
+          true,
+          recordUsage(request, capability, 'deny', evaluatedAt)
         );
       }
     } else if (request.requireReplayProtection) {
@@ -378,7 +461,8 @@ export function consumeCapabilityAccess(
         checks,
         sanitizeMetadata({ ...metadata, failureStage: 'replay' }),
         false,
-        true
+        true,
+        recordUsage(request, capability, 'deny', evaluatedAt)
       );
     }
 
@@ -413,7 +497,8 @@ export function consumeCapabilityAccess(
               : 'integrity'
         }),
         shouldCheckReplay,
-        true
+        true,
+        recordUsage(request, capability, 'deny', evaluatedAt)
       );
     }
 
@@ -423,6 +508,8 @@ export function consumeCapabilityAccess(
       nonceRegistry.cleanup?.(now);
       consumed = true;
     }
+
+    const usage = recordUsage(request, capability, 'allow', evaluatedAt);
 
     return {
       allowed: true,
@@ -434,7 +521,8 @@ export function consumeCapabilityAccess(
       metadata: sanitizeMetadata({ ...metadata, failureStage: 'completed' }),
       consumed,
       replayChecked: shouldCheckReplay,
-      revocationChecked: true
+      revocationChecked: true,
+      ...(usage ? { usage } : {})
     };
   } catch (error) {
     if (checks.consent === 'not_applicable' && request.consent) {
@@ -448,7 +536,8 @@ export function consumeCapabilityAccess(
       checks,
       sanitizeMetadata({ failureStage: 'integrity' }),
       false,
-      checks.revocation !== 'not_applicable'
+      checks.revocation !== 'not_applicable',
+      recordUsage(request, capabilityForUsage, 'deny', evaluatedAt)
     );
   }
 }

--- a/protocol/capabilities/core-capability-enforcement-engine.md
+++ b/protocol/capabilities/core-capability-enforcement-engine.md
@@ -117,14 +117,29 @@ Consumption semantics:
 
 1. **Structural validation** — capability is validated with the canonical token validator; optional consent is validated and, if supplied, matched against the capability.
 2. **Revocation at consumption time** — revoked capabilities deny immediately with a machine-readable revoke code before resource delivery.
-3. **Replay handling** — if a nonce registry is supplied and `consume !== false`, replay is checked before authorization; repeated presentation denies. If `consume === false`, the request is treated as a non-marking presentation and replay is not checked or marked. If `requireReplayProtection` is `true` but no nonce registry is supplied, the request denies fail-closed.
+3. **Replay handling** — if a nonce registry is supplied and `consume !== false`, replay is checked before authorization; repeated presentation denies. If `consume === false`, the request is treated as a non-marking presentation for replay only, and replay is not checked or marked. If `requireReplayProtection` is `true` but no nonce registry is supplied, the request denies fail-closed.
 4. **Central authorization** — `evaluateCapabilityAccess(...)` remains the source of truth for action/resource/market-maker/policy decisions.
-5. **Post-allow marking** — nonce state is marked only after an allow decision and only when `consume !== false` and a nonce registry is present. Denies never mark replay state.
+5. **Per-consent usage metering** — if a consent-usage registry is supplied, usage is recorded by `consent_ref` after the authorization decision is made. `usageCount` increments only on allowed consumption attempts; `lastAccessedAt` and `lastAccessResult` update on both allow and deny. This metering is deterministic protocol state for the grant itself, not analytics, billing, or quota enforcement.
+6. **Post-allow marking** — nonce state is marked only after an allow decision and only when `consume !== false` and a nonce registry is present. Denies never mark replay state.
+
+When `consume === false`, usage is still recorded if a consent-usage registry is present. `consume` only controls replay marking, not whether an access attempt updates per-consent usage state.
+
+If usage metering fails, the original allow/deny decision is preserved and the response may omit the `usage` block. Metering is strictly a side effect and MUST NOT change authorization behavior.
+
+`CapabilityConsumptionDecision` may include an optional `usage` block when metering is enabled:
+
+```ts
+usage: {
+  usageCount: number;
+  lastAccessedAt: string;
+  lastAccessResult: 'allow' | 'deny';
+}
+```
 
 Non-goals of the consumption boundary in this card:
 
-- usage metering / quotas;
 - billing or paid grants;
+- quotas or usage-based denies;
 - AI interpreter execution;
 - transport-specific HTTP/UI shaping.
 

--- a/protocol/capabilities/index.ts
+++ b/protocol/capabilities/index.ts
@@ -17,11 +17,15 @@ export type {
 
 export {
   consumeCapabilityAccess,
-  capabilityConsumptionReasonCodes
+  capabilityConsumptionReasonCodes,
+  InMemoryConsentUsageRegistry
 } from './consumeCapabilityAccess';
 export type {
   CapabilityConsumptionChecks,
   CapabilityConsumptionDecision,
   CapabilityConsumptionReasonCode,
-  CapabilityConsumptionRequest
+  CapabilityConsumptionRequest,
+  ConsentUsageRegistry,
+  ConsentUsageResult,
+  ConsentUsageState
 } from './consumeCapabilityAccess';


### PR DESCRIPTION
### Motivation
- Provide a deterministic, protocol-level usage state attached to a consent (grant) so the system can track access attempts per `consent_ref` without introducing billing, quotas, or changing authorization semantics. 
- Ensure usage is recorded on every consumption attempt (allow or deny) while counting only successful consumptions for `usageCount` and keeping metering strictly side-effect-only.

### Description
- Introduce `ConsentUsageState`, `ConsentUsageRegistry` and an in-memory implementation `InMemoryConsentUsageRegistry` keyed by `consent_ref` and exposing `get` and `record` methods. 
- Wire a `consentUsageRegistry` into `CapabilityConsumptionRequest.registries` and add optional `usage` to `CapabilityConsumptionDecision` with `{ usageCount, lastAccessedAt, lastAccessResult }` when a registry is provided. 
- Integrate metering into `consumeCapabilityAccess(...)`: authorization is evaluated first, then `record` is called as a deterministic side effect; `usageCount` increments only for allowed consumptions, `lastAccessedAt` and `lastAccessResult` update on allow and deny, and `consume=false` still records usage. 
- Preserve authorization behavior on registry failures by swallowing usage errors (omitting `usage` in responses) so metering never flips allow→deny. 
- Re-export new types/registry from `protocol/capabilities/index.ts` and update docs (`core-capability-enforcement-engine.md`) to describe semantics and non-goals (no billing/quotas). 
- Add unit tests covering first-time init, allow increment, deny recording without increment, accumulation across calls, `consume=false` behavior, registry failure tolerance, and backward compatibility when no registry is provided.

### Testing
- Ran targeted tests: `npm test -- --runInBand protocol/capabilities/__tests__/consumeCapabilityAccess.test.ts` and all cases in that file passed. 
- Ran full test suite: `npm test -- --runInBand` and all test suites passed (386 tests, 22 suites) with no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1bd1ae65883258afef0e18881a0b2)