### PR TITLE
Add deterministic fixed-window rate limiting for capability consumption

### DIFF
--- a/aoc/capabilities/README.md
+++ b/aoc/capabilities/README.md
@@ -12,6 +12,7 @@
 - Market-maker trust boundary: `MarketMakerRegistry`
 - Interpreter enforcement hook: `interpretWithCapability(...)`
 - Legacy bridge adapter: `legacy/capabilityEnforcer`
+- Deterministic runtime throttling: optional fixed-window rate limiting in `consumeCapabilityAccess(...)`
 
 ## How application layers should use it
 
@@ -19,8 +20,24 @@ Application integrations (including HRKey) should treat this folder as a client-
 
 1. Construct capability + consent + request inputs in app code.
 2. Call `evaluateCapabilityAccess(...)` for deterministic authorization decisions.
-3. Call `consumeCapabilityAccess(...)` for runtime use (replay, revocation, payment, usage metering).
+3. Call `consumeCapabilityAccess(...)` for runtime use (replay, revocation, rate limiting, payment, usage metering).
 4. Keep all policy/usage hooks pure and deterministic.
+
+### Runtime rate limiting (MVP)
+
+`consumeCapabilityAccess(...)` optionally accepts:
+
+- `rateLimit.registry` (sync in-memory or equivalent deterministic registry)
+- `rateLimit.maxAttempts`
+- `rateLimit.windowMs`
+
+Behavior:
+
+- rate limiting is **runtime throttling**, not authorization
+- it runs **after** `evaluateCapabilityAccess(...)` allow and **before** payment/interpreter/nonce side effects
+- keying strategy is `capability.consent_ref` (business-level throttle key)
+- denial reason code is `RATE_LIMITED`
+- omitting `rateLimit` preserves existing non-throttled behavior
 
 ## What is intentionally not included
 

--- a/aoc/capabilities/legacy/capabilityEnforcer.ts
+++ b/aoc/capabilities/legacy/capabilityEnforcer.ts
@@ -9,7 +9,9 @@ import {
 } from '../core';
 import {
   consumeCapabilityAccess,
-  capabilityConsumptionReasonCodes
+  capabilityConsumptionReasonCodes,
+  type RateLimitConfig,
+  type RateLimitRegistry
 } from '../runtime/consumeCapabilityAccess';
 
 export type EnforceCapabilityInput = {
@@ -20,6 +22,7 @@ export type EnforceCapabilityInput = {
   resource_context?: Record<string, unknown>;
   request_context?: Record<string, unknown>;
   registries?: { nonceRegistry?: NonceRegistry; revocationRegistry?: RevocationRegistry };
+  rateLimit?: RateLimitConfig & { registry: RateLimitRegistry };
   consume?: boolean;
   action?: 'read';
   hooks?: CapabilityAccessRequest['hooks'];
@@ -87,6 +90,7 @@ function mapReasonCode(reasonCode: string): EnforceCapabilityDecision['code'] {
     case capabilityAccessReasonCodes.POLICY_DENIED:
     case capabilityAccessReasonCodes.USAGE_DENIED:
     case capabilityAccessReasonCodes.PAYMENT_REQUIRED:
+    case capabilityConsumptionReasonCodes.RATE_LIMITED:
       return 'RESOURCE_RESTRICTION_FAILED';
     default:
       return 'INTERNAL_DENY';
@@ -136,6 +140,7 @@ export function enforceCapability(
   const decision = consumeCapabilityAccess({
     ...buildLegacyAccessRequest(input, type, ref),
     registries: input.registries,
+    rateLimit: input.rateLimit,
     consume: input.consume,
     requireReplayProtection: false
   });

--- a/aoc/capabilities/runtime/consumeCapabilityAccess.ts
+++ b/aoc/capabilities/runtime/consumeCapabilityAccess.ts
@@ -31,7 +31,8 @@ export const capabilityConsumptionReasonCodes = {
   ...capabilityAccessReasonCodes,
   CAPABILITY_REVOKED: 'CAPABILITY_REVOKED',
   CAPABILITY_REPLAYED: 'CAPABILITY_REPLAYED',
-  REPLAY_PROTECTION_REQUIRED: 'REPLAY_PROTECTION_REQUIRED'
+  REPLAY_PROTECTION_REQUIRED: 'REPLAY_PROTECTION_REQUIRED',
+  RATE_LIMITED: 'RATE_LIMITED'
 } as const;
 
 export type CapabilityConsumptionReasonCode =
@@ -65,6 +66,67 @@ export interface ConsentUsageRegistry {
     result: ConsentUsageResult,
     timestamp: string
   ): ConsentUsageState;
+}
+
+export type RateLimitConfig = {
+  maxAttempts: number;
+  windowMs: number;
+};
+
+export type RateLimitState = {
+  key: string;
+  count: number;
+  windowStartedAt: string;
+};
+
+export interface RateLimitRegistry {
+  get(key: string): RateLimitState | undefined;
+  increment(key: string, now: Date, config: RateLimitConfig): RateLimitState;
+  isLimited(key: string, now: Date, config: RateLimitConfig): boolean;
+}
+
+export class InMemoryRateLimitRegistry implements RateLimitRegistry {
+  private readonly states = new Map<string, RateLimitState>();
+
+  get(key: string): RateLimitState | undefined {
+    const state = this.states.get(key);
+    return state ? { ...state } : undefined;
+  }
+
+  increment(key: string, now: Date, config: RateLimitConfig): RateLimitState {
+    const nowMs = now.getTime();
+    const current = this.states.get(key);
+    const shouldResetWindow =
+      !current || nowMs - Date.parse(current.windowStartedAt) >= config.windowMs;
+    const next: RateLimitState = shouldResetWindow
+      ? {
+          key,
+          count: 1,
+          windowStartedAt: normalizeEvaluatedAt(now)
+        }
+      : {
+          key,
+          count: current.count + 1,
+          windowStartedAt: current.windowStartedAt
+        };
+
+    this.states.set(key, next);
+    return { ...next };
+  }
+
+  isLimited(key: string, now: Date, config: RateLimitConfig): boolean {
+    const state = this.states.get(key);
+    if (!state) {
+      return false;
+    }
+
+    const withinWindow = now.getTime() - Date.parse(state.windowStartedAt) < config.windowMs;
+    if (!withinWindow) {
+      return false;
+    }
+
+    return state.count >= config.maxAttempts;
+  }
 }
 
 export class InMemoryConsentUsageRegistry implements ConsentUsageRegistry {
@@ -106,6 +168,11 @@ export type CapabilityConsumptionRequest = {
   };
   policyContext?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
+  rateLimit?: {
+    registry: RateLimitRegistry;
+    maxAttempts: number;
+    windowMs: number;
+  };
   marketMakerRegistry?: Pick<MarketMakerRegistry, 'exists' | 'getStatus'>;
   hooks?: CapabilityAccessRequest['hooks'];
   registries?: {
@@ -284,11 +351,25 @@ function enforceCapabilityTemporalIntegrity(
 function sanitizeMetadata(base: {
   capabilityHash?: string;
   tokenId?: string;
+  rateLimitKey?: string;
+  rateLimitWindowStartedAt?: string;
+  rateLimitCount?: number;
+  rateLimitMaxAttempts?: number;
+  rateLimitWindowMs?: number;
   failureStage?: string;
 }): Record<string, unknown> {
   return {
     ...(base.capabilityHash !== undefined ? { capabilityHash: base.capabilityHash } : {}),
     ...(base.tokenId !== undefined ? { tokenId: base.tokenId } : {}),
+    ...(base.rateLimitKey !== undefined ? { rateLimitKey: base.rateLimitKey } : {}),
+    ...(base.rateLimitWindowStartedAt !== undefined
+      ? { rateLimitWindowStartedAt: base.rateLimitWindowStartedAt }
+      : {}),
+    ...(base.rateLimitCount !== undefined ? { rateLimitCount: base.rateLimitCount } : {}),
+    ...(base.rateLimitMaxAttempts !== undefined
+      ? { rateLimitMaxAttempts: base.rateLimitMaxAttempts }
+      : {}),
+    ...(base.rateLimitWindowMs !== undefined ? { rateLimitWindowMs: base.rateLimitWindowMs } : {}),
     ...(base.failureStage !== undefined ? { failureStage: base.failureStage } : {})
   };
 }
@@ -383,6 +464,15 @@ function buildEvaluationRequest(
     marketMakerRegistry: request.marketMakerRegistry,
     hooks: request.hooks
   };
+}
+
+function validateRateLimitConfig(config: RateLimitConfig): void {
+  if (!Number.isInteger(config.maxAttempts) || config.maxAttempts <= 0) {
+    throw new Error('rateLimit.maxAttempts must be a positive integer.');
+  }
+  if (!Number.isInteger(config.windowMs) || config.windowMs <= 0) {
+    throw new Error('rateLimit.windowMs must be a positive integer.');
+  }
 }
 
 export function consumeCapabilityAccess(
@@ -517,6 +607,45 @@ export function consumeCapabilityAccess(
         recordUsage(request, capability, 'deny', evaluatedAt),
         buildPaymentDecision(normalizedConsent, request.paymentContext?.paid === true)
       );
+    }
+
+    if (request.rateLimit) {
+      validateRateLimitConfig(request.rateLimit);
+      const rateLimitKey = capability.consent_ref;
+      const rateLimitConfig: RateLimitConfig = {
+        maxAttempts: request.rateLimit.maxAttempts,
+        windowMs: request.rateLimit.windowMs
+      };
+      if (request.rateLimit.registry.isLimited(rateLimitKey, now, rateLimitConfig)) {
+        const state = request.rateLimit.registry.get(rateLimitKey);
+        return deny(
+          evaluatedAt,
+          capabilityConsumptionReasonCodes.RATE_LIMITED,
+          `Rate limit exceeded for consent_ref "${rateLimitKey}".`,
+          checks,
+          sanitizeMetadata({
+            ...metadata,
+            rateLimitKey,
+            rateLimitWindowStartedAt: state?.windowStartedAt,
+            rateLimitCount: state?.count,
+            rateLimitMaxAttempts: rateLimitConfig.maxAttempts,
+            rateLimitWindowMs: rateLimitConfig.windowMs,
+            failureStage: 'rate_limit'
+          }),
+          shouldCheckReplay,
+          true,
+          recordUsage(request, capability, 'deny', evaluatedAt)
+        );
+      }
+
+      const state = request.rateLimit.registry.increment(rateLimitKey, now, rateLimitConfig);
+      Object.assign(metadata, {
+        rateLimitKey,
+        rateLimitWindowStartedAt: state.windowStartedAt,
+        rateLimitCount: state.count,
+        rateLimitMaxAttempts: rateLimitConfig.maxAttempts,
+        rateLimitWindowMs: rateLimitConfig.windowMs
+      });
     }
 
     const paid = request.paymentContext?.paid === true;

--- a/aoc/capabilities/runtime/index.ts
+++ b/aoc/capabilities/runtime/index.ts
@@ -1,13 +1,17 @@
 export {
   consumeCapabilityAccess,
   capabilityConsumptionReasonCodes,
-  InMemoryConsentUsageRegistry
+  InMemoryConsentUsageRegistry,
+  InMemoryRateLimitRegistry
 } from './consumeCapabilityAccess';
 export type {
   CapabilityConsumptionChecks,
   CapabilityConsumptionDecision,
   CapabilityConsumptionReasonCode,
   CapabilityConsumptionRequest,
+  RateLimitConfig,
+  RateLimitRegistry,
+  RateLimitState,
   ConsentUsageRegistry,
   ConsentUsageResult,
   ConsentUsageState

--- a/aoc/sdk/README.md
+++ b/aoc/sdk/README.md
@@ -45,7 +45,8 @@ import {
   buildConsentObject,
   mintCapabilityToken,
   evaluateCapabilityAccess,
-  consumeCapabilityAccess
+  consumeCapabilityAccess,
+  InMemoryRateLimitRegistry
 } from '../aoc/sdk';
 
 const consent = buildConsentObject(
@@ -84,7 +85,12 @@ const consumption = consumeCapabilityAccess({
   action: 'read',
   resource: { type: 'content', ref: 'a'.repeat(64) },
   marketMakerId: 'hrkey-v1',
-  now: '2025-06-15T10:00:00Z'
+  now: '2025-06-15T10:00:00Z',
+  rateLimit: {
+    registry: new InMemoryRateLimitRegistry(),
+    maxAttempts: 5,
+    windowMs: 60_000
+  }
 });
 ```
 
@@ -180,3 +186,9 @@ if (!result.allowed) {
   console.error('Reason:', result.reason);
 }
 ```
+
+## Runtime throttling note
+
+`RATE_LIMITED` is a deterministic **consumption-stage** deny reason from `consumeCapabilityAccess(...)`.
+It is not an authorization failure: evaluation still runs first, then rate limiting, then (if allowed) payment/usage/interpreter side effects.
+The current MVP strategy is a fixed-window counter keyed by `consent_ref`, and if `rateLimit` is omitted there is no throttling.

--- a/aoc/sdk/executeCapabilityFlow.ts
+++ b/aoc/sdk/executeCapabilityFlow.ts
@@ -26,6 +26,7 @@ export type ExecuteCapabilityFlowRequest = {
   paymentContext?: {
     paid: boolean;
   };
+  rateLimit?: CapabilityConsumptionRequest['rateLimit'];
   registries?: CapabilityConsumptionRequest['registries'];
   hooks?: CapabilityAccessRequest['hooks'];
   interpreter?: {
@@ -85,6 +86,7 @@ export function executeCapabilityFlow(
     marketMakerRegistry: request.marketMakerRegistry,
     now: request.now,
     paymentContext: request.paymentContext,
+    rateLimit: request.rateLimit,
     hooks: request.hooks,
     registries: request.registries
   });

--- a/aoc/sdk/index.ts
+++ b/aoc/sdk/index.ts
@@ -1,5 +1,9 @@
 export { evaluateCapabilityAccess } from '../capabilities/core/evaluateCapabilityAccess';
-export { consumeCapabilityAccess } from '../capabilities/runtime/consumeCapabilityAccess';
+export {
+  consumeCapabilityAccess,
+  InMemoryRateLimitRegistry,
+  InMemoryConsentUsageRegistry
+} from '../capabilities/runtime/consumeCapabilityAccess';
 
 export {
   mintCapabilityToken,
@@ -34,7 +38,10 @@ export type {
 export type {
   CapabilityConsumptionDecision,
   CapabilityConsumptionRequest,
-  CapabilityConsumptionReasonCode
+  CapabilityConsumptionReasonCode,
+  RateLimitConfig,
+  RateLimitRegistry,
+  RateLimitState
 } from '../capabilities/runtime';
 
 export type { CapabilityTokenV1, MintCapabilityOptions, ScopeEntry as CapabilityScopeEntry } from '../../capability/types';

--- a/protocol/capabilities/__tests__/capabilityEnforcer.test.ts
+++ b/protocol/capabilities/__tests__/capabilityEnforcer.test.ts
@@ -3,6 +3,7 @@ import { mintCapabilityToken } from '../../../capability';
 import { capabilityAccessReasonCodes } from '../../../enforcement';
 import { enforceCapability } from '../capabilityEnforcer';
 import { MarketMakerRegistry } from '../../../shared/marketMakerRegistry';
+import { InMemoryRateLimitRegistry } from '../consumeCapabilityAccess';
 
 const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
 const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
@@ -227,6 +228,40 @@ describe('legacy capability bridge mapping', () => {
       }
     });
     expect(policyDecision.code).toBe('RESOURCE_RESTRICTION_FAILED');
+  });
+
+  it('maps RATE_LIMITED consumption denies to RESOURCE_RESTRICTION_FAILED', () => {
+    const { token, consent } = buildToken();
+    const rateLimitRegistry = new InMemoryRateLimitRegistry();
+
+    const firstDecision = enforceCapability({
+      token,
+      consent,
+      required_scope: `content:${CONTENT_REF}`,
+      now: NOW,
+      consume: false,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 60_000
+      }
+    });
+    expect(firstDecision.code).toBe('OK');
+
+    const secondDecision = enforceCapability({
+      token: buildToken().token,
+      consent,
+      required_scope: `content:${CONTENT_REF}`,
+      now: new Date('2025-06-15T10:00:01Z'),
+      consume: false,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 60_000
+      }
+    });
+    expect(secondDecision.code).toBe('RESOURCE_RESTRICTION_FAILED');
+    expect(secondDecision.reason).toContain('Rate limit exceeded');
   });
 
   it('denies non-read actions when the legacy bridge is misused outside its read-only contract', () => {

--- a/protocol/capabilities/__tests__/consumeCapabilityAccess.test.ts
+++ b/protocol/capabilities/__tests__/consumeCapabilityAccess.test.ts
@@ -12,6 +12,7 @@ import {
   capabilityConsumptionReasonCodes,
   consumeCapabilityAccess,
   InMemoryConsentUsageRegistry,
+  InMemoryRateLimitRegistry,
   type ConsentUsageRegistry
 } from '../consumeCapabilityAccess';
 import { enforceCapability } from '../capabilityEnforcer';
@@ -218,6 +219,141 @@ describe('consumeCapabilityAccess', () => {
     expect(decision.reasonCode).toBe(capabilityAccessReasonCodes.ACCESS_ALLOWED);
     expect(decision.payment).toBeUndefined();
     expect(decision.usage?.usageCount).toBe(1);
+  });
+
+  it('allows consumption under the configured fixed-window rate limit', () => {
+    const rateLimitRegistry = new InMemoryRateLimitRegistry();
+    const first = buildToken();
+    const second = buildToken();
+
+    const firstDecision = consumeCapabilityAccess({
+      capability: first.token,
+      consent: first.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      consume: false,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 2,
+        windowMs: 60_000
+      },
+      registries: { revocationRegistry: new InMemoryRevocationRegistry() }
+    });
+
+    const secondDecision = consumeCapabilityAccess({
+      capability: second.token,
+      consent: second.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: new Date('2025-06-15T10:00:10Z'),
+      consume: false,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 2,
+        windowMs: 60_000
+      },
+      registries: { revocationRegistry: new InMemoryRevocationRegistry() }
+    });
+
+    expect(firstDecision.allowed).toBe(true);
+    expect(secondDecision.allowed).toBe(true);
+    expect(rateLimitRegistry.get(first.token.consent_ref)?.count).toBe(2);
+  });
+
+  it('denies with RATE_LIMITED once configured attempts are exceeded', () => {
+    const usageRegistry = new InMemoryConsentUsageRegistry();
+    const nonceRegistry = new InMemoryNonceRegistry();
+    const rateLimitRegistry = new InMemoryRateLimitRegistry();
+    const first = buildToken();
+    const second = buildToken();
+
+    consumeCapabilityAccess({
+      capability: first.token,
+      consent: first.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 60_000
+      },
+      registries: {
+        nonceRegistry,
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: usageRegistry
+      }
+    });
+
+    const limitedDecision = consumeCapabilityAccess({
+      capability: second.token,
+      consent: second.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: new Date('2025-06-15T10:00:10Z'),
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 60_000
+      },
+      registries: {
+        nonceRegistry,
+        revocationRegistry: new InMemoryRevocationRegistry(),
+        consentUsageRegistry: usageRegistry
+      }
+    });
+
+    expect(limitedDecision.allowed).toBe(false);
+    expect(limitedDecision.reasonCode).toBe(capabilityConsumptionReasonCodes.RATE_LIMITED);
+    expect(limitedDecision.metadata.failureStage).toBe('rate_limit');
+    expect(limitedDecision.metadata.rateLimitKey).toBe(first.token.consent_ref);
+    expect(limitedDecision.usage).toEqual({
+      usageCount: 1,
+      lastAccessedAt: '2025-06-15T10:00:10Z',
+      lastAccessResult: 'deny'
+    });
+    expect(nonceRegistry.hasSeen(second.token.token_id, NOW)).toBe(false);
+  });
+
+  it('resets fixed-window rate limits after windowMs passes', () => {
+    const rateLimitRegistry = new InMemoryRateLimitRegistry();
+    const first = buildToken();
+    const second = buildToken();
+
+    const firstDecision = consumeCapabilityAccess({
+      capability: first.token,
+      consent: first.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      consume: false,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 30_000
+      },
+      registries: { revocationRegistry: new InMemoryRevocationRegistry() }
+    });
+
+    const secondDecision = consumeCapabilityAccess({
+      capability: second.token,
+      consent: second.consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: new Date('2025-06-15T10:00:31Z'),
+      consume: false,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 30_000
+      },
+      registries: { revocationRegistry: new InMemoryRevocationRegistry() }
+    });
+
+    expect(firstDecision.allowed).toBe(true);
+    expect(secondDecision.allowed).toBe(true);
+    expect(rateLimitRegistry.get(first.token.consent_ref)?.count).toBe(1);
   });
 
   it('denies priced capability consumption when payment has not been satisfied', () => {
@@ -499,6 +635,29 @@ describe('consumeCapabilityAccess', () => {
     expect(decision.reasonCode).toBe(capabilityAccessReasonCodes.ACTION_NOT_ALLOWED);
     expect(decision.consumed).toBe(false);
     expect(nonceRegistry.hasSeen(token.token_id, NOW)).toBe(false);
+  });
+
+  it('keeps evaluation deny precedence over rate limiting', () => {
+    const rateLimitRegistry = new InMemoryRateLimitRegistry();
+    const { token, consent } = buildToken();
+
+    const decision = consumeCapabilityAccess({
+      capability: token,
+      consent,
+      action: 'share',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 60_000
+      },
+      registries: { revocationRegistry: new InMemoryRevocationRegistry() }
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCode).toBe(capabilityAccessReasonCodes.ACTION_NOT_ALLOWED);
+    expect(rateLimitRegistry.get(token.consent_ref)).toBeUndefined();
   });
 
   it('denies malformed resources and invalid inputs deterministically', () => {

--- a/protocol/capabilities/consumeCapabilityAccess.ts
+++ b/protocol/capabilities/consumeCapabilityAccess.ts
@@ -1,7 +1,8 @@
 export {
   consumeCapabilityAccess,
   capabilityConsumptionReasonCodes,
-  InMemoryConsentUsageRegistry
+  InMemoryConsentUsageRegistry,
+  InMemoryRateLimitRegistry
 } from '../../aoc/capabilities/runtime/consumeCapabilityAccess';
 
 export type {
@@ -10,6 +11,9 @@ export type {
   CapabilityConsumptionDecision,
   CapabilityConsumptionReasonCode,
   CapabilityConsumptionRequest,
+  RateLimitConfig,
+  RateLimitRegistry,
+  RateLimitState,
   ConsentUsageRegistry,
   ConsentUsageResult,
   ConsentUsageState

--- a/tests/sdk/executeCapabilityFlow.test.ts
+++ b/tests/sdk/executeCapabilityFlow.test.ts
@@ -1,4 +1,5 @@
 import {
+  InMemoryRateLimitRegistry,
   MarketMakerRegistry,
   buildConsentObject,
   executeCapabilityFlow,
@@ -161,6 +162,50 @@ describe('executeCapabilityFlow', () => {
     expect(result.consumption?.allowed).toBe(true);
     expect(result.interpretation?.allowed).toBe(true);
     expect(result.allowed).toBe(true);
+  });
+
+  it('returns consumption-stage RATE_LIMITED and does not invoke interpreter when rate limit is hit', () => {
+    const { consent, capability: firstCapability } = createCapability({ marketMakerBound: false });
+    const { capability: secondCapability } = createCapability({ marketMakerBound: false });
+    const rateLimitRegistry = new InMemoryRateLimitRegistry();
+
+    const first = executeCapabilityFlow({
+      capability: firstCapability,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: NOW,
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 60_000
+      }
+    });
+
+    const second = executeCapabilityFlow({
+      capability: secondCapability,
+      consent,
+      action: 'read',
+      resource: { type: 'content', ref: CONTENT_REF },
+      now: '2025-06-15T10:00:05Z',
+      rateLimit: {
+        registry: rateLimitRegistry,
+        maxAttempts: 1,
+        windowMs: 60_000
+      },
+      interpreter: {
+        enabled: true,
+        query: 'This second request should be throttled.'
+      }
+    });
+
+    expect(first.allowed).toBe(true);
+    expect(first.stage).toBe('consumption');
+    expect(second.allowed).toBe(false);
+    expect(second.stage).toBe('consumption');
+    expect(second.reasonCode).toBe('RATE_LIMITED');
+    expect(second.reasonCode).toBe(second.consumption?.reasonCode);
+    expect(second.interpretation).toBeUndefined();
   });
 
   it('returns evaluation-stage deny with trust reason passthrough for deprecated and revoked market makers', () => {


### PR DESCRIPTION
### Motivation
- Implement protocol-aware, deterministic runtime throttling at the consumption boundary to satisfy issue #63 and prevent repeated access attempts from progressing to downstream side effects.
- Provide a minimal MVP-safe fixed-window model keyed by business-level consent so throttling is deterministic, fail-closed, and isolated to the consumption flow.

### Description
- Add a synchronous `RateLimitRegistry` abstraction and `InMemoryRateLimitRegistry` with state `{ count, windowStartedAt }` and API `get`, `increment`, and `isLimited`. (`aoc/capabilities/runtime/consumeCapabilityAccess.ts`).
- Extend the `CapabilityConsumptionRequest` with an optional `rateLimit` config: `{ registry, maxAttempts, windowMs }` and validate the config before use. (`consumeCapabilityAccess` request shape). 
- Enforce rate limiting in `consumeCapabilityAccess(...)` after `evaluateCapabilityAccess(...)` allows and before payment, usage increment, nonce marking, and interpreter invocation; denial returns with reason code `RATE_LIMITED` and includes deterministic metadata (key, window, count, failureStage). (`consumeCapabilityAccess` enforcement). 
- Propagate `rateLimit` through the SDK wrapper `executeCapabilityFlow(...)` so wrapper returns `stage: 'consumption'` with passthrough `reasonCode`, and update the legacy bridge to accept and forward `rateLimit` while mapping `RATE_LIMITED` to `RESOURCE_RESTRICTION_FAILED`. (SDK and legacy bridge changes). 
- Export the new primitives (`InMemoryRateLimitRegistry`, `RateLimitConfig`, `RateLimitRegistry`, `RateLimitState`) from runtime and SDK layers and add concise docs describing the MVP fixed-window behavior and keying strategy (`capability.consent_ref`).

### Testing
- Ran targeted tests: `npm test -- --runTestsByPath protocol/capabilities/__tests__/consumeCapabilityAccess.test.ts tests/sdk/executeCapabilityFlow.test.ts protocol/capabilities/__tests__/capabilityEnforcer.test.ts` and fixed an initial test expectation; after fix the targeted suites passed. 
- Ran full test suite: `npm test` and verified all test suites passed (25 suites, 432 tests) with the new rate limiting tests included.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c21982c22c8325968b15055f715395)