### PR TITLE
Add AOC Capability SDK: executeCapabilityFlow, README, example, and tests

### DIFF
--- a/aoc/sdk/README.md
+++ b/aoc/sdk/README.md
@@ -1,0 +1,171 @@
+# AOC Capability SDK
+
+A minimal developer entry layer for using Architects of Change (AOC) capabilities in external applications.
+
+## 1) What is the AOC Capability Layer?
+
+The AOC capability layer is a consent-first authorization system for sovereign data exchange.
+
+- **Consent-based access**: access starts from an explicit consent grant.
+- **Capability tokens**: scoped, signed protocol objects derived from consent.
+- **Market maker binding**: capabilities can be bound to trusted market makers.
+- **Sovereign data model**: access decisions are deterministic and portable across integrations.
+
+## 2) Install / Usage
+
+In this monorepo, import from the SDK entrypoint:
+
+```ts
+import {
+  buildConsentObject,
+  mintCapabilityToken,
+  evaluateCapabilityAccess,
+  consumeCapabilityAccess,
+  MarketMakerRegistry
+} from '../aoc/sdk';
+```
+
+If published externally, this surface is designed to map to:
+
+```ts
+import { ... } from 'aoc-sdk';
+```
+
+## 3) Minimal Flow
+
+1. `buildConsentObject(...)`
+2. `mintCapabilityToken(...)`
+3. `evaluateCapabilityAccess(...)`
+4. `consumeCapabilityAccess(...)`
+
+## 4) Example snippet
+
+```ts
+import {
+  buildConsentObject,
+  mintCapabilityToken,
+  evaluateCapabilityAccess,
+  consumeCapabilityAccess
+} from '../aoc/sdk';
+
+const consent = buildConsentObject(
+  'did:key:subject123',
+  'did:key:marketmaker456',
+  'grant',
+  [{ type: 'content', ref: 'a'.repeat(64) }],
+  ['read'],
+  {
+    now: new Date('2025-06-15T10:00:00Z'),
+    expires_at: '2025-06-15T10:05:00Z',
+    marketMakerId: 'hrkey-v1'
+  }
+);
+
+const capability = mintCapabilityToken(
+  consent,
+  [{ type: 'content', ref: 'a'.repeat(64) }],
+  ['read'],
+  '2025-06-15T10:05:00Z',
+  { now: new Date('2025-06-15T10:00:00Z') }
+);
+
+const access = evaluateCapabilityAccess({
+  capability,
+  consent,
+  action: 'read',
+  resource: { type: 'content', ref: 'a'.repeat(64) },
+  marketMakerId: 'hrkey-v1',
+  now: '2025-06-15T10:00:00Z'
+});
+
+const consumption = consumeCapabilityAccess({
+  capability,
+  consent,
+  action: 'read',
+  resource: { type: 'content', ref: 'a'.repeat(64) },
+  marketMakerId: 'hrkey-v1',
+  now: '2025-06-15T10:00:00Z'
+});
+```
+
+## 5) Concepts
+
+- **Consent**: user-authorized policy object defining who can do what and for how long.
+- **Capability**: runtime token derived from consent with bounded scope and permissions.
+- **Market Maker**: integration boundary that can be bound to consent/capability for trust enforcement.
+- **Enforcement**: deterministic allow/deny decisions across evaluation and consumption boundaries.
+
+## Simplified Flow Wrapper
+
+For the most common SDK usage, call `executeCapabilityFlow(...)`.
+It orchestrates evaluation, consumption, and optional interpreter execution in one call while preserving the same enforcement behavior.
+
+```ts
+import {
+  buildConsentObject,
+  mintCapabilityToken,
+  executeCapabilityFlow,
+  MarketMakerRegistry
+} from '../aoc/sdk';
+
+const CONTENT_REF = 'a'.repeat(64);
+const NOW = '2025-06-15T10:00:00Z';
+const marketMakerRegistry = new MarketMakerRegistry();
+marketMakerRegistry.register({
+  id: 'hrkey-v1',
+  name: 'HRKey',
+  version: '1.0.0',
+  capabilities: ['content.read'],
+  status: 'active',
+  created_at: NOW
+});
+
+const consent = buildConsentObject(
+  'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK',
+  'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH',
+  'grant',
+  [{ type: 'content', ref: CONTENT_REF }],
+  ['read'],
+  { now: new Date(NOW), expires_at: '2025-06-15T10:05:00Z', marketMakerId: 'hrkey-v1' }
+);
+
+const capability = mintCapabilityToken(
+  consent,
+  [{ type: 'content', ref: CONTENT_REF }],
+  ['read'],
+  '2025-06-15T10:05:00Z',
+  { now: new Date(NOW) }
+);
+
+const result = executeCapabilityFlow({
+  capability,
+  consent,
+  action: 'read',
+  resource: { type: 'content', ref: CONTENT_REF },
+  marketMakerId: 'hrkey-v1',
+  marketMakerRegistry,
+  now: NOW,
+  interpreter: {
+    enabled: true,
+    query: 'Summarize the candidate profile.'
+  }
+});
+```
+
+## Handling denied flows
+
+When `executeCapabilityFlow(...)` returns `allowed: false`, inspect these fields first:
+
+- `result.stage` — where denial happened (`evaluation` or `consumption`).
+- `result.reasonCode` — stable machine-readable code from the underlying decision.
+- `result.reason` — human-readable explanation.
+
+```ts
+const result = executeCapabilityFlow(/* ... */);
+
+if (!result.allowed) {
+  console.error('Denied stage:', result.stage);
+  console.error('Reason code:', result.reasonCode);
+  console.error('Reason:', result.reason);
+}
+```

--- a/aoc/sdk/executeCapabilityFlow.ts
+++ b/aoc/sdk/executeCapabilityFlow.ts
@@ -1,0 +1,148 @@
+import type { CapabilityTokenV1 } from '../../capability/types';
+import type { ConsentObjectV1 } from '../../consent/types';
+import type { AIInterpreterResponse } from '../../interpreter/interpreterTypes';
+import type {
+  CapabilityAccessDecision,
+  CapabilityAccessRequest,
+  CapabilityResource
+} from '../capabilities/core';
+import type {
+  CapabilityConsumptionDecision,
+  CapabilityConsumptionRequest
+} from '../capabilities/runtime';
+import type { MarketMakerRegistry } from '../capabilities/market/marketMakerRegistry';
+import { evaluateCapabilityAccess } from '../capabilities/core/evaluateCapabilityAccess';
+import { consumeCapabilityAccess } from '../capabilities/runtime/consumeCapabilityAccess';
+import { interpretWithCapability } from '../capabilities/interpreter/interpretWithCapability';
+
+export type ExecuteCapabilityFlowRequest = {
+  capability: CapabilityTokenV1;
+  consent?: ConsentObjectV1 | null;
+  action: string;
+  resource: CapabilityResource;
+  marketMakerId?: string;
+  marketMakerRegistry?: Pick<MarketMakerRegistry, 'exists' | 'getStatus'>;
+  now?: string | number | Date;
+  paymentContext?: {
+    paid: boolean;
+  };
+  registries?: CapabilityConsumptionRequest['registries'];
+  hooks?: CapabilityAccessRequest['hooks'];
+  interpreter?: {
+    enabled: boolean;
+    query: string;
+    context?: Record<string, unknown>;
+  };
+};
+
+export type ExecuteCapabilityFlowResponse = {
+  allowed: boolean;
+  stage: 'evaluation' | 'consumption' | 'interpretation';
+  evaluation: CapabilityAccessDecision;
+  consumption?: CapabilityConsumptionDecision;
+  interpretation?: AIInterpreterResponse;
+  reasonCode?: string;
+  reason?: string;
+};
+
+function normalizeResourceForInterpreter(resource: CapabilityResource): string {
+  if (typeof resource === 'string') {
+    return resource;
+  }
+  return `${resource.type}:${resource.ref}`;
+}
+
+export function executeCapabilityFlow(
+  request: ExecuteCapabilityFlowRequest
+): ExecuteCapabilityFlowResponse {
+  const evaluation = evaluateCapabilityAccess({
+    capability: request.capability,
+    consent: request.consent,
+    action: request.action,
+    resource: request.resource,
+    marketMakerId: request.marketMakerId,
+    marketMakerRegistry: request.marketMakerRegistry,
+    now: request.now,
+    hooks: request.hooks
+  });
+
+  if (!evaluation.allowed) {
+    return {
+      allowed: false,
+      stage: 'evaluation',
+      evaluation,
+      reasonCode: evaluation.reasonCode,
+      reason: evaluation.reason
+    };
+  }
+
+  const consumption = consumeCapabilityAccess({
+    capability: request.capability,
+    consent: request.consent,
+    action: request.action,
+    resource: request.resource,
+    marketMakerId: request.marketMakerId,
+    marketMakerRegistry: request.marketMakerRegistry,
+    now: request.now,
+    paymentContext: request.paymentContext,
+    hooks: request.hooks,
+    registries: request.registries
+  });
+
+  if (!consumption.allowed) {
+    return {
+      allowed: false,
+      stage: 'consumption',
+      evaluation,
+      consumption,
+      reasonCode: consumption.reasonCode,
+      reason: consumption.reason
+    };
+  }
+
+  if (!request.interpreter?.enabled) {
+    return {
+      allowed: true,
+      stage: 'consumption',
+      evaluation,
+      consumption,
+      reasonCode: consumption.reasonCode,
+      reason: consumption.reason
+    };
+  }
+
+  const interpretation = interpretWithCapability(
+    {
+      capability: request.capability,
+      consent: request.consent ?? undefined,
+      action: request.action,
+      resource: normalizeResourceForInterpreter(request.resource),
+      now:
+        request.now instanceof Date
+          ? request.now.toISOString().replace(/\.\d{3}Z$/, 'Z')
+          : typeof request.now === 'number'
+            ? new Date(request.now).toISOString().replace(/\.\d{3}Z$/, 'Z')
+            : request.now,
+      paymentContext: request.paymentContext,
+      input: {
+        query: request.interpreter.query,
+        context: request.interpreter.context
+      }
+    },
+    {
+      marketMakerRegistry: request.marketMakerRegistry,
+      hooks: request.hooks,
+      registries: request.registries
+    }
+  );
+
+  return {
+    allowed: interpretation.allowed,
+    stage: 'interpretation',
+    evaluation,
+    consumption,
+    interpretation,
+    reasonCode: interpretation.allowed ? undefined : interpretation.error?.code,
+    reason: interpretation.allowed ? undefined : interpretation.error?.message
+  };
+}

--- a/aoc/sdk/index.ts
+++ b/aoc/sdk/index.ts
@@ -1,0 +1,51 @@
+export { evaluateCapabilityAccess } from '../capabilities/core/evaluateCapabilityAccess';
+export { consumeCapabilityAccess } from '../capabilities/runtime/consumeCapabilityAccess';
+
+export {
+  mintCapabilityToken,
+  validateCapabilityToken,
+  verifyCapabilityToken
+} from '../capabilities/tokens/capabilityToken';
+
+export {
+  buildConsentObject,
+  validateConsentObject
+} from '../../consent/consentObject';
+
+export { MarketMakerRegistry } from '../capabilities/market/marketMakerRegistry';
+export {
+  executeCapabilityFlow
+} from './executeCapabilityFlow';
+
+export type {
+  ExecuteCapabilityFlowRequest,
+  ExecuteCapabilityFlowResponse
+} from './executeCapabilityFlow';
+
+export { interpretWithCapability } from '../capabilities/interpreter/interpretWithCapability';
+
+export type {
+  CapabilityAccessDecision,
+  CapabilityAccessRequest,
+  CapabilityAccessReasonCode,
+  CapabilityResource
+} from '../capabilities/core';
+
+export type {
+  CapabilityConsumptionDecision,
+  CapabilityConsumptionRequest,
+  CapabilityConsumptionReasonCode
+} from '../capabilities/runtime';
+
+export type { CapabilityTokenV1, MintCapabilityOptions, ScopeEntry as CapabilityScopeEntry } from '../../capability/types';
+
+export type {
+  BuildConsentOptions,
+  ConsentObjectV1,
+  ScopeEntry as ConsentScopeEntry
+} from '../../consent/types';
+
+export type {
+  MarketMaker,
+  MarketMakerStatus
+} from '../../shared/marketMakerRegistry';

--- a/examples/basic-market-maker.ts
+++ b/examples/basic-market-maker.ts
@@ -1,0 +1,145 @@
+import {
+  MarketMakerRegistry,
+  buildConsentObject,
+  consumeCapabilityAccess,
+  evaluateCapabilityAccess,
+  executeCapabilityFlow,
+  interpretWithCapability,
+  mintCapabilityToken
+} from '../aoc/sdk';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const MARKET_MAKER_DID = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const MARKET_MAKER_ID = 'hrkey-v1';
+const CONTENT_REF = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const NOW = '2025-06-15T10:00:00Z';
+
+const marketMakers = new MarketMakerRegistry();
+marketMakers.register({
+  id: MARKET_MAKER_ID,
+  name: 'HRKey',
+  version: '1.0.0',
+  capabilities: ['content.read'],
+  endpoint: 'https://api.hrkey.example/capabilities',
+  status: 'active',
+  created_at: NOW
+});
+
+const consent = buildConsentObject(
+  SUBJECT,
+  MARKET_MAKER_DID,
+  'grant',
+  [{ type: 'content', ref: CONTENT_REF }],
+  ['read'],
+  {
+    now: new Date(NOW),
+    expires_at: '2025-06-15T10:05:00Z',
+    marketMakerId: MARKET_MAKER_ID
+  }
+);
+
+const capability = mintCapabilityToken(
+  consent,
+  [{ type: 'content', ref: CONTENT_REF }],
+  ['read'],
+  '2025-06-15T10:05:00Z',
+  { now: new Date(NOW) }
+);
+
+// ------------------------------
+// 1) Low-level explicit flow
+// ------------------------------
+const evaluation = evaluateCapabilityAccess({
+  capability,
+  consent,
+  action: 'read',
+  resource: { type: 'content', ref: CONTENT_REF },
+  marketMakerId: MARKET_MAKER_ID,
+  marketMakerRegistry: marketMakers,
+  now: NOW
+});
+
+if (!evaluation.allowed) {
+  throw new Error(`Evaluation denied: ${evaluation.reasonCode} (${evaluation.reason})`);
+}
+
+const consumption = consumeCapabilityAccess({
+  capability,
+  consent,
+  action: 'read',
+  resource: { type: 'content', ref: CONTENT_REF },
+  marketMakerId: MARKET_MAKER_ID,
+  marketMakerRegistry: marketMakers,
+  now: NOW
+});
+
+if (!consumption.allowed) {
+  throw new Error(`Consumption denied: ${consumption.reasonCode} (${consumption.reason})`);
+}
+
+const explicitInterpretation = interpretWithCapability(
+  {
+    capability,
+    consent,
+    action: 'read',
+    resource: `content:${CONTENT_REF}`,
+    now: NOW,
+    input: {
+      query: 'Summarize the content for hiring readiness.',
+      context: {
+        resources: {
+          [`content:${CONTENT_REF}`]: {
+            profile: {
+              yearsExperience: 6,
+              domains: ['payments', 'identity']
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    marketMakerRegistry: marketMakers
+  }
+);
+
+// ------------------------------
+// 2) Simplified wrapper flow
+// ------------------------------
+const wrapped = executeCapabilityFlow({
+  capability,
+  consent,
+  action: 'read',
+  resource: { type: 'content', ref: CONTENT_REF },
+  marketMakerId: MARKET_MAKER_ID,
+  marketMakerRegistry: marketMakers,
+  now: NOW,
+  interpreter: {
+    enabled: true,
+    query: 'Summarize the content for hiring readiness.',
+    context: {
+      resources: {
+        [`content:${CONTENT_REF}`]: {
+          profile: {
+            yearsExperience: 6,
+            domains: ['payments', 'identity']
+          }
+        }
+      }
+    }
+  }
+});
+
+console.log({
+  lowLevel: {
+    evaluationAllowed: evaluation.allowed,
+    consumptionAllowed: consumption.allowed,
+    interpreterAllowed: explicitInterpretation.allowed
+  },
+  wrapper: {
+    allowed: wrapped.allowed,
+    stage: wrapped.stage,
+    reasonCode: wrapped.reasonCode,
+    reason: wrapped.reason
+  }
+});

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ export * from './pack';
 export * from './storage';
 export * from './protocol/capabilities';
 export * from './aoc/capabilities';
+export * from './aoc/sdk';
 export * from './interpreter';
 
 export * from './enforcement';

--- a/tests/sdk/basicFlow.test.ts
+++ b/tests/sdk/basicFlow.test.ts
@@ -1,0 +1,74 @@
+import {
+  buildConsentObject,
+  consumeCapabilityAccess,
+  evaluateCapabilityAccess,
+  mintCapabilityToken,
+  MarketMakerRegistry
+} from '../../aoc/sdk';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const MARKET_MAKER_ID = 'hrkey-v1';
+const CONTENT_REF = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const NOW = '2025-06-15T10:00:00Z';
+
+describe('AOC capability SDK basic flow', () => {
+  it('creates consent, mints capability, evaluates allow, and consumes successfully via SDK exports', () => {
+    const marketMakers = new MarketMakerRegistry();
+    marketMakers.register({
+      id: MARKET_MAKER_ID,
+      name: 'HRKey',
+      version: '1.0.0',
+      capabilities: ['content.read'],
+      status: 'active',
+      created_at: NOW
+    });
+
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: CONTENT_REF }],
+      ['read'],
+      {
+        now: new Date(NOW),
+        expires_at: '2025-06-15T10:05:00Z',
+        marketMakerId: MARKET_MAKER_ID
+      }
+    );
+
+    const capability = mintCapabilityToken(
+      consent,
+      [{ type: 'content', ref: CONTENT_REF }],
+      ['read'],
+      '2025-06-15T10:05:00Z',
+      { now: new Date(NOW) }
+    );
+
+    const evaluation = evaluateCapabilityAccess({
+      capability,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      marketMakerId: MARKET_MAKER_ID,
+      marketMakerRegistry: marketMakers,
+      now: NOW
+    });
+
+    expect(evaluation.allowed).toBe(true);
+    expect(evaluation.decision).toBe('allow');
+
+    const consumption = consumeCapabilityAccess({
+      capability,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      marketMakerId: MARKET_MAKER_ID,
+      marketMakerRegistry: marketMakers,
+      now: NOW
+    });
+
+    expect(consumption.allowed).toBe(true);
+    expect(consumption.decision).toBe('allow');
+  });
+});

--- a/tests/sdk/executeCapabilityFlow.test.ts
+++ b/tests/sdk/executeCapabilityFlow.test.ts
@@ -1,0 +1,165 @@
+import {
+  MarketMakerRegistry,
+  buildConsentObject,
+  executeCapabilityFlow,
+  mintCapabilityToken
+} from '../../aoc/sdk';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const MARKET_MAKER_ID = 'hrkey-v1';
+const CONTENT_REF = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const NOW = '2025-06-15T10:00:00Z';
+
+function createMarketMakerRegistry(): MarketMakerRegistry {
+  const marketMakers = new MarketMakerRegistry();
+  marketMakers.register({
+    id: MARKET_MAKER_ID,
+    name: 'HRKey',
+    version: '1.0.0',
+    capabilities: ['content.read'],
+    status: 'active',
+    created_at: NOW
+  });
+  return marketMakers;
+}
+
+function createCapability(options?: {
+  pricing?: { model: 'per_use'; amount: number; currency: string };
+  marketMakerBound?: boolean;
+}) {
+  const marketMakerBound = options?.marketMakerBound ?? true;
+  const consent = buildConsentObject(
+    SUBJECT,
+    GRANTEE,
+    'grant',
+    [{ type: 'content', ref: CONTENT_REF }],
+    ['read'],
+    {
+      now: new Date(NOW),
+      expires_at: '2025-06-15T10:05:00Z',
+      ...(marketMakerBound ? { marketMakerId: MARKET_MAKER_ID } : {}),
+      ...(options?.pricing ? { pricing: options.pricing } : {})
+    }
+  );
+
+  const capability = mintCapabilityToken(
+    consent,
+    [{ type: 'content', ref: CONTENT_REF }],
+    ['read'],
+    '2025-06-15T10:05:00Z',
+    { now: new Date(NOW) }
+  );
+
+  return { consent, capability };
+}
+
+describe('executeCapabilityFlow', () => {
+  it('returns evaluation-stage deny and does not call interpreter when evaluation fails', () => {
+    const marketMakerRegistry = createMarketMakerRegistry();
+    const { consent, capability } = createCapability();
+
+    const result = executeCapabilityFlow({
+      capability,
+      consent,
+      action: 'store',
+      resource: { type: 'content', ref: CONTENT_REF },
+      marketMakerId: MARKET_MAKER_ID,
+      marketMakerRegistry,
+      now: NOW,
+      interpreter: {
+        enabled: true,
+        query: 'This should not run.'
+      }
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.stage).toBe('evaluation');
+    expect(result.evaluation.allowed).toBe(false);
+    expect(result.consumption).toBeUndefined();
+    expect(result.interpretation).toBeUndefined();
+    expect(result.reasonCode).toBe(result.evaluation.reasonCode);
+    expect(result.reason).toBe(result.evaluation.reason);
+  });
+
+  it('returns consumption-stage deny and does not call interpreter when consumption fails', () => {
+    const marketMakerRegistry = createMarketMakerRegistry();
+    const { consent, capability } = createCapability({
+      pricing: { model: 'per_use', amount: 10, currency: 'USD' }
+    });
+
+    const result = executeCapabilityFlow({
+      capability,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      marketMakerId: MARKET_MAKER_ID,
+      marketMakerRegistry,
+      now: NOW,
+      interpreter: {
+        enabled: true,
+        query: 'This should not run either.'
+      }
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.stage).toBe('consumption');
+    expect(result.evaluation.allowed).toBe(true);
+    expect(result.consumption?.allowed).toBe(false);
+    expect(result.interpretation).toBeUndefined();
+    expect(result.reasonCode).toBe('PAYMENT_REQUIRED');
+    expect(result.reasonCode).toBe(result.consumption?.reasonCode);
+    expect(result.reason).toBe(result.consumption?.reason);
+  });
+
+  it('returns successful consumption when interpreter is disabled', () => {
+    const marketMakerRegistry = createMarketMakerRegistry();
+    const { consent, capability } = createCapability();
+
+    const result = executeCapabilityFlow({
+      capability,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      marketMakerId: MARKET_MAKER_ID,
+      marketMakerRegistry,
+      now: NOW
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.stage).toBe('consumption');
+    expect(result.evaluation.allowed).toBe(true);
+    expect(result.consumption?.allowed).toBe(true);
+    expect(result.interpretation).toBeUndefined();
+    expect(result.reasonCode).toBe(result.consumption?.reasonCode);
+  });
+
+  it('runs interpretation only after successful consumption', () => {
+    const { consent, capability } = createCapability({ marketMakerBound: false });
+
+    const result = executeCapabilityFlow({
+      capability,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      interpreter: {
+        enabled: true,
+        query: 'Summarize the candidate profile.',
+        context: {
+          resources: {
+            [`content:${CONTENT_REF}`]: {
+              profile: { seniority: 'senior' }
+            }
+          }
+        }
+      }
+    });
+
+    expect(result.stage).toBe('interpretation');
+    expect(result.evaluation.allowed).toBe(true);
+    expect(result.consumption?.allowed).toBe(true);
+    expect(result.interpretation?.allowed).toBe(true);
+    expect(result.allowed).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a minimal developer entry layer to consume Architects of Change (AOC) capabilities from external applications. 
- Offer a single, simplified flow that composes access evaluation, consumption, and optional AI interpretation into one call via `executeCapabilityFlow`. 
- Surface the SDK exports from the repository root so integrators can import a consistent API.

### Description

- Add `aoc/sdk/README.md` documenting SDK concepts, usage, example snippets, and the simplified `executeCapabilityFlow` wrapper. 
- Implement `aoc/sdk/executeCapabilityFlow.ts` that orchestrates `evaluateCapabilityAccess`, `consumeCapabilityAccess`, and optional `interpretWithCapability`, and returns a consolidated `ExecuteCapabilityFlowResponse`. 
- Add `aoc/sdk/index.ts` to re-export core capability and consent functions/types and expose the SDK API surface, and update the repository `index.ts` to export the SDK. 
- Include an example `examples/basic-market-maker.ts` demonstrating both low-level and wrapped flows, and add unit tests `tests/sdk/basicFlow.test.ts` and `tests/sdk/executeCapabilityFlow.test.ts` validating evaluation, consumption, and interpretation behavior.

### Testing

- Ran the new unit tests `tests/sdk/basicFlow.test.ts` and `tests/sdk/executeCapabilityFlow.test.ts` via the test runner (`npm test`), and both tests passed. 
- The tests cover creation of consent and capability tokens, successful evaluate/consume cycles, denial handling at evaluation and consumption stages, and interpreter invocation only after successful consumption. 
- The changes are also exercised by the added example `examples/basic-market-maker.ts` for manual verification of flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2108272ec8325b8d106b91b72d854)