### PR TITLE
Add protocol enforcement runtime core decision layer

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ export * from './pack';
 export * from './storage';
 export * from './protocol/capabilities';
 export * from './protocol/consent';
+export * from './protocol/enforcement';
 export * from './aoc/capabilities';
 export * from './aoc/sdk';
 export * from './interpreter';

--- a/protocol/enforcement/README.md
+++ b/protocol/enforcement/README.md
@@ -1,0 +1,39 @@
+# Protocol Enforcement Runtime
+
+## Propósito
+
+`protocol/enforcement` implementa la capa runtime de enforcement del protocolo AOC.
+Recibe solicitudes de acceso/acción, valida capability tokens, evalúa su estado y emite una decisión canónica, determinista y fail-closed.
+
+## Relación con Capability Layer
+
+El enforcement runtime envuelve la capa `protocol/capability` como fuente única para:
+
+- `verifyCapability(...)`
+- `evaluateCapabilityState(...)`
+- `evaluateCapabilityAccess(...)`
+
+La capa de enforcement no reimplementa lifecycle de capability: agrega normalización del request y construcción de decisiones estructuradas reutilizables.
+
+## Salida canónica
+
+La función principal `evaluateEnforcement(...)` devuelve un `EnforcementDecision` con:
+
+- `allowed` + `decision`
+- `reason_code` canónico
+- `reasons` detallados
+- `evaluated_at`
+- request/capability normalizados y matches evaluados cuando aplica
+
+## Qué **no** hace todavía
+
+Este runtime está limitado a core decision logic. No incluye:
+
+- side effects reales de ejecución
+- networking / API pública
+- SDK final
+- audit trail persistente
+- storage providers externos
+- policy marketplace complejo
+
+Los market makers/adapters ejecutan acciones fuera del core; el core solo decide.

--- a/protocol/enforcement/__tests__/enforcementEngine.test.ts
+++ b/protocol/enforcement/__tests__/enforcementEngine.test.ts
@@ -1,0 +1,229 @@
+import { buildConsentObject } from '../../../consent';
+import { mintCapability } from '../../capability';
+import { ENFORCEMENT_REASON_CODES, evaluateEnforcement } from '..';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const REF_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const REF_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function buildCapability() {
+  const consent = buildConsentObject(
+    SUBJECT,
+    GRANTEE,
+    'grant',
+    [
+      { type: 'content', ref: REF_A },
+      { type: 'pack', ref: REF_B },
+    ],
+    ['read', 'share'],
+    {
+      now: new Date('2026-01-01T00:00:00Z'),
+      expires_at: '2026-12-31T00:00:00Z',
+      marketMakerId: 'mm-01',
+    }
+  );
+
+  return mintCapability({
+    consent,
+    requested_scope: [{ type: 'content', ref: REF_A }],
+    requested_permissions: ['read'],
+    issued_at: '2026-02-01T00:00:00Z',
+    expires_at: '2026-03-01T00:00:00Z',
+    marketMakerId: 'mm-01',
+  });
+}
+
+describe('protocol enforcement runtime', () => {
+  it('request válido => allow', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      marketMakerId: 'mm-01',
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.decision).toBe('allow');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.ENFORCEMENT_ALLOW);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('capability inválido => deny CAPABILITY_INVALID', () => {
+    const decision = evaluateEnforcement({
+      capability: {},
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.CAPABILITY_INVALID);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('capability expired => deny CAPABILITY_EXPIRED', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      now: new Date('2026-04-01T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.CAPABILITY_EXPIRED);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('capability revoked => deny CAPABILITY_REVOKED', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      now: new Date('2026-02-15T00:00:00Z'),
+      isRevoked: () => true,
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.CAPABILITY_REVOKED);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('capability not_yet_active => deny CAPABILITY_NOT_YET_ACTIVE', () => {
+    const consent = buildConsentObject(
+      SUBJECT,
+      GRANTEE,
+      'grant',
+      [{ type: 'content', ref: REF_A }],
+      ['read'],
+      { now: new Date('2026-01-01T00:00:00Z'), expires_at: '2026-12-31T00:00:00Z' }
+    );
+
+    const capability = mintCapability({
+      consent,
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      issued_at: '2026-02-01T00:00:00Z',
+      not_before: '2026-02-20T00:00:00Z',
+      expires_at: '2026-03-01T00:00:00Z',
+    });
+
+    const decision = evaluateEnforcement({
+      capability,
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.CAPABILITY_NOT_YET_ACTIVE);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('requested_scope fuera => deny SCOPE_NOT_ALLOWED', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'pack', ref: REF_B }],
+      requested_permissions: ['read'],
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.SCOPE_NOT_ALLOWED);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('requested_permissions fuera => deny PERMISSION_NOT_ALLOWED', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['share'],
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.PERMISSION_NOT_ALLOWED);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('subject mismatch => deny SUBJECT_MISMATCH', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      subject: 'did:key:z6MkDifferentSubject1234567890abc',
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.SUBJECT_MISMATCH);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('grantee mismatch => deny GRANTEE_MISMATCH', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      grantee: 'did:key:z6MkDifferentGrantee1234567890abc',
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.GRANTEE_MISMATCH);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('marketMaker mismatch => deny MARKET_MAKER_MISMATCH', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      marketMakerId: 'mm-02',
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.MARKET_MAKER_MISMATCH);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('request inválido => deny REQUEST_INVALID', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [],
+      requested_permissions: ['read'],
+      now: new Date('2026-02-15T00:00:00Z'),
+    } as any);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.REQUEST_INVALID);
+    expect(decision.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('fail-closed cuando permission está vacía', () => {
+    const decision = evaluateEnforcement({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['   '],
+      now: new Date('2026-02-15T00:00:00Z'),
+    } as any);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decision).toBe('deny');
+    expect(decision.reason_code).toBe(ENFORCEMENT_REASON_CODES.REQUEST_INVALID);
+  });
+});

--- a/protocol/enforcement/enforcement-decision.ts
+++ b/protocol/enforcement/enforcement-decision.ts
@@ -1,0 +1,7 @@
+import type { EnforcementDecision } from './enforcement-types';
+
+export function buildDecisionTimestamp(date: Date): string {
+  return date.toISOString();
+}
+
+export type { EnforcementDecision };

--- a/protocol/enforcement/enforcement-engine.ts
+++ b/protocol/enforcement/enforcement-engine.ts
@@ -1,0 +1,193 @@
+import { evaluateCapabilityAccess, evaluateCapabilityState, verifyCapability } from '../capability';
+import type { ScopeEntry } from '../consent/consent-types';
+import { parseEnforcementRequest, normalizeEnforcementRequest } from './enforcement-request';
+import type { EnforcementDecision, EnforcementRequest, NormalizedEnforcementRequest } from './enforcement-types';
+import { ENFORCEMENT_REASON_CODES } from './enforcement-types';
+import { buildAllowDecision, buildDenyDecision, mapCapabilityStateToReason } from './enforcement-policy';
+
+function toScopeKey(entry: ScopeEntry): string {
+  return `${entry.type}:${entry.ref}`;
+}
+
+function findScopeMismatch(
+  normalizedRequest: NormalizedEnforcementRequest,
+  allowedScope: ScopeEntry[]
+): { matched: ScopeEntry[]; mismatch?: ScopeEntry } {
+  const allowed = new Set(allowedScope.map(toScopeKey));
+  const matched: ScopeEntry[] = [];
+
+  for (const requested of normalizedRequest.requested_scope) {
+    if (!allowed.has(toScopeKey(requested))) {
+      return { matched, mismatch: requested };
+    }
+    matched.push(requested);
+  }
+
+  return { matched };
+}
+
+function findPermissionMismatch(
+  normalizedRequest: NormalizedEnforcementRequest,
+  allowedPermissions: string[]
+): { matched: string[]; mismatch?: string } {
+  const allowed = new Set(allowedPermissions);
+  const matched: string[] = [];
+
+  for (const permission of normalizedRequest.requested_permissions) {
+    if (!allowed.has(permission)) {
+      return { matched, mismatch: permission };
+    }
+    matched.push(permission);
+  }
+
+  return { matched };
+}
+
+export function evaluateEnforcement(request: EnforcementRequest): EnforcementDecision {
+  const now = request.now ?? new Date();
+
+  let normalizedRequest: NormalizedEnforcementRequest;
+  try {
+    normalizedRequest = normalizeEnforcementRequest(parseEnforcementRequest(request));
+  } catch (error) {
+    return buildDenyDecision(
+      ENFORCEMENT_REASON_CODES.REQUEST_INVALID,
+      [error instanceof Error ? error.message : 'Enforcement request parsing failed.'],
+      { now }
+    );
+  }
+
+  const verification = verifyCapability(normalizedRequest.capability);
+  if (!verification.valid || verification.normalized === undefined) {
+    return buildDenyDecision(ENFORCEMENT_REASON_CODES.CAPABILITY_INVALID, verification.errors, {
+      now,
+      normalized_request: normalizedRequest,
+    });
+  }
+
+  const normalizedCapability = verification.normalized;
+  const state = evaluateCapabilityState(normalizedCapability, {
+    now: normalizedRequest.now ?? now,
+    isRevoked: normalizedRequest.isRevoked,
+  });
+
+  if (state.state !== 'active') {
+    return buildDenyDecision(mapCapabilityStateToReason(state.state), state.reasons, {
+      now,
+      normalized_request: normalizedRequest,
+      normalized_capability: normalizedCapability,
+    });
+  }
+
+  const scopeMatch = findScopeMismatch(normalizedRequest, normalizedCapability.scope);
+  if (scopeMatch.mismatch !== undefined) {
+    return buildDenyDecision(
+      ENFORCEMENT_REASON_CODES.SCOPE_NOT_ALLOWED,
+      [`Requested scope is not allowed: ${scopeMatch.mismatch.type}:${scopeMatch.mismatch.ref}.`],
+      {
+        now,
+        normalized_request: normalizedRequest,
+        normalized_capability: normalizedCapability,
+        matched_scope: scopeMatch.matched,
+      }
+    );
+  }
+
+  const permissionMatch = findPermissionMismatch(normalizedRequest, normalizedCapability.permissions);
+  if (permissionMatch.mismatch !== undefined) {
+    return buildDenyDecision(
+      ENFORCEMENT_REASON_CODES.PERMISSION_NOT_ALLOWED,
+      [`Requested permission is not allowed: ${permissionMatch.mismatch}.`],
+      {
+        now,
+        normalized_request: normalizedRequest,
+        normalized_capability: normalizedCapability,
+        matched_scope: scopeMatch.matched,
+        matched_permissions: permissionMatch.matched,
+      }
+    );
+  }
+
+  if (
+    normalizedRequest.subject !== undefined &&
+    normalizedRequest.subject !== normalizedCapability.subject
+  ) {
+    return buildDenyDecision(
+      ENFORCEMENT_REASON_CODES.SUBJECT_MISMATCH,
+      ['Request subject does not match capability subject.'],
+      {
+        now,
+        normalized_request: normalizedRequest,
+        normalized_capability: normalizedCapability,
+        matched_scope: scopeMatch.matched,
+        matched_permissions: permissionMatch.matched,
+      }
+    );
+  }
+
+  if (
+    normalizedRequest.grantee !== undefined &&
+    normalizedRequest.grantee !== normalizedCapability.grantee
+  ) {
+    return buildDenyDecision(
+      ENFORCEMENT_REASON_CODES.GRANTEE_MISMATCH,
+      ['Request grantee does not match capability grantee.'],
+      {
+        now,
+        normalized_request: normalizedRequest,
+        normalized_capability: normalizedCapability,
+        matched_scope: scopeMatch.matched,
+        matched_permissions: permissionMatch.matched,
+      }
+    );
+  }
+
+  if (
+    normalizedRequest.marketMakerId !== undefined &&
+    normalizedRequest.marketMakerId !== (normalizedCapability.marketMakerId ?? undefined)
+  ) {
+    return buildDenyDecision(
+      ENFORCEMENT_REASON_CODES.MARKET_MAKER_MISMATCH,
+      ['Request market maker binding does not match capability marketMakerId.'],
+      {
+        now,
+        normalized_request: normalizedRequest,
+        normalized_capability: normalizedCapability,
+        matched_scope: scopeMatch.matched,
+        matched_permissions: permissionMatch.matched,
+      }
+    );
+  }
+
+  const accessAllowed = evaluateCapabilityAccess(normalizedCapability, {
+    requested_scope: normalizedRequest.requested_scope,
+    requested_permissions: normalizedRequest.requested_permissions,
+    subject: normalizedRequest.subject,
+    grantee: normalizedRequest.grantee,
+    marketMakerId: normalizedRequest.marketMakerId,
+    now: normalizedRequest.now ?? now,
+    isRevoked: normalizedRequest.isRevoked,
+  });
+
+  if (!accessAllowed) {
+    return buildDenyDecision(
+      ENFORCEMENT_REASON_CODES.REQUEST_INVALID,
+      ['Capability access evaluation denied the request.'],
+      {
+        now,
+        normalized_request: normalizedRequest,
+        normalized_capability: normalizedCapability,
+        matched_scope: scopeMatch.matched,
+        matched_permissions: permissionMatch.matched,
+      }
+    );
+  }
+
+  return buildAllowDecision({
+    now,
+    normalized_request: normalizedRequest,
+    normalized_capability: normalizedCapability,
+    matched_scope: scopeMatch.matched,
+    matched_permissions: permissionMatch.matched,
+  });
+}

--- a/protocol/enforcement/enforcement-errors.ts
+++ b/protocol/enforcement/enforcement-errors.ts
@@ -1,0 +1,7 @@
+export class EnforcementRequestParseError extends Error {
+  readonly name = 'EnforcementRequestParseError';
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/protocol/enforcement/enforcement-policy.ts
+++ b/protocol/enforcement/enforcement-policy.ts
@@ -1,0 +1,66 @@
+import type { CapabilityState } from '../capability/capability-types';
+import type {
+  EnforcementDecision,
+  EnforcementReasonCode,
+  NormalizedEnforcementRequest,
+} from './enforcement-types';
+import { ENFORCEMENT_REASON_CODES } from './enforcement-types';
+import type { ProtocolCapability } from '../capability/capability-types';
+import { buildDecisionTimestamp } from './enforcement-decision';
+
+export function mapCapabilityStateToReason(state: CapabilityState): EnforcementReasonCode {
+  switch (state) {
+    case 'expired':
+      return ENFORCEMENT_REASON_CODES.CAPABILITY_EXPIRED;
+    case 'revoked':
+      return ENFORCEMENT_REASON_CODES.CAPABILITY_REVOKED;
+    case 'not_yet_active':
+      return ENFORCEMENT_REASON_CODES.CAPABILITY_NOT_YET_ACTIVE;
+    case 'invalid':
+      return ENFORCEMENT_REASON_CODES.CAPABILITY_INVALID;
+    case 'active':
+      return ENFORCEMENT_REASON_CODES.ENFORCEMENT_ALLOW;
+    default:
+      return ENFORCEMENT_REASON_CODES.CAPABILITY_INVALID;
+  }
+}
+
+type DecisionContext = {
+  now: Date;
+  normalized_request?: NormalizedEnforcementRequest;
+  normalized_capability?: ProtocolCapability;
+  matched_scope?: NormalizedEnforcementRequest['requested_scope'];
+  matched_permissions?: string[];
+};
+
+export function buildDenyDecision(
+  reason_code: EnforcementReasonCode,
+  reasons: string[],
+  context: DecisionContext
+): EnforcementDecision {
+  return {
+    allowed: false,
+    decision: 'deny',
+    reason_code,
+    reasons,
+    evaluated_at: buildDecisionTimestamp(context.now),
+    normalized_request: context.normalized_request,
+    normalized_capability: context.normalized_capability,
+    matched_scope: context.matched_scope,
+    matched_permissions: context.matched_permissions,
+  };
+}
+
+export function buildAllowDecision(context: DecisionContext): EnforcementDecision {
+  return {
+    allowed: true,
+    decision: 'allow',
+    reason_code: ENFORCEMENT_REASON_CODES.ENFORCEMENT_ALLOW,
+    reasons: ['Enforcement checks passed.'],
+    evaluated_at: buildDecisionTimestamp(context.now),
+    normalized_request: context.normalized_request,
+    normalized_capability: context.normalized_capability,
+    matched_scope: context.matched_scope,
+    matched_permissions: context.matched_permissions,
+  };
+}

--- a/protocol/enforcement/enforcement-request.ts
+++ b/protocol/enforcement/enforcement-request.ts
@@ -1,0 +1,168 @@
+import { EnforcementRequestParseError } from './enforcement-errors';
+import type { EnforcementRequest, EnforcementResource, NormalizedEnforcementRequest } from './enforcement-types';
+import type { ScopeEntry } from '../consent/consent-types';
+import type { ProtocolCapability } from '../capability/capability-types';
+
+const VALID_SCOPE_TYPES = new Set<ScopeEntry['type']>(['field', 'content', 'pack']);
+
+function asRecord(input: unknown): Record<string, unknown> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new EnforcementRequestParseError('Enforcement request must be a non-null JSON object.');
+  }
+
+  return input as Record<string, unknown>;
+}
+
+function parseNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new EnforcementRequestParseError(`Enforcement field "${field}" must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function parseScopeEntry(input: unknown, index: number): ScopeEntry {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new EnforcementRequestParseError(`Enforcement scope entry ${index} must be a JSON object.`);
+  }
+
+  const record = input as Record<string, unknown>;
+  const type = parseNonEmptyString(record.type, `requested_scope[${index}].type`);
+  const ref = parseNonEmptyString(record.ref, `requested_scope[${index}].ref`).toLowerCase();
+
+  if (!VALID_SCOPE_TYPES.has(type as ScopeEntry['type'])) {
+    throw new EnforcementRequestParseError(`Enforcement scope entry ${index} has invalid type.`);
+  }
+
+  return {
+    type: type as ScopeEntry['type'],
+    ref,
+  };
+}
+
+function parseRequestedScope(value: unknown): ScopeEntry[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new EnforcementRequestParseError('Enforcement field "requested_scope" must be a non-empty array.');
+  }
+
+  return value.map((entry, index) => parseScopeEntry(entry, index));
+}
+
+function parseRequestedPermissions(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new EnforcementRequestParseError('Enforcement field "requested_permissions" must be a non-empty array.');
+  }
+
+  return value.map((permission, index) => {
+    if (typeof permission !== 'string' || permission.trim() === '') {
+      throw new EnforcementRequestParseError(`Enforcement permission ${index} must be a non-empty string.`);
+    }
+
+    return permission.trim().toLowerCase();
+  });
+}
+
+function parseOptionalBinding(record: Record<string, unknown>, field: 'subject' | 'grantee' | 'marketMakerId'): string | undefined {
+  if (!(field in record) || record[field] === undefined) {
+    return undefined;
+  }
+
+  return parseNonEmptyString(record[field], field);
+}
+
+function parseResource(value: unknown): EnforcementResource | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new EnforcementRequestParseError('Enforcement field "resource" must be an object or null when provided.');
+  }
+
+  const record = value as Record<string, unknown>;
+  const type = parseNonEmptyString(record.type, 'resource.type');
+  if (!VALID_SCOPE_TYPES.has(type as ScopeEntry['type'])) {
+    throw new EnforcementRequestParseError('Enforcement resource.type is invalid.');
+  }
+
+  return {
+    type: type as EnforcementResource['type'],
+    ref: parseNonEmptyString(record.ref, 'resource.ref').toLowerCase(),
+  };
+}
+
+function parseNow(value: unknown): Date | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new EnforcementRequestParseError('Enforcement field "now" must be a valid Date when provided.');
+  }
+
+  return value;
+}
+
+function parseActionContext(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new EnforcementRequestParseError('Enforcement field "action_context" must be a JSON object when provided.');
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export function parseEnforcementRequest(input: unknown): EnforcementRequest {
+  const record = asRecord(input);
+
+  if (!('capability' in record)) {
+    throw new EnforcementRequestParseError('Enforcement field "capability" is required.');
+  }
+
+  return {
+    capability: record.capability,
+    requested_scope: parseRequestedScope(record.requested_scope),
+    requested_permissions: parseRequestedPermissions(record.requested_permissions),
+    subject: parseOptionalBinding(record, 'subject'),
+    grantee: parseOptionalBinding(record, 'grantee'),
+    marketMakerId: parseOptionalBinding(record, 'marketMakerId'),
+    resource: parseResource(record.resource),
+    action_context: parseActionContext(record.action_context),
+    now: parseNow(record.now),
+    isRevoked:
+      typeof record.isRevoked === 'function'
+        ? (record.isRevoked as (capability: ProtocolCapability) => boolean)
+        : undefined,
+  };
+}
+
+function dedupeScope(scope: ScopeEntry[]): ScopeEntry[] {
+  const deduped = new Map<string, ScopeEntry>();
+  for (const entry of scope) {
+    deduped.set(`${entry.type}:${entry.ref}`, entry);
+  }
+
+  return [...deduped.values()].sort((a, b) => {
+    const typeCmp = a.type.localeCompare(b.type);
+    if (typeCmp !== 0) {
+      return typeCmp;
+    }
+
+    return a.ref.localeCompare(b.ref);
+  });
+}
+
+export function normalizeEnforcementRequest(input: EnforcementRequest): NormalizedEnforcementRequest {
+  return {
+    ...input,
+    requested_scope: dedupeScope(input.requested_scope),
+    requested_permissions: [...new Set(input.requested_permissions.map((permission) => permission.trim().toLowerCase()))].sort(),
+  };
+}

--- a/protocol/enforcement/enforcement-types.ts
+++ b/protocol/enforcement/enforcement-types.ts
@@ -1,0 +1,61 @@
+import type { ScopeEntry } from '../consent/consent-types';
+import type { ProtocolCapability } from '../capability/capability-types';
+
+export const ENFORCEMENT_REASON_CODES = {
+  CAPABILITY_INVALID: 'CAPABILITY_INVALID',
+  CAPABILITY_EXPIRED: 'CAPABILITY_EXPIRED',
+  CAPABILITY_REVOKED: 'CAPABILITY_REVOKED',
+  CAPABILITY_NOT_YET_ACTIVE: 'CAPABILITY_NOT_YET_ACTIVE',
+  SCOPE_NOT_ALLOWED: 'SCOPE_NOT_ALLOWED',
+  PERMISSION_NOT_ALLOWED: 'PERMISSION_NOT_ALLOWED',
+  SUBJECT_MISMATCH: 'SUBJECT_MISMATCH',
+  GRANTEE_MISMATCH: 'GRANTEE_MISMATCH',
+  MARKET_MAKER_MISMATCH: 'MARKET_MAKER_MISMATCH',
+  REQUEST_INVALID: 'REQUEST_INVALID',
+  ENFORCEMENT_ALLOW: 'ENFORCEMENT_ALLOW',
+} as const;
+
+export type EnforcementReasonCode = (typeof ENFORCEMENT_REASON_CODES)[keyof typeof ENFORCEMENT_REASON_CODES];
+
+export type EnforcementResource = {
+  type: 'field' | 'content' | 'pack';
+  ref: string;
+};
+
+export type EnforcementRequest = {
+  capability: unknown;
+  requested_scope: ScopeEntry[];
+  requested_permissions: string[];
+  subject?: string;
+  grantee?: string;
+  marketMakerId?: string;
+  resource?: EnforcementResource | null;
+  action_context?: Record<string, unknown>;
+  now?: Date;
+  isRevoked?: (capability: ProtocolCapability) => boolean;
+};
+
+export type NormalizedEnforcementRequest = {
+  capability: unknown;
+  requested_scope: ScopeEntry[];
+  requested_permissions: string[];
+  subject?: string;
+  grantee?: string;
+  marketMakerId?: string;
+  resource?: EnforcementResource | null;
+  action_context?: Record<string, unknown>;
+  now?: Date;
+  isRevoked?: (capability: ProtocolCapability) => boolean;
+};
+
+export type EnforcementDecision = {
+  allowed: boolean;
+  decision: 'allow' | 'deny';
+  reason_code: EnforcementReasonCode;
+  reasons: string[];
+  evaluated_at: string;
+  normalized_request?: NormalizedEnforcementRequest;
+  normalized_capability?: ProtocolCapability;
+  matched_scope?: ScopeEntry[];
+  matched_permissions?: string[];
+};

--- a/protocol/enforcement/index.ts
+++ b/protocol/enforcement/index.ts
@@ -1,0 +1,13 @@
+export { evaluateEnforcement } from './enforcement-engine';
+export { parseEnforcementRequest, normalizeEnforcementRequest } from './enforcement-request';
+export { buildAllowDecision, buildDenyDecision, mapCapabilityStateToReason } from './enforcement-policy';
+export { EnforcementRequestParseError } from './enforcement-errors';
+export { ENFORCEMENT_REASON_CODES } from './enforcement-types';
+
+export type {
+  EnforcementDecision,
+  EnforcementReasonCode,
+  EnforcementRequest,
+  EnforcementResource,
+  NormalizedEnforcementRequest,
+} from './enforcement-types';


### PR DESCRIPTION
### Motivation
- Conectar las primitivas de capability/consent con una capa de enforcement que emita decisiones canónicas y fail-closed antes de cualquier ejecución externa.
- Proveer lógica core que valide tokens, evalúe estado y aplique enforcement estricto de scope, permissions y bindings sin side effects ni dependencias externas.

### Description
- Añadido el módulo `protocol/enforcement` con tipos (`enforcement-types.ts`), errores (`enforcement-errors.ts`), parseo/normalización (`enforcement-request.ts`), construcción de decisiones (`enforcement-decision.ts`), helpers de policy (`enforcement-policy.ts`), motor principal (`enforcement-engine.ts`), exports (`index.ts`) y documentación (`README.md`).
- Implementada la API pública `evaluateEnforcement(request: EnforcementRequest): EnforcementDecision` que: parsea/normaliza, invoca `verifyCapability`, `evaluateCapabilityState` y `evaluateCapabilityAccess`, aplica checks de scope/permissions/subject/grantee/marketMakerId y devuelve un `EnforcementDecision` estructurado con reason codes canónicos.
- Separación clara entre engine (evaluación mecánica) y policy (mapeo de estados a reason codes y helpers `buildAllowDecision` / `buildDenyDecision`), con normalización determinista (dedupe/sort) y sin defaults permisivos.
- Exportado el módulo desde `protocol/enforcement/index.ts` y añadido al entrypoint raíz; creado suite de tests en `protocol/enforcement/__tests__/enforcementEngine.test.ts` que cubre los casos allow y todos los deny canónicos.

### Testing
- Ejecutado `npm test -- protocol/enforcement/__tests__/enforcementEngine.test.ts` y la suite pasó: enforcement tests 12 passed (12 total).
- Ejecutado combinado `npm test -- protocol/capability/__tests__/capabilityLifecycle.test.ts protocol/enforcement/__tests__/enforcementEngine.test.ts` y ambas suites pasaron: 2 test suites, 26 tests passed in total.
- Todas las pruebas automáticas relacionadas con capability + enforcement pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d923c15ac483258e88eb5873a1fa60)