### PR TITLE
Extract protocol-level consent core and enforce consent validation in HRKey adapter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ export * from './field';
 export * from './pack';
 export * from './storage';
 export * from './protocol/capabilities';
+export * from './protocol/consent';
 export * from './aoc/capabilities';
 export * from './aoc/sdk';
 export * from './interpreter';

--- a/integration/hrkey/aocVaultAdapter.ts
+++ b/integration/hrkey/aocVaultAdapter.ts
@@ -17,6 +17,7 @@
 import { createInMemoryVault } from '../../vault';
 import type { Vault } from '../../vault';
 import { buildConsentObject } from '../../consent';
+import { normalizeConsent, parseConsent, validateConsent } from '../../protocol/consent';
 
 import type {
   IHRKeyVaultAdapter,
@@ -89,10 +90,22 @@ export function createHRKeyAdapter(vault?: Vault): IHRKeyVaultAdapter {
       },
     );
 
-    // Store in Vault (Vault validates structure).
-    const consent_hash = v.storeConsent(consent);
+    // Transitional adapter step while HRKey migrates to protocol consent core:
+    // fail-closed before persistence if consent cannot be parsed/validated.
+    const parsedConsent = parseConsent(consent);
+    const normalizedConsent = normalizeConsent(parsedConsent);
+    const validation = validateConsent(normalizedConsent);
 
-    return { consent_hash, consent };
+    if (!validation.valid) {
+      throw new Error(
+        `Consent rejected by protocol core validator: ${validation.errors.join('; ')}`
+      );
+    }
+
+    // Store in Vault (Vault validates structure).
+    const consent_hash = v.storeConsent(normalizedConsent);
+
+    return { consent_hash, consent: normalizedConsent };
   }
 
   // ── mintCapability ──────────────────────────────────────────────

--- a/protocol/consent/README.md
+++ b/protocol/consent/README.md
@@ -1,0 +1,64 @@
+# Protocol Consent Core (Extraction Baseline)
+
+## Purpose
+
+This module is the **protocol-level reusable Consent Engine baseline** for AOC.
+It centralizes fail-closed consent parsing, normalization, validation, state evaluation,
+and scope checks so market makers (including HRKey) consume one canonical core.
+
+## What was extracted into protocol core
+
+The following reusable concerns are now defined in `protocol/consent/*.ts`:
+
+- `parseConsent(...)`: strict parsing gate for critical consent identity fields.
+- `normalizeConsent(...)`: deterministic normalization (trimming, lowercasing refs/hashes, ordered scope/permissions).
+- `validateConsent(...)`: structural/semantic verification using canonical consent invariants.
+- `evaluateConsentState(...)`: state classification (`active`, `expired`, `revoked`, `inactive`, `invalid`).
+- `isConsentActive(...)` and `isConsentRevoked(...)`: narrow state predicates.
+- `doesConsentAllowScope(...)`: fail-closed scope containment check for active consents.
+
+## What remains HR-specific (not extracted)
+
+The following stays in `integration/hrkey/*` because it is market-maker domain logic:
+
+- Candidate/employer nomenclature and HR entity assumptions.
+- HR-specific SDL mapping flows (`work.reference.score`, etc.).
+- Product orchestration (`registerPack`, `grantConsent`, `mintCapability`, `requestAccess`).
+- Route/UI/business workflow concerns.
+
+## Fail-closed guarantees in this layer
+
+- Missing critical consent fields fail in `parseConsent`.
+- Invalid consent schema/hash/timestamps fail in `validateConsent` / `evaluateConsentState`.
+- Non-active states (`expired`, `revoked`, `inactive`, `invalid`) deny scope by default.
+- Empty or ambiguous scope requests are denied.
+
+## Hardening updates (critical)
+
+- `protocol/consent` is now **self-contained** for consent validation logic (no validator dependency on legacy `../../consent`).
+- `parseConsent(...)` now hard-fails on incomplete objects:
+  - missing/empty `subject` or `grantee`
+  - invalid `action`
+  - missing/empty `scope`
+  - malformed scope entries
+  - missing/empty `permissions`
+  - non-parseable `issued_at`
+  - missing/empty `consent_hash`
+- `normalizeConsent(...)` does not silently repair invalid payloads (no fallback defaults for required arrays).
+- `doesConsentAllowScope(...)` enforces:
+  - requested scope subset
+  - requested permissions subset
+  - optional binding checks (`subject`, `grantee`, `marketMakerId`) when provided
+- `evaluateConsentState(...)` explicitly rejects non-`grant` actions for active-state evaluation and fails closed as `invalid`.
+
+## Transitional adoption status
+
+HRKey adapter now runs protocol consent parse/normalize/validate before persistence.
+This is an intermediate integration bridge so HRKey can migrate to full AOC protocol-core consumption without breaking current flow.
+
+## Not included in this extraction
+
+- Capability token lifecycle end-to-end orchestration.
+- Final enforcement interfaces.
+- Full HRKey refactor removing all duplication.
+- Final audit model.

--- a/protocol/consent/__tests__/consentEngine.test.ts
+++ b/protocol/consent/__tests__/consentEngine.test.ts
@@ -1,0 +1,234 @@
+import { buildConsentObject } from '../../../consent';
+import {
+  doesConsentAllowScope,
+  evaluateConsentState,
+  isConsentActive,
+  isConsentRevoked,
+  normalizeConsent,
+  parseConsent,
+  validateConsent,
+} from '..';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const REF_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+describe('protocol consent core extraction', () => {
+  it('accepts a valid active consent', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: REF_A }],
+      ['read'],
+      {
+        now: new Date('2025-01-01T00:00:00Z'),
+        expires_at: '2025-12-31T00:00:00Z',
+      }
+    );
+
+    const parsed = parseConsent(consent);
+    const normalized = normalizeConsent(parsed);
+    const validation = validateConsent(normalized);
+    const state = evaluateConsentState(normalized, { now: new Date('2025-06-01T00:00:00Z') });
+
+    expect(validation.valid).toBe(true);
+    expect(state.state).toBe('active');
+    expect(isConsentActive(normalized, { now: new Date('2025-06-01T00:00:00Z') })).toBe(true);
+    expect(
+      doesConsentAllowScope(normalized, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: ['read'],
+        now: new Date('2025-06-01T00:00:00Z'),
+      })
+    ).toBe(true);
+  });
+
+  it('marks expired consent as expired and deny scope', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: REF_A }],
+      ['read'],
+      {
+        now: new Date('2025-01-01T00:00:00Z'),
+        expires_at: '2025-01-02T00:00:00Z',
+      }
+    );
+
+    const state = evaluateConsentState(consent, { now: new Date('2025-01-03T00:00:00Z') });
+    expect(state.state).toBe('expired');
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: ['read'],
+        now: new Date('2025-01-03T00:00:00Z'),
+      })
+    ).toBe(false);
+  });
+
+  it('marks consent as revoked by revocation hook', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: REF_A }],
+      ['read'],
+      { now: new Date('2025-01-01T00:00:00Z') }
+    );
+
+    const state = evaluateConsentState(consent, {
+      now: new Date('2025-01-03T00:00:00Z'),
+      isRevoked: () => true,
+    });
+
+    expect(state.state).toBe('revoked');
+    expect(isConsentRevoked(consent, { isRevoked: () => true })).toBe(true);
+  });
+
+  it('fails closed on invalid or incomplete scope requests', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: REF_A }],
+      ['read'],
+      { now: new Date('2025-01-01T00:00:00Z') }
+    );
+
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [],
+        permissions: ['read'],
+        now: new Date('2025-01-01T01:00:00Z'),
+      })
+    ).toBe(false);
+
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [{ type: 'content', ref: '' }],
+        permissions: ['read'],
+        now: new Date('2025-01-01T01:00:00Z'),
+      })
+    ).toBe(false);
+  });
+
+  it('denies when request permissions are invalid or not granted', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: REF_A }],
+      ['read'],
+      { now: new Date('2025-01-01T00:00:00Z') }
+    );
+
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: ['store'],
+      })
+    ).toBe(false);
+
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: [''],
+      })
+    ).toBe(false);
+  });
+
+  it('denies on subject/grantee binding mismatch', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: REF_A }],
+      ['read'],
+      { now: new Date('2025-01-01T00:00:00Z'), marketMakerId: 'hrkey-v1' }
+    );
+
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: ['read'],
+        subject: 'did:key:z6MkDifferentSubject1234567890abc',
+      })
+    ).toBe(false);
+
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: ['read'],
+        grantee: 'did:key:z6MkDifferentGrantee1234567890abc',
+      })
+    ).toBe(false);
+
+    expect(
+      doesConsentAllowScope(consent, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: ['read'],
+        marketMakerId: 'another-mm',
+      })
+    ).toBe(false);
+  });
+
+  it('fails closed with missing critical fields', () => {
+    expect(() => parseConsent({})).toThrow('Consent field "subject" must be a string.');
+    expect(() => parseConsent({ subject: SUBJECT, grantee: GRANTEE, action: 'grant' })).toThrow(
+      'Consent field "scope" must be a non-empty array.'
+    );
+    expect(() =>
+      parseConsent({
+        subject: SUBJECT,
+        grantee: GRANTEE,
+        action: 'grant',
+        scope: [{ type: 'content', ref: REF_A }],
+      })
+    ).toThrow('Consent field "permissions" must be a non-empty array.');
+
+    const malformed = {
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      action: 'grant',
+      scope: [{ type: 'content', ref: REF_A }],
+      permissions: ['read'],
+      issued_at: '2025-01-01T00:00:00Z',
+      expires_at: null,
+      prior_consent: null,
+      consent_hash: 'not-a-hash',
+    } as any;
+
+    const validation = validateConsent(malformed);
+    expect(validation.valid).toBe(false);
+  });
+
+  it('invalid state denies by default', () => {
+    const malformed = {
+      version: '1.0',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      action: 'grant',
+      scope: [{ type: 'content', ref: REF_A }],
+      permissions: ['read'],
+      issued_at: 'invalid-date',
+      expires_at: null,
+      prior_consent: null,
+      consent_hash: REF_A,
+    } as any;
+
+    const state = evaluateConsentState(malformed, {
+      now: new Date('2025-01-01T00:00:00Z'),
+    });
+
+    expect(state.state).toBe('invalid');
+    expect(
+      doesConsentAllowScope(malformed, {
+        scope: [{ type: 'content', ref: REF_A }],
+        permissions: ['read'],
+      })
+    ).toBe(false);
+  });
+});

--- a/protocol/consent/consent-errors.ts
+++ b/protocol/consent/consent-errors.ts
@@ -1,0 +1,16 @@
+export class ConsentParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConsentParseError';
+  }
+}
+
+export class ConsentValidationError extends Error {
+  readonly errors: string[];
+
+  constructor(message: string, errors: string[]) {
+    super(message);
+    this.name = 'ConsentValidationError';
+    this.errors = errors;
+  }
+}

--- a/protocol/consent/consent-machine.ts
+++ b/protocol/consent/consent-machine.ts
@@ -1,0 +1,64 @@
+import type { ScopeEntry, ConsentScopeRequest, ProtocolConsent } from './consent-types';
+import { evaluateConsentState } from './consent-state';
+
+function toScopeKey(entry: ScopeEntry): string {
+  return `${entry.type}:${entry.ref}`;
+}
+
+export function doesConsentAllowScope(
+  consent: ProtocolConsent,
+  request: ConsentScopeRequest
+): boolean {
+  const state = evaluateConsentState(consent, {
+    now: request.now,
+    isRevoked: request.isRevoked,
+  });
+
+  if (state.state !== 'active') {
+    return false;
+  }
+
+  if (!Array.isArray(request.scope) || request.scope.length === 0) {
+    return false;
+  }
+  if (!Array.isArray(request.permissions) || request.permissions.length === 0) {
+    return false;
+  }
+  if (request.subject !== undefined && request.subject !== consent.subject) {
+    return false;
+  }
+  if (request.grantee !== undefined && request.grantee !== consent.grantee) {
+    return false;
+  }
+  if (
+    request.marketMakerId !== undefined &&
+    consent.marketMakerId !== undefined &&
+    request.marketMakerId !== consent.marketMakerId
+  ) {
+    return false;
+  }
+
+  const allowedScope = new Set(consent.scope.map(toScopeKey));
+  const allowedPermissions = new Set(consent.permissions);
+
+  for (const requiredEntry of request.scope) {
+    if (!requiredEntry || typeof requiredEntry.ref !== 'string' || requiredEntry.ref.trim() === '') {
+      return false;
+    }
+
+    if (!allowedScope.has(toScopeKey(requiredEntry))) {
+      return false;
+    }
+  }
+
+  for (const permission of request.permissions) {
+    if (typeof permission !== 'string' || permission.trim() === '') {
+      return false;
+    }
+    if (!allowedPermissions.has(permission)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/protocol/consent/consent-normalizer.ts
+++ b/protocol/consent/consent-normalizer.ts
@@ -1,0 +1,50 @@
+import type { ProtocolConsent, ScopeEntry } from './consent-types';
+import { parseConsent } from './consent-object';
+
+function normalizeString(value: string): string {
+  return value.trim();
+}
+
+function normalizeScope(scope: ScopeEntry[]): ScopeEntry[] {
+  return [...scope]
+    .map((entry) => ({
+      type: entry.type,
+      ref: normalizeString(entry.ref).toLowerCase(),
+    }))
+    .sort((a, b) => {
+      const typeCmp = a.type.localeCompare(b.type);
+      if (typeCmp !== 0) return typeCmp;
+      return a.ref.localeCompare(b.ref);
+    });
+}
+
+export function normalizeConsent(input: unknown): ProtocolConsent {
+  const consent = parseConsent(input);
+
+  return {
+    ...consent,
+    version: normalizeString(consent.version),
+    subject: normalizeString(consent.subject),
+    grantee: normalizeString(consent.grantee),
+    action: consent.action,
+    scope: normalizeScope(consent.scope),
+    permissions: [...consent.permissions]
+      .map((permission) => normalizeString(permission).toLowerCase())
+      .sort(),
+    issued_at: normalizeString(consent.issued_at),
+    expires_at: consent.expires_at === null ? null : normalizeString(consent.expires_at),
+    prior_consent:
+      consent.prior_consent === null ? null : normalizeString(consent.prior_consent).toLowerCase(),
+    consent_hash: normalizeString(consent.consent_hash).toLowerCase(),
+    ...(consent.marketMakerId !== undefined
+      ? { marketMakerId: normalizeString(consent.marketMakerId) }
+      : {}),
+    ...(consent.revoke_target !== undefined
+      ? {
+        revoke_target: {
+          capability_hash: normalizeString(consent.revoke_target.capability_hash).toLowerCase(),
+        },
+      }
+      : {}),
+  };
+}

--- a/protocol/consent/consent-object.ts
+++ b/protocol/consent/consent-object.ts
@@ -1,0 +1,88 @@
+import { ConsentParseError } from './consent-errors';
+import type { ProtocolConsent } from './consent-types';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new ConsentParseError('Consent must be a non-null JSON object.');
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function parseStringField(record: Record<string, unknown>, field: string): string {
+  const value = record[field];
+
+  if (typeof value !== 'string') {
+    throw new ConsentParseError(`Consent field "${field}" must be a string.`);
+  }
+
+  return value;
+}
+
+function parseDateField(record: Record<string, unknown>, field: string): string {
+  const value = parseStringField(record, field);
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new ConsentParseError(`Consent field "${field}" must be a parseable ISO date string.`);
+  }
+  return value;
+}
+
+function parseScope(record: Record<string, unknown>): void {
+  const scope = record.scope;
+  if (!Array.isArray(scope) || scope.length === 0) {
+    throw new ConsentParseError('Consent field "scope" must be a non-empty array.');
+  }
+
+  for (let i = 0; i < scope.length; i++) {
+    const entry = scope[i];
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      throw new ConsentParseError(`Consent scope entry ${i} must be a JSON object.`);
+    }
+    const entryRecord = entry as Record<string, unknown>;
+    parseStringField(entryRecord, 'type');
+    const ref = parseStringField(entryRecord, 'ref');
+    if (ref.trim() === '') {
+      throw new ConsentParseError(`Consent scope entry ${i} ref must be non-empty.`);
+    }
+  }
+}
+
+function parsePermissions(record: Record<string, unknown>): void {
+  const permissions = record.permissions;
+  if (!Array.isArray(permissions) || permissions.length === 0) {
+    throw new ConsentParseError('Consent field "permissions" must be a non-empty array.');
+  }
+  for (let i = 0; i < permissions.length; i++) {
+    if (typeof permissions[i] !== 'string' || permissions[i].trim() === '') {
+      throw new ConsentParseError(`Consent permission ${i} must be a non-empty string.`);
+    }
+  }
+}
+
+export function parseConsent(input: unknown): ProtocolConsent {
+  const record = asRecord(input);
+
+  const subject = parseStringField(record, 'subject');
+  if (subject.trim() === '') {
+    throw new ConsentParseError('Consent field "subject" must be non-empty.');
+  }
+  const grantee = parseStringField(record, 'grantee');
+  if (grantee.trim() === '') {
+    throw new ConsentParseError('Consent field "grantee" must be non-empty.');
+  }
+  const action = parseStringField(record, 'action');
+  if (action !== 'grant' && action !== 'revoke') {
+    throw new ConsentParseError('Consent field "action" must be one of: grant, revoke.');
+  }
+
+  parseScope(record);
+  parsePermissions(record);
+  parseDateField(record, 'issued_at');
+
+  const consentHash = parseStringField(record, 'consent_hash');
+  if (consentHash.trim() === '') {
+    throw new ConsentParseError('Consent field "consent_hash" must be non-empty.');
+  }
+
+  return record as ProtocolConsent;
+}

--- a/protocol/consent/consent-state.ts
+++ b/protocol/consent/consent-state.ts
@@ -1,0 +1,60 @@
+import type { ConsentEvaluationOptions, ConsentStateResult, ProtocolConsent } from './consent-types';
+import { validateConsent } from './consent-validator';
+
+export function evaluateConsentState(
+  consent: ProtocolConsent,
+  opts: ConsentEvaluationOptions = {}
+): ConsentStateResult {
+  if (consent.action !== 'grant' && consent.action !== 'revoke') {
+    return { state: 'invalid', reasons: ['Consent action is invalid.'] };
+  }
+
+  const validation = validateConsent(consent);
+  if (!validation.valid) {
+    return { state: 'invalid', reasons: validation.errors };
+  }
+
+  if (consent.action !== 'grant') {
+    return { state: 'invalid', reasons: ['Consent action must be grant for active evaluation.'] };
+  }
+
+  if (opts.isRevoked?.(consent) === true) {
+    return { state: 'revoked', reasons: ['Consent was revoked by registry hook.'] };
+  }
+
+  const now = opts.now ?? new Date();
+  const issuedAt = Date.parse(consent.issued_at);
+
+  if (!Number.isFinite(issuedAt)) {
+    return { state: 'invalid', reasons: ['Consent issued_at is not parseable.'] };
+  }
+
+  if (now.getTime() < issuedAt) {
+    return {
+      state: 'inactive',
+      reasons: ['Consent issued_at is in the future for evaluation time.'],
+    };
+  }
+
+  if (consent.expires_at !== null) {
+    const expiresAt = Date.parse(consent.expires_at);
+
+    if (!Number.isFinite(expiresAt)) {
+      return { state: 'invalid', reasons: ['Consent expires_at is not parseable.'] };
+    }
+
+    if (now.getTime() >= expiresAt) {
+      return { state: 'expired', reasons: ['Consent is expired.'] };
+    }
+  }
+
+  return { state: 'active', reasons: [] };
+}
+
+export function isConsentActive(consent: ProtocolConsent, opts: ConsentEvaluationOptions = {}): boolean {
+  return evaluateConsentState(consent, opts).state === 'active';
+}
+
+export function isConsentRevoked(consent: ProtocolConsent, opts: ConsentEvaluationOptions = {}): boolean {
+  return evaluateConsentState(consent, opts).state === 'revoked';
+}

--- a/protocol/consent/consent-types.ts
+++ b/protocol/consent/consent-types.ts
@@ -1,0 +1,58 @@
+export type ScopeEntry = {
+  type: 'field' | 'content' | 'pack';
+  ref: string;
+};
+
+export type ProtocolConsent = {
+  version: string;
+  subject: string;
+  grantee: string;
+  action: 'grant' | 'revoke';
+  scope: ScopeEntry[];
+  permissions: string[];
+  pricing?: {
+    model: 'per_use';
+    amount: number;
+    currency: string;
+  };
+  marketMakerId?: string;
+  revoke_target?: {
+    capability_hash: string;
+  };
+  issued_at: string;
+  expires_at: string | null;
+  prior_consent: string | null;
+  consent_hash: string;
+};
+
+export type ConsentState =
+  | 'active'
+  | 'expired'
+  | 'revoked'
+  | 'inactive'
+  | 'invalid';
+
+export type ConsentValidationResult = {
+  valid: boolean;
+  errors: string[];
+};
+
+export type ConsentStateResult = {
+  state: ConsentState;
+  reasons: string[];
+};
+
+export type ConsentEvaluationOptions = {
+  now?: Date;
+  isRevoked?: (consent: ProtocolConsent) => boolean;
+};
+
+export type ConsentScopeRequest = {
+  scope: ScopeEntry[];
+  permissions: string[];
+  subject?: string;
+  grantee?: string;
+  marketMakerId?: string;
+  now?: Date;
+  isRevoked?: (consent: ProtocolConsent) => boolean;
+};

--- a/protocol/consent/consent-validator.ts
+++ b/protocol/consent/consent-validator.ts
@@ -1,0 +1,105 @@
+import type { ProtocolConsent, ConsentValidationResult } from './consent-types';
+import { parseConsent } from './consent-object';
+
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+$/;
+const DID_PATTERN = /^did:[a-z0-9]+:[a-zA-Z0-9._%-]+$/;
+const HASH_HEX_PATTERN = /^[a-f0-9]{64}$/;
+const ISO8601_UTC_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
+const PERMISSION_PATTERN = /^[a-z0-9-]+$/;
+const VALID_SCOPE_TYPES = new Set(['field', 'content', 'pack']);
+const VALID_ACTIONS = new Set(['grant', 'revoke']);
+const MAX_SCOPE_ENTRIES = 10000;
+const MAX_PERMISSIONS = 100;
+
+export function validateConsent(consent: ProtocolConsent): ConsentValidationResult {
+  const errors: string[] = [];
+
+  try {
+    parseConsent(consent);
+  } catch (error) {
+    return { valid: false, errors: [error instanceof Error ? error.message : 'Invalid consent.'] };
+  }
+
+  if (!VERSION_PATTERN.test(consent.version)) {
+    errors.push('Consent version must match MAJOR.MINOR.');
+  }
+  if (!DID_PATTERN.test(consent.subject)) {
+    errors.push('Consent subject must be a valid DID.');
+  }
+  if (!DID_PATTERN.test(consent.grantee)) {
+    errors.push('Consent grantee must be a valid DID.');
+  }
+  if (!VALID_ACTIONS.has(consent.action)) {
+    errors.push('Consent action must be grant or revoke.');
+  }
+  if (!ISO8601_UTC_PATTERN.test(consent.issued_at)) {
+    errors.push('Consent issued_at must be ISO8601 UTC with second precision.');
+  }
+  if (!HASH_HEX_PATTERN.test(consent.consent_hash)) {
+    errors.push('Consent consent_hash must be 64 lowercase hex.');
+  }
+
+  if (consent.scope.length > MAX_SCOPE_ENTRIES) {
+    errors.push(`Consent scope must not exceed ${MAX_SCOPE_ENTRIES} entries.`);
+  }
+  const seenScope = new Set<string>();
+  for (let i = 0; i < consent.scope.length; i++) {
+    const entry = consent.scope[i];
+    if (!VALID_SCOPE_TYPES.has(entry.type)) {
+      errors.push(`Consent scope entry ${i} has invalid type.`);
+    }
+    if (!HASH_HEX_PATTERN.test(entry.ref)) {
+      errors.push(`Consent scope entry ${i} ref must be 64 lowercase hex.`);
+    }
+    const key = `${entry.type}:${entry.ref}`;
+    if (seenScope.has(key)) {
+      errors.push(`Consent scope entry ${i} is duplicated.`);
+    }
+    seenScope.add(key);
+  }
+
+  if (consent.permissions.length > MAX_PERMISSIONS) {
+    errors.push(`Consent permissions must not exceed ${MAX_PERMISSIONS} entries.`);
+  }
+  const seenPermissions = new Set<string>();
+  for (let i = 0; i < consent.permissions.length; i++) {
+    const permission = consent.permissions[i];
+    if (!PERMISSION_PATTERN.test(permission)) {
+      errors.push(`Consent permission ${i} must be lowercase alphanumeric with hyphens.`);
+    }
+    if (seenPermissions.has(permission)) {
+      errors.push(`Consent permission ${i} is duplicated.`);
+    }
+    seenPermissions.add(permission);
+  }
+
+  if (consent.expires_at !== null) {
+    if (!ISO8601_UTC_PATTERN.test(consent.expires_at)) {
+      errors.push('Consent expires_at must be ISO8601 UTC or null.');
+    } else if (consent.expires_at <= consent.issued_at) {
+      errors.push('Consent expires_at must be greater than issued_at.');
+    }
+  }
+
+  if (consent.prior_consent !== null && !HASH_HEX_PATTERN.test(consent.prior_consent)) {
+    errors.push('Consent prior_consent must be 64 lowercase hex or null.');
+  }
+
+  if (consent.action === 'grant') {
+    if (consent.revoke_target !== undefined) {
+      errors.push('Consent revoke_target is only valid for revoke actions.');
+    }
+  } else if (consent.action === 'revoke') {
+    if (
+      consent.revoke_target === undefined ||
+      !HASH_HEX_PATTERN.test(consent.revoke_target.capability_hash)
+    ) {
+      errors.push('Consent revoke_target.capability_hash must be 64 lowercase hex.');
+    }
+    if (consent.expires_at !== null) {
+      errors.push('Consent revoke action must have expires_at = null.');
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/protocol/consent/index.ts
+++ b/protocol/consent/index.ts
@@ -1,0 +1,16 @@
+export { parseConsent } from './consent-object';
+export { normalizeConsent } from './consent-normalizer';
+export { validateConsent } from './consent-validator';
+export { evaluateConsentState, isConsentActive, isConsentRevoked } from './consent-state';
+export { doesConsentAllowScope } from './consent-machine';
+
+export { ConsentParseError, ConsentValidationError } from './consent-errors';
+
+export type {
+  ProtocolConsent,
+  ConsentState,
+  ConsentValidationResult,
+  ConsentStateResult,
+  ConsentEvaluationOptions,
+  ConsentScopeRequest,
+} from './consent-types';


### PR DESCRIPTION
### Motivation
- Centralize and harden consent parsing, normalization, validation, state evaluation and scope checks into a reusable protocol-level consent core and ensure market-maker adapters fail-closed before persisting malformed consent.

### Description
- Add a new `protocol/consent` package implementing `parseConsent`, `normalizeConsent`, `validateConsent`, `evaluateConsentState`, `doesConsentAllowScope`, error types, types, and a README documenting behavior and guarantees.
- Wire the new module into the public surface by exporting `protocol/consent` from root `index.ts`.
- Update `integration/hrkey/aocVaultAdapter.ts` to run `parseConsent`, `normalizeConsent`, and `validateConsent` before storing consent and to persist the normalized consent object; adapter now throws on validation failures (fail-closed transition step).
- Add unit tests `protocol/consent/__tests__/consentEngine.test.ts` covering parsing, normalization, validation, state evaluation, scope checks, and failure modes.

### Testing
- Executed the new consent engine tests (`protocol/consent/__tests__/consentEngine.test.ts`) via the project test runner and they passed.
- Ran the repository test suite (`yarn test`) to catch regressions and observed no failures related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9135d1a68832584b85f0b033ede93)