### PR TITLE
Add protocol execution authorization handoff layer (PR4)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ export * from './storage';
 export * from './protocol/capabilities';
 export * from './protocol/consent';
 export * from './protocol/enforcement';
+export * from './protocol/execution';
 export * from './aoc/capabilities';
 export * from './aoc/sdk';
 export * from './interpreter';

--- a/protocol/execution/README.md
+++ b/protocol/execution/README.md
@@ -1,0 +1,41 @@
+# Protocol Execution Layer (PR4)
+
+Esta capa implementa el **handoff canónico de autorización de ejecución** entre AOC y market makers/adapters.
+
+## Qué hace
+
+- Recibe un `ExecutionRequest` canónico.
+- Normaliza y valida fail-closed el request.
+- Ejecuta evaluación contra `evaluateEnforcement(...)` como fuente única de decisión.
+- Devuelve un `ExecutionAuthorizationResult` estructurado.
+- Cuando autoriza, construye un `ExecutionContract` canónico para handoff a adapters externos.
+
+## Qué NO hace (en esta fase)
+
+- No ejecuta side effects reales.
+- No integra cloud providers.
+- No implementa networking/API REST.
+- No registra auditoría persistente.
+- No agrega colas, workers ni orchestration async.
+
+## Responsabilidades arquitectónicas
+
+- **AOC core protocol**: decide canónicamente si una ejecución está autorizada.
+- **Market makers/adapters**: ejecutan acciones reales fuera del core.
+- **Execution layer**: puente formal entre decisión protocolar y ejecución externa, sin centralizar runtime de side effects.
+
+## Contrato de salida
+
+Cuando `authorized = true`, el resultado incluye `execution_contract` con:
+
+- `adapter`
+- `operation`
+- `subject`
+- `grantee`
+- `allowed_scope`
+- `allowed_permissions`
+- `capability_hash`
+- `parent_consent_hash`
+- `issued_at`
+
+y opcionalmente `marketMakerId`, `resource`, `action_context`.

--- a/protocol/execution/__tests__/executionEngine.test.ts
+++ b/protocol/execution/__tests__/executionEngine.test.ts
@@ -1,0 +1,188 @@
+import { buildConsentObject } from '../../../consent';
+import { mintCapability } from '../../capability';
+import { ENFORCEMENT_REASON_CODES } from '../../enforcement';
+import { authorizeExecution } from '..';
+import { EXECUTION_REASON_CODES } from '../execution-types';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const REF_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function buildCapability() {
+  const consent = buildConsentObject(SUBJECT, GRANTEE, 'grant', [{ type: 'content', ref: REF_A }], ['read'], {
+    now: new Date('2026-01-01T00:00:00Z'),
+    expires_at: '2026-12-31T00:00:00Z',
+    marketMakerId: 'mm-01',
+  });
+
+  return mintCapability({
+    consent,
+    requested_scope: [{ type: 'content', ref: REF_A }],
+    requested_permissions: ['read'],
+    issued_at: '2026-02-01T00:00:00Z',
+    expires_at: '2026-03-01T00:00:00Z',
+    marketMakerId: 'mm-01',
+  });
+}
+
+describe('protocol execution authorization handoff', () => {
+  it('execution request válido + enforcement allow => authorized', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      marketMakerId: 'mm-01',
+      execution_target: { adapter: 'hrkey', operation: 'read_content' },
+      action_context: { workflow: 'access-request' },
+      payload: { correlationId: 'abc-123' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(true);
+    expect(result.decision).toBe('authorized');
+    expect(result.reason_code).toBe(EXECUTION_REASON_CODES.EXECUTION_AUTHORIZED);
+    expect(result.execution_target).toEqual({ adapter: 'hrkey', operation: 'read_content' });
+    expect(result.enforcement_decision).toBeDefined();
+    expect(result.enforcement_decision?.allowed).toBe(true);
+    expect(result.execution_contract).toBeDefined();
+    expect(result.execution_contract).toMatchObject({
+      adapter: 'hrkey',
+      operation: 'read_content',
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      allowed_scope: [{ type: 'content', ref: REF_A }],
+      allowed_permissions: ['read'],
+      marketMakerId: 'mm-01',
+    });
+  });
+
+  it('execution request inválido => rejected', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [],
+      requested_permissions: ['read'],
+      execution_target: { adapter: 'hrkey', operation: 'read_content' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    } as any);
+
+    expect(result.authorized).toBe(false);
+    expect(result.decision).toBe('rejected');
+    expect(result.reason_code).toBe(EXECUTION_REASON_CODES.EXECUTION_REQUEST_INVALID);
+    expect(result.execution_contract).toBeUndefined();
+  });
+
+  it('capability inválido => rejected', () => {
+    const result = authorizeExecution({
+      capability: {},
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      execution_target: { adapter: 'hrkey', operation: 'read_content' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(result.decision).toBe('rejected');
+    expect(result.reason_code).toBe(ENFORCEMENT_REASON_CODES.CAPABILITY_INVALID);
+    expect(result.enforcement_decision).toBeDefined();
+    expect(result.execution_contract).toBeUndefined();
+  });
+
+  it('enforcement expired => rejected', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      execution_target: { adapter: 'hrkey', operation: 'read_content' },
+      now: new Date('2026-04-01T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(result.reason_code).toBe(ENFORCEMENT_REASON_CODES.CAPABILITY_EXPIRED);
+  });
+
+  it('enforcement permission deny => rejected', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['write'],
+      execution_target: { adapter: 'hrkey', operation: 'write_content' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(result.reason_code).toBe(ENFORCEMENT_REASON_CODES.PERMISSION_NOT_ALLOWED);
+  });
+
+  it('enforcement subject mismatch => rejected', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      subject: 'did:key:z6MkDifferentSubject1234567890abc',
+      execution_target: { adapter: 'hrkey', operation: 'read_content' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(result.reason_code).toBe(ENFORCEMENT_REASON_CODES.SUBJECT_MISMATCH);
+  });
+
+  it('execution_target inválido => rejected', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      execution_target: { adapter: '', operation: 'read_content' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    } as any);
+
+    expect(result.authorized).toBe(false);
+    expect(result.reason_code).toBe(EXECUTION_REASON_CODES.EXECUTION_REQUEST_INVALID);
+  });
+
+  it('payload inválido => rejected', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      execution_target: { adapter: 'hrkey', operation: 'read_content' },
+      payload: 'invalid-payload',
+      now: new Date('2026-02-15T00:00:00Z'),
+    } as any);
+
+    expect(result.authorized).toBe(false);
+    expect(result.reason_code).toBe(EXECUTION_REASON_CODES.EXECUTION_REQUEST_INVALID);
+  });
+
+  it('authorization result incluye execution_contract cuando authorized', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['read'],
+      execution_target: { adapter: 'hrkey', operation: 'read_content' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(true);
+    expect(result.execution_contract).toBeDefined();
+    expect(result.execution_contract?.capability_hash).toHaveLength(64);
+    expect(result.execution_contract?.parent_consent_hash).toHaveLength(64);
+  });
+
+  it('authorization result NO incluye execution_contract válido cuando rejected', () => {
+    const result = authorizeExecution({
+      capability: buildCapability(),
+      requested_scope: [{ type: 'content', ref: REF_A }],
+      requested_permissions: ['write'],
+      execution_target: { adapter: 'hrkey', operation: 'write_content' },
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(result.execution_contract).toBeUndefined();
+    expect(result.execution_target).toEqual({ adapter: 'hrkey', operation: 'write_content' });
+    expect(result.enforcement_decision).toBeDefined();
+  });
+});

--- a/protocol/execution/execution-contract.ts
+++ b/protocol/execution/execution-contract.ts
@@ -1,0 +1,27 @@
+import type { ProtocolCapability } from '../capability/capability-types';
+import type { NormalizedExecutionRequest, ExecutionContract } from './execution-types';
+
+export type BuildExecutionContractInput = {
+  normalized_request: NormalizedExecutionRequest;
+  normalized_capability: ProtocolCapability;
+  issued_at: string;
+};
+
+export function buildExecutionContract(input: BuildExecutionContractInput): ExecutionContract {
+  const { normalized_request, normalized_capability, issued_at } = input;
+
+  return {
+    adapter: normalized_request.execution_target.adapter,
+    operation: normalized_request.execution_target.operation,
+    subject: normalized_capability.subject,
+    grantee: normalized_capability.grantee,
+    allowed_scope: normalized_request.requested_scope,
+    allowed_permissions: normalized_request.requested_permissions,
+    capability_hash: normalized_capability.capability_hash,
+    parent_consent_hash: normalized_capability.parent_consent_hash,
+    ...(normalized_request.marketMakerId !== undefined ? { marketMakerId: normalized_request.marketMakerId } : {}),
+    ...(normalized_request.resource !== undefined ? { resource: normalized_request.resource } : {}),
+    ...(normalized_request.action_context !== undefined ? { action_context: normalized_request.action_context } : {}),
+    issued_at,
+  };
+}

--- a/protocol/execution/execution-engine.ts
+++ b/protocol/execution/execution-engine.ts
@@ -1,0 +1,74 @@
+import { evaluateEnforcement } from '../enforcement/enforcement-engine';
+import { EXECUTION_REASON_CODES } from './execution-types';
+import type { ExecutionAuthorizationResult, ExecutionRequest } from './execution-types';
+import { parseExecutionRequest, normalizeExecutionRequest } from './execution-request';
+import { buildExecutionContract } from './execution-contract';
+import { buildAuthorizedExecutionResult, buildRejectedExecutionResult } from './execution-result';
+
+function resolveExecutionTarget(input: unknown): { adapter: string; operation: string } {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return { adapter: 'unknown', operation: 'unknown' };
+  }
+
+  const record = input as Record<string, unknown>;
+  return {
+    adapter: typeof record.adapter === 'string' && record.adapter.trim() !== '' ? record.adapter.trim() : 'unknown',
+    operation:
+      typeof record.operation === 'string' && record.operation.trim() !== '' ? record.operation.trim() : 'unknown',
+  };
+}
+
+export function authorizeExecution(request: ExecutionRequest): ExecutionAuthorizationResult {
+  const now = request.now ?? new Date();
+  const fallbackTarget = resolveExecutionTarget((request as unknown as { execution_target?: unknown }).execution_target);
+
+  let normalizedRequest;
+  try {
+    normalizedRequest = normalizeExecutionRequest(parseExecutionRequest(request));
+  } catch (error) {
+    return buildRejectedExecutionResult({
+      reason_code: EXECUTION_REASON_CODES.EXECUTION_REQUEST_INVALID,
+      reasons: [error instanceof Error ? error.message : 'Execution request parsing failed.'],
+      now,
+      execution_target: fallbackTarget,
+    });
+  }
+
+  const enforcementDecision = evaluateEnforcement({
+    capability: normalizedRequest.capability,
+    requested_scope: normalizedRequest.requested_scope,
+    requested_permissions: normalizedRequest.requested_permissions,
+    subject: normalizedRequest.subject,
+    grantee: normalizedRequest.grantee,
+    marketMakerId: normalizedRequest.marketMakerId,
+    resource: normalizedRequest.resource,
+    action_context: normalizedRequest.action_context,
+    now: normalizedRequest.now ?? now,
+    isRevoked: normalizedRequest.isRevoked,
+  });
+
+  if (!enforcementDecision.allowed || enforcementDecision.normalized_capability === undefined) {
+    return buildRejectedExecutionResult({
+      reason_code: enforcementDecision.reason_code,
+      reasons: enforcementDecision.reasons,
+      now,
+      execution_target: normalizedRequest.execution_target,
+      normalized_request: normalizedRequest,
+      enforcement_decision: enforcementDecision,
+    });
+  }
+
+  const executionContract = buildExecutionContract({
+    normalized_request: normalizedRequest,
+    normalized_capability: enforcementDecision.normalized_capability,
+    issued_at: now.toISOString(),
+  });
+
+  return buildAuthorizedExecutionResult({
+    now,
+    execution_target: normalizedRequest.execution_target,
+    normalized_request: normalizedRequest,
+    enforcement_decision: enforcementDecision,
+    execution_contract: executionContract,
+  });
+}

--- a/protocol/execution/execution-errors.ts
+++ b/protocol/execution/execution-errors.ts
@@ -1,0 +1,6 @@
+export class ExecutionRequestParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExecutionRequestParseError';
+  }
+}

--- a/protocol/execution/execution-request.ts
+++ b/protocol/execution/execution-request.ts
@@ -1,0 +1,151 @@
+import type { ScopeEntry } from '../consent/consent-types';
+import type { ProtocolCapability } from '../capability/capability-types';
+import { parseEnforcementRequest, normalizeEnforcementRequest } from '../enforcement/enforcement-request';
+import type { ExecutionRequest, ExecutionResource, ExecutionTarget, NormalizedExecutionRequest } from './execution-types';
+import { ExecutionRequestParseError } from './execution-errors';
+
+const VALID_SCOPE_TYPES = new Set<ScopeEntry['type']>(['field', 'content', 'pack']);
+
+function asRecord(input: unknown): Record<string, unknown> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new ExecutionRequestParseError('Execution request must be a non-null JSON object.');
+  }
+
+  return input as Record<string, unknown>;
+}
+
+function parseNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new ExecutionRequestParseError(`Execution field "${field}" must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function parseOptionalBinding(record: Record<string, unknown>, field: 'subject' | 'grantee' | 'marketMakerId'): string | undefined {
+  if (!(field in record) || record[field] === undefined) {
+    return undefined;
+  }
+
+  return parseNonEmptyString(record[field], field);
+}
+
+function parseResource(value: unknown): ExecutionResource | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new ExecutionRequestParseError('Execution field "resource" must be an object or null when provided.');
+  }
+
+  const record = value as Record<string, unknown>;
+  const type = parseNonEmptyString(record.type, 'resource.type');
+  if (!VALID_SCOPE_TYPES.has(type as ScopeEntry['type'])) {
+    throw new ExecutionRequestParseError('Execution resource.type is invalid.');
+  }
+
+  return {
+    type: type as ExecutionResource['type'],
+    ref: parseNonEmptyString(record.ref, 'resource.ref').toLowerCase(),
+  };
+}
+
+function parseExecutionTarget(value: unknown): ExecutionTarget {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new ExecutionRequestParseError('Execution field "execution_target" must be a JSON object.');
+  }
+
+  const record = value as Record<string, unknown>;
+  return {
+    adapter: parseNonEmptyString(record.adapter, 'execution_target.adapter'),
+    operation: parseNonEmptyString(record.operation, 'execution_target.operation'),
+  };
+}
+
+function parseActionContext(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new ExecutionRequestParseError('Execution field "action_context" must be a JSON object when provided.');
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function parsePayload(value: unknown): Record<string, unknown> | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new ExecutionRequestParseError('Execution field "payload" must be a JSON object or null when provided.');
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function parseNow(value: unknown): Date | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new ExecutionRequestParseError('Execution field "now" must be a valid Date when provided.');
+  }
+
+  return value;
+}
+
+export function parseExecutionRequest(input: unknown): ExecutionRequest {
+  const record = asRecord(input);
+
+  if (!('capability' in record)) {
+    throw new ExecutionRequestParseError('Execution field "capability" is required.');
+  }
+
+  const parsedEnforcement = parseEnforcementRequest({
+    capability: record.capability,
+    requested_scope: record.requested_scope,
+    requested_permissions: record.requested_permissions,
+    subject: parseOptionalBinding(record, 'subject'),
+    grantee: parseOptionalBinding(record, 'grantee'),
+    marketMakerId: parseOptionalBinding(record, 'marketMakerId'),
+    resource: parseResource(record.resource),
+    action_context: parseActionContext(record.action_context),
+    now: parseNow(record.now),
+    isRevoked:
+      typeof record.isRevoked === 'function'
+        ? (record.isRevoked as (capability: ProtocolCapability) => boolean)
+        : undefined,
+  });
+
+  return {
+    ...parsedEnforcement,
+    execution_target: parseExecutionTarget(record.execution_target),
+    payload: parsePayload(record.payload),
+  };
+}
+
+export function normalizeExecutionRequest(input: ExecutionRequest): NormalizedExecutionRequest {
+  const normalizedEnforcement = normalizeEnforcementRequest(input);
+
+  return {
+    ...normalizedEnforcement,
+    execution_target: {
+      adapter: input.execution_target.adapter.trim(),
+      operation: input.execution_target.operation.trim(),
+    },
+    payload: input.payload,
+  };
+}

--- a/protocol/execution/execution-result.ts
+++ b/protocol/execution/execution-result.ts
@@ -1,0 +1,78 @@
+import type { EnforcementDecision } from '../enforcement/enforcement-types';
+import { EXECUTION_REASON_CODES } from './execution-types';
+import type {
+  ExecutionAuthorizationResult,
+  ExecutionContract,
+  ExecutionReasonCode,
+  ExecutionTarget,
+  NormalizedExecutionRequest,
+} from './execution-types';
+
+export type BuildExecutionAuthorizationResultInput = {
+  authorized: boolean;
+  reason_code: ExecutionReasonCode;
+  reasons: string[];
+  evaluated_at: string;
+  execution_target: ExecutionTarget;
+  normalized_request?: NormalizedExecutionRequest;
+  enforcement_decision?: EnforcementDecision;
+  execution_contract?: ExecutionContract;
+  authorization_token?: string | null;
+};
+
+export function buildExecutionAuthorizationResult(
+  input: BuildExecutionAuthorizationResultInput
+): ExecutionAuthorizationResult {
+  return {
+    authorized: input.authorized,
+    decision: input.authorized ? 'authorized' : 'rejected',
+    reason_code: input.reason_code,
+    reasons: input.reasons,
+    evaluated_at: input.evaluated_at,
+    execution_target: input.execution_target,
+    ...(input.normalized_request !== undefined ? { normalized_request: input.normalized_request } : {}),
+    ...(input.enforcement_decision !== undefined ? { enforcement_decision: input.enforcement_decision } : {}),
+    ...(input.execution_contract !== undefined ? { execution_contract: input.execution_contract } : {}),
+    authorization_token: input.authorization_token ?? null,
+  };
+}
+
+export function buildRejectedExecutionResult(input: {
+  reason_code: ExecutionReasonCode;
+  reasons: string[];
+  now: Date;
+  execution_target: ExecutionTarget;
+  normalized_request?: NormalizedExecutionRequest;
+  enforcement_decision?: EnforcementDecision;
+}): ExecutionAuthorizationResult {
+  return buildExecutionAuthorizationResult({
+    authorized: false,
+    reason_code: input.reason_code,
+    reasons: input.reasons,
+    evaluated_at: input.now.toISOString(),
+    execution_target: input.execution_target,
+    normalized_request: input.normalized_request,
+    enforcement_decision: input.enforcement_decision,
+    authorization_token: null,
+  });
+}
+
+export function buildAuthorizedExecutionResult(input: {
+  now: Date;
+  execution_target: ExecutionTarget;
+  normalized_request: NormalizedExecutionRequest;
+  enforcement_decision: EnforcementDecision;
+  execution_contract: ExecutionContract;
+}): ExecutionAuthorizationResult {
+  return buildExecutionAuthorizationResult({
+    authorized: true,
+    reason_code: EXECUTION_REASON_CODES.EXECUTION_AUTHORIZED,
+    reasons: ['Execution request authorized by canonical enforcement runtime.'],
+    evaluated_at: input.now.toISOString(),
+    execution_target: input.execution_target,
+    normalized_request: input.normalized_request,
+    enforcement_decision: input.enforcement_decision,
+    execution_contract: input.execution_contract,
+    authorization_token: null,
+  });
+}

--- a/protocol/execution/execution-types.ts
+++ b/protocol/execution/execution-types.ts
@@ -1,0 +1,93 @@
+import type { ScopeEntry } from '../consent/consent-types';
+import type { ProtocolCapability } from '../capability/capability-types';
+import type { EnforcementDecision, EnforcementReasonCode } from '../enforcement/enforcement-types';
+
+export const EXECUTION_REASON_CODES = {
+  ...{
+    CAPABILITY_INVALID: 'CAPABILITY_INVALID',
+    CAPABILITY_EXPIRED: 'CAPABILITY_EXPIRED',
+    CAPABILITY_REVOKED: 'CAPABILITY_REVOKED',
+    CAPABILITY_NOT_YET_ACTIVE: 'CAPABILITY_NOT_YET_ACTIVE',
+    SCOPE_NOT_ALLOWED: 'SCOPE_NOT_ALLOWED',
+    PERMISSION_NOT_ALLOWED: 'PERMISSION_NOT_ALLOWED',
+    SUBJECT_MISMATCH: 'SUBJECT_MISMATCH',
+    GRANTEE_MISMATCH: 'GRANTEE_MISMATCH',
+    MARKET_MAKER_MISMATCH: 'MARKET_MAKER_MISMATCH',
+    REQUEST_INVALID: 'REQUEST_INVALID',
+  },
+  EXECUTION_REQUEST_INVALID: 'EXECUTION_REQUEST_INVALID',
+  EXECUTION_AUTHORIZED: 'EXECUTION_AUTHORIZED',
+} as const;
+
+export type ExecutionReasonCode =
+  | EnforcementReasonCode
+  | (typeof EXECUTION_REASON_CODES)['EXECUTION_REQUEST_INVALID']
+  | (typeof EXECUTION_REASON_CODES)['EXECUTION_AUTHORIZED'];
+
+export type ExecutionResource = {
+  type: 'field' | 'content' | 'pack';
+  ref: string;
+};
+
+export type ExecutionTarget = {
+  adapter: string;
+  operation: string;
+};
+
+export type ExecutionRequest = {
+  capability: unknown;
+  requested_scope: ScopeEntry[];
+  requested_permissions: string[];
+  subject?: string;
+  grantee?: string;
+  marketMakerId?: string;
+  resource?: ExecutionResource | null;
+  execution_target: ExecutionTarget;
+  action_context?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
+  now?: Date;
+  isRevoked?: (capability: ProtocolCapability) => boolean;
+};
+
+export type NormalizedExecutionRequest = {
+  capability: unknown;
+  requested_scope: ScopeEntry[];
+  requested_permissions: string[];
+  subject?: string;
+  grantee?: string;
+  marketMakerId?: string;
+  resource?: ExecutionResource | null;
+  execution_target: ExecutionTarget;
+  action_context?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
+  now?: Date;
+  isRevoked?: (capability: ProtocolCapability) => boolean;
+};
+
+export type ExecutionContract = {
+  adapter: string;
+  operation: string;
+  subject: string;
+  grantee: string;
+  allowed_scope: ScopeEntry[];
+  allowed_permissions: string[];
+  capability_hash: string;
+  parent_consent_hash: string;
+  marketMakerId?: string;
+  resource?: ExecutionResource | null;
+  action_context?: Record<string, unknown>;
+  issued_at: string;
+};
+
+export type ExecutionAuthorizationResult = {
+  authorized: boolean;
+  decision: 'authorized' | 'rejected';
+  reason_code: ExecutionReasonCode;
+  reasons: string[];
+  evaluated_at: string;
+  execution_target: ExecutionTarget;
+  normalized_request?: NormalizedExecutionRequest;
+  enforcement_decision?: EnforcementDecision;
+  execution_contract?: ExecutionContract;
+  authorization_token?: string | null;
+};

--- a/protocol/execution/index.ts
+++ b/protocol/execution/index.ts
@@ -1,0 +1,20 @@
+export { authorizeExecution } from './execution-engine';
+export { parseExecutionRequest, normalizeExecutionRequest } from './execution-request';
+export { buildExecutionContract } from './execution-contract';
+export {
+  buildExecutionAuthorizationResult,
+  buildAuthorizedExecutionResult,
+  buildRejectedExecutionResult,
+} from './execution-result';
+export { ExecutionRequestParseError } from './execution-errors';
+export { EXECUTION_REASON_CODES } from './execution-types';
+
+export type {
+  ExecutionAuthorizationResult,
+  ExecutionContract,
+  ExecutionReasonCode,
+  ExecutionRequest,
+  ExecutionResource,
+  ExecutionTarget,
+  NormalizedExecutionRequest,
+} from './execution-types';


### PR DESCRIPTION
### Motivation

- Definir una capa protocolar que convierta decisiones canónicas en un handoff claro hacia market makers/adapters sin ejecutar side effects en el core. 
- Mantener a `evaluateEnforcement(...)` como fuente única de verdad para lifecycle, scope y permisos y garantizar un comportamiento fail-closed en ambigüedades.

### Description

- Se agrega el módulo `protocol/execution` con modelos canónicos y tipos en `execution-types.ts` que definen `ExecutionRequest`, `ExecutionAuthorizationResult` y `ExecutionContract` y códigos de razón explícitos. 
- Se implementan parseo y normalización strict fail-closed en `execution-request.ts` con validaciones para `execution_target`, `requested_scope`, `requested_permissions`, `payload`, `action_context`, `now` y bindings. 
- Se implementa el motor `authorizeExecution` en `execution-engine.ts` que hace: parse/normalize → delega a `evaluateEnforcement(...)` → si permite construye `ExecutionContract` (con `buildExecutionContract`) y devuelve un `ExecutionAuthorizationResult`, y si no permite devuelve un resultado `rejected` alineado con la decisión de enforcement. 
- Se añaden helpers para construir resultados y contratos en `execution-result.ts` y `execution-contract.ts`, documentación en `README.md` y exportación desde `protocol/execution/index.ts` y desde el entrypoint raíz `index.ts`.

### Testing

- Se añadió `protocol/execution/__tests__/executionEngine.test.ts` y se ejecutó `npm test -- protocol/execution/__tests__/executionEngine.test.ts` como suite automatizada. 
- Resultado: todos los tests pasaron (`10/10` tests OK) cubriendo allow, request inválido, capability inválido, expired, permission deny, subject mismatch, execution_target inválido, payload inválido y la presencia/ausencia del `execution_contract` en los resultados autorizados/rechazados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92923a6c48325b341fd8d92ed51c7)