### PR TITLE
Add protocol-native AI interpreter hook (capability‑gated, deterministic)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,5 +7,6 @@ export * from './field';
 export * from './pack';
 export * from './storage';
 export * from './protocol/capabilities';
+export * from './interpreter';
 
 export * from './enforcement';

--- a/interpreter/__tests__/aiInterpreter.test.ts
+++ b/interpreter/__tests__/aiInterpreter.test.ts
@@ -1,0 +1,225 @@
+import { mintCapabilityToken } from '../../capability';
+import { buildConsentObject } from '../../consent';
+import { capabilityAccessReasonCodes } from '../../enforcement';
+import { InMemoryConsentUsageRegistry } from '../../protocol/capabilities';
+import { interpretWithCapability, runInterpreter } from '../aiInterpreter';
+
+const NOW = '2025-06-15T10:00:00Z';
+const EXPIRES_AT = '2025-06-15T10:05:00Z';
+const CONTENT_REF = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function buildRequest(overrides: Partial<Parameters<typeof interpretWithCapability>[0]> = {}) {
+  const consent = buildConsentObject(
+    'did:aoc:subject123',
+    'did:aoc:grantee456',
+    'grant',
+    [{ type: 'content', ref: CONTENT_REF }],
+    ['read'],
+    {
+      now: new Date(NOW),
+      expires_at: EXPIRES_AT
+    }
+  );
+
+  const capability = mintCapabilityToken(
+    consent,
+    [{ type: 'content', ref: CONTENT_REF }],
+    ['read'],
+    EXPIRES_AT,
+    { now: new Date(NOW) }
+  );
+
+  return {
+    consent,
+    capability,
+    action: 'read',
+    resource: `content:${CONTENT_REF}`,
+    input: {
+      query: 'Summarize the reference payload',
+      context: {
+        resources: {
+          [`content:${CONTENT_REF}`]: {
+            candidate: 'Taylor',
+            role: 'Engineer',
+            rating: 'strong'
+          }
+        }
+      }
+    },
+    now: NOW,
+    ...overrides
+  };
+}
+
+describe('runInterpreter', () => {
+  it('returns deterministic structure', () => {
+    const data = { b: 2, a: 1 };
+    expect(runInterpreter('Explain', data)).toBe(runInterpreter('Explain', data));
+  });
+});
+
+describe('interpretWithCapability', () => {
+  it('allows interpretation with valid capability', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const response = interpretWithCapability(buildRequest(), {
+      registries: { consentUsageRegistry: usageRegistry }
+    });
+
+    expect(response.allowed).toBe(true);
+    expect(response.result?.metadata?.source).toBe('capability-context');
+    expect(response.usage.usageCount).toBe(1);
+  });
+
+  it('denies when capability invalid', () => {
+    const request = buildRequest();
+    const response = interpretWithCapability({
+      ...request,
+      capability: {
+        ...request.capability,
+        permissions: []
+      }
+    });
+
+    expect(response.allowed).toBe(false);
+    expect(response.error?.code).toBe(capabilityAccessReasonCodes.CAPABILITY_INVALID);
+  });
+
+  it('denies when payment required but not paid', () => {
+    const request = buildRequest({
+      consent: buildConsentObject(
+        'did:aoc:subject123',
+        'did:aoc:grantee456',
+        'grant',
+        [{ type: 'content', ref: CONTENT_REF }],
+        ['read'],
+        {
+          now: new Date(NOW),
+          expires_at: EXPIRES_AT,
+          pricing: { model: 'per_use', amount: 25, currency: 'USD' }
+        }
+      )
+    });
+
+    const capability = mintCapabilityToken(
+      request.consent!,
+      [{ type: 'content', ref: CONTENT_REF }],
+      ['read'],
+      EXPIRES_AT,
+      { now: new Date(NOW) }
+    );
+
+    const response = interpretWithCapability({
+      ...request,
+      capability
+    });
+
+    expect(response.allowed).toBe(false);
+    expect(response.error?.code).toBe(capabilityAccessReasonCodes.PAYMENT_REQUIRED);
+    expect(response.payment).toEqual({ required: true, amount: 25, currency: 'USD' });
+  });
+
+  it('executes AI when paid', () => {
+    const pricedConsent = buildConsentObject(
+      'did:aoc:subject123',
+      'did:aoc:grantee456',
+      'grant',
+      [{ type: 'content', ref: CONTENT_REF }],
+      ['read'],
+      {
+        now: new Date(NOW),
+        expires_at: EXPIRES_AT,
+        pricing: { model: 'per_use', amount: 25, currency: 'USD' }
+      }
+    );
+    const capability = mintCapabilityToken(
+      pricedConsent,
+      [{ type: 'content', ref: CONTENT_REF }],
+      ['read'],
+      EXPIRES_AT,
+      { now: new Date(NOW) }
+    );
+
+    const response = interpretWithCapability(
+      buildRequest({
+        consent: pricedConsent,
+        capability,
+        paymentContext: { paid: true }
+      }),
+      { registries: { consentUsageRegistry: new InMemoryConsentUsageRegistry() } }
+    );
+
+    expect(response.allowed).toBe(true);
+    expect(response.result?.interpretation).toContain('Deterministic interpretation');
+    expect(response.payment).toEqual({ required: false, amount: 25, currency: 'USD' });
+  });
+
+  it('does not increment usage on denied access', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const request = buildRequest();
+
+    const response = interpretWithCapability(
+      {
+        ...request,
+        capability: {
+          ...request.capability,
+          permissions: []
+        }
+      },
+      { registries: { consentUsageRegistry: usageRegistry } }
+    );
+
+    expect(response.allowed).toBe(false);
+    expect(usageRegistry.get(request.capability.consent_ref)).toBeUndefined();
+  });
+
+  it('increments usage on successful interpretation', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const request = buildRequest();
+
+    const response = interpretWithCapability(request, {
+      registries: { consentUsageRegistry: usageRegistry }
+    });
+
+    expect(response.allowed).toBe(true);
+    expect(usageRegistry.get(request.capability.consent_ref)?.usageCount).toBe(1);
+  });
+
+  it('returns deterministic structure', () => {
+    const request = buildRequest();
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+
+    const first = interpretWithCapability(request, {
+      registries: { consentUsageRegistry: usageRegistry }
+    });
+    const second = interpretWithCapability(request, {
+      registries: { consentUsageRegistry: new InMemoryConsentUsageRegistry() }
+    });
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    expect(first.result?.interpretation).toBe(second.result?.interpretation);
+  });
+
+  it('supports HRKey reference payload metadata', () => {
+    const response = interpretWithCapability(
+      buildRequest({
+        input: {
+          query: 'Summarize the HRKey reference',
+          context: {
+            hrkeyReference: {
+              [`content:${CONTENT_REF}`]: {
+                referee: 'Jordan',
+                relationship: 'Manager',
+                recommendation: 'hire'
+              }
+            }
+          }
+        }
+      }),
+      { registries: { consentUsageRegistry: new InMemoryConsentUsageRegistry() } }
+    );
+
+    expect(response.allowed).toBe(true);
+    expect(response.result?.metadata).toMatchObject({ source: 'hrkey-reference' });
+  });
+});

--- a/interpreter/aiInterpreter.ts
+++ b/interpreter/aiInterpreter.ts
@@ -1,0 +1,216 @@
+import { consumeCapabilityAccess } from '../protocol/capabilities';
+import { capabilityAccessReasonCodes, evaluateCapabilityAccess } from '../enforcement';
+import type {
+  AIInterpreterRequest,
+  AIInterpreterResponse,
+  InterpreterDependencies,
+  InterpreterResolvedResource
+} from './interpreterTypes';
+
+const DETERMINISTIC_GUARDRAIL =
+  'You are a deterministic interpreter. Only use provided data. Do not infer beyond given facts.';
+
+type NormalizedResource = {
+  type: 'field' | 'content' | 'pack';
+  ref: string;
+  key: string;
+};
+
+function normalizeUsageCount(response: AIInterpreterResponse['usage'] | undefined): number {
+  return response?.usageCount ?? 0;
+}
+
+function denyResponse(
+  code: string,
+  message: string,
+  usageCount = 0,
+  payment?: AIInterpreterResponse['payment']
+): AIInterpreterResponse {
+  return {
+    allowed: false,
+    error: { code, message },
+    usage: { usageCount },
+    ...(payment ? { payment } : {})
+  };
+}
+
+function normalizeResource(resource: string): NormalizedResource {
+  const [type, ref, ...rest] = resource.trim().split(':');
+  if (!type || !ref || rest.length > 0) {
+    throw new Error('Interpreter resource must be a canonical "type:ref" string.');
+  }
+
+  if (type !== 'field' && type !== 'content' && type !== 'pack') {
+    throw new Error('Interpreter resource type must be one of: field, content, pack.');
+  }
+
+  return {
+    type,
+    ref,
+    key: `${type}:${ref}`
+  };
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableSerialize(entry)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableSerialize(entry)}`)
+    .join(',')}}`;
+}
+
+function resolveCapabilityData(
+  request: AIInterpreterRequest,
+  normalizedResource: NormalizedResource
+): InterpreterResolvedResource {
+  const context = request.input.context ?? {};
+  const resourceMap =
+    context.resources && typeof context.resources === 'object' && !Array.isArray(context.resources)
+      ? (context.resources as Record<string, unknown>)
+      : undefined;
+
+  if (resourceMap && normalizedResource.key in resourceMap) {
+    return {
+      key: normalizedResource.key,
+      data: resourceMap[normalizedResource.key]
+    };
+  }
+
+  if (normalizedResource.key in context) {
+    return {
+      key: normalizedResource.key,
+      data: context[normalizedResource.key]
+    };
+  }
+
+  if (
+    context.hrkeyReference &&
+    typeof context.hrkeyReference === 'object' &&
+    !Array.isArray(context.hrkeyReference)
+  ) {
+    const hrkeyReference = context.hrkeyReference as Record<string, unknown>;
+    if (normalizedResource.key in hrkeyReference) {
+      return {
+        key: normalizedResource.key,
+        data: hrkeyReference[normalizedResource.key]
+      };
+    }
+  }
+
+  throw new Error(`No capability-resolved data found for resource ${normalizedResource.key}.`);
+}
+
+export function runInterpreter(query: string, data: unknown): string {
+  const normalizedQuery = query.trim();
+  const serializedData = stableSerialize(data);
+
+  return stableSerialize({
+    instruction: DETERMINISTIC_GUARDRAIL,
+    query: normalizedQuery,
+    facts: data,
+    conclusion: `Deterministic interpretation for "${normalizedQuery}" based only on provided data: ${serializedData}`
+  });
+}
+
+export function interpretWithCapability(
+  input: AIInterpreterRequest,
+  dependencies: InterpreterDependencies = {}
+): AIInterpreterResponse {
+  try {
+    const normalizedResource = normalizeResource(input.resource);
+
+    const accessDecision = evaluateCapabilityAccess({
+      capability: input.capability,
+      consent: input.consent,
+      action: input.action,
+      resource: { type: normalizedResource.type, ref: normalizedResource.ref },
+      now: input.now,
+      marketMakerRegistry: dependencies.marketMakerRegistry,
+      hooks: dependencies.hooks
+    });
+
+    if (!accessDecision.allowed) {
+      return denyResponse(accessDecision.reasonCode, accessDecision.reason);
+    }
+
+    const paid = input.paymentContext?.paid === true;
+    const payment = input.consent?.pricing
+      ? {
+          required: !paid,
+          amount: input.consent.pricing.amount,
+          currency: input.consent.pricing.currency
+        }
+      : undefined;
+
+    if (payment?.required) {
+      return denyResponse(
+        capabilityAccessReasonCodes.PAYMENT_REQUIRED,
+        'Payment is required before interpreter execution.',
+        0,
+        payment
+      );
+    }
+
+    const consumeDecision = consumeCapabilityAccess({
+      capability: input.capability,
+      consent: input.consent,
+      action: input.action,
+      resource: { type: normalizedResource.type, ref: normalizedResource.ref },
+      now: input.now,
+      paymentContext: input.paymentContext,
+      marketMakerRegistry: dependencies.marketMakerRegistry,
+      hooks: dependencies.hooks,
+      registries: {
+        nonceRegistry: dependencies.registries?.nonceRegistry,
+        revocationRegistry: dependencies.registries?.revocationRegistry
+      },
+      consume: false
+    });
+
+    if (!consumeDecision.allowed) {
+      return denyResponse(
+        consumeDecision.reasonCode,
+        consumeDecision.reason,
+        normalizeUsageCount(consumeDecision.usage),
+        consumeDecision.payment
+      );
+    }
+
+    const resolved = resolveCapabilityData(input, normalizedResource);
+    const interpretation = runInterpreter(input.input.query, resolved.data);
+
+    const usageState = dependencies.registries?.consentUsageRegistry?.record(
+      input.capability.consent_ref,
+      'allow',
+      input.now ?? new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
+    );
+
+    return {
+      allowed: true,
+      result: {
+        interpretation,
+        metadata: {
+          resource: resolved.key,
+          source:
+            input.input.context?.hrkeyReference !== undefined ? 'hrkey-reference' : 'capability-context'
+        }
+      },
+      usage: {
+        usageCount: usageState?.usageCount ?? normalizeUsageCount(consumeDecision.usage)
+      },
+      ...(consumeDecision.payment ? { payment: consumeDecision.payment } : {})
+    };
+  } catch (error) {
+    return denyResponse(
+      capabilityAccessReasonCodes.INTERNAL_EVALUATION_ERROR,
+      (error as Error).message || 'Interpreter execution failed.'
+    );
+  }
+}

--- a/interpreter/index.ts
+++ b/interpreter/index.ts
@@ -1,0 +1,7 @@
+export { interpretWithCapability, runInterpreter } from './aiInterpreter';
+export type {
+  AIInterpreterRequest,
+  AIInterpreterResponse,
+  InterpreterDependencies,
+  InterpreterResolvedResource
+} from './interpreterTypes';

--- a/interpreter/interpreterTypes.ts
+++ b/interpreter/interpreterTypes.ts
@@ -1,0 +1,57 @@
+import type { CapabilityTokenV1 } from '../capability';
+import type { ConsentObjectV1 } from '../consent';
+import type { ConsentUsageRegistry } from '../protocol/capabilities';
+import type { NonceRegistry } from '../capability/registries/NonceRegistry';
+import type { RevocationRegistry } from '../capability/registries/RevocationRegistry';
+import type { MarketMakerRegistry } from '../shared/marketMakerRegistry';
+import type { CapabilityAccessRequest } from '../enforcement';
+
+export type AIInterpreterRequest = {
+  capability: CapabilityTokenV1;
+  consent?: ConsentObjectV1;
+  action: string;
+  resource: string;
+  paymentContext?: {
+    paid: boolean;
+  };
+  input: {
+    query: string;
+    context?: Record<string, unknown>;
+  };
+  now?: string;
+};
+
+export type AIInterpreterResponse = {
+  allowed: boolean;
+  result?: {
+    interpretation: string;
+    metadata?: Record<string, unknown>;
+  };
+  error?: {
+    code: string;
+    message: string;
+  };
+  usage: {
+    usageCount: number;
+  };
+  payment?: {
+    required: boolean;
+    amount?: number;
+    currency?: string;
+  };
+};
+
+export type InterpreterResolvedResource = {
+  key: string;
+  data: unknown;
+};
+
+export type InterpreterDependencies = {
+  registries?: {
+    nonceRegistry?: NonceRegistry;
+    revocationRegistry?: RevocationRegistry;
+    consentUsageRegistry?: ConsentUsageRegistry;
+  };
+  marketMakerRegistry?: Pick<MarketMakerRegistry, 'exists'>;
+  hooks?: CapabilityAccessRequest['hooks'];
+};


### PR DESCRIPTION
### Motivation
- Provide a protocol-native AI interpreter that can only operate after capability evaluation and payment gating so AI use cannot bypass AOC enforcement or access raw storage.
- Ensure AI outputs are deterministic, auditable, and metered per-consent so usage and monetization hooks remain in-protocol.
- Support HRKey reference payloads as an allowed metadata source while keeping resolution strictly within the capability-consumption layer.

### Description
- Added a new `interpreter/` module with typed contracts: `interpreter/interpreterTypes.ts`, `interpreter/aiInterpreter.ts`, and an `interpreter/index.ts` barrel, and exported the module from the package root via `index.ts`.
- Implemented `interpretWithCapability(input, dependencies)` with the required fail-closed flow: capability enforcement (`evaluateCapabilityAccess`) → payment gating → capability consumption (`consumeCapabilityAccess`) → scoped data resolution only from capability-resolved context → deterministic interpreter execution (`runInterpreter`) → usage metering via `consentUsageRegistry` and response shaping including payment metadata and HRKey `source` tagging.
- Implemented `runInterpreter(query, data)` which produces deterministic, structured output and includes an explicit guardrail instruction to avoid hallucination and inference beyond provided facts.
- Added comprehensive tests in `interpreter/__tests__/aiInterpreter.test.ts` covering valid access, invalid capability denial, payment-required denial, paid execution, denied-access non-metering, successful metering, deterministic structure, and HRKey reference metadata handling.

### Testing
- Ran `npm test -- --runInBand interpreter/__tests__/aiInterpreter.test.ts` and the interpreter test suite passed (all tests green).
- Ran `npm test -- --runInBand interpreter/__tests__/aiInterpreter.test.ts protocol/capabilities/__tests__/consumeCapabilityAccess.test.ts` to validate integration with capability consumption and metering, and both test suites passed.
- All automated tests executed for the changed paths reported as passing (no failing tests observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c64cd0a48325ba2c2f5698d35e60)