### PR TITLE
feat(protocol): add optional adapter identity + in-memory registry

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ export * from './protocol/capabilities';
 export * from './protocol/consent';
 export * from './protocol/enforcement';
 export * from './protocol/execution';
+export * from './protocol/adapters';
 export * from './aoc/capabilities';
 export * from './aoc/sdk';
 export * from './interpreter';

--- a/protocol/adapters/README.md
+++ b/protocol/adapters/README.md
@@ -1,0 +1,54 @@
+# AOC Adapter Identity + Optional Registry
+
+This module defines the canonical adapter identity model for AOC and provides an **official but optional** in-memory adapter registry.
+
+## Permissionless by design
+
+- AOC remains an open, permissionless protocol.
+- No adapter registration is required to use consent, capability lifecycle, enforcement, or execution flows.
+- This registry is an ecosystem utility layer for discovery, metadata, and trust signaling.
+
+## Why this optional registry exists
+
+The official registry layer is intended for:
+
+- discovery of known adapters in the AOC ecosystem
+- standardized metadata
+- trust signals (`declared`, `verified`, `revoked`)
+- future compliance overlays
+- future hosted/official AOC infrastructure
+
+It is **not** a protocol gatekeeper.
+
+## Status semantics
+
+- `declared`: adapter record is declared, but not automatically trusted.
+- `verified`: adapter has a positive verification signal from the official registry.
+- `revoked`: adapter status is revoked in this registry context; protocol primitives can still exist independently.
+
+## Notes for integrators
+
+- You can run AOC integrations without this registry.
+- You can run your own private/public adapter index.
+- Using the official registry does not invalidate adapters that are outside of it.
+
+## Current scope
+
+This PR intentionally includes only core identity + optional registry model:
+
+- canonical adapter type (`AOCAdapterRecord`)
+- parse/normalize/validate (fail-closed)
+- in-memory optional registry
+- simple filtering and resolution
+- policy helpers
+
+Explicitly out of scope for now:
+
+- human approval workflows
+- billing and API keys
+- network transport and auth
+- persistent databases
+- dashboards
+- advanced governance
+- dynamic reputation scoring
+- cryptographic certification workflows

--- a/protocol/adapters/__tests__/adapterRegistry.test.ts
+++ b/protocol/adapters/__tests__/adapterRegistry.test.ts
@@ -1,0 +1,173 @@
+import {
+  createAdapterRegistry,
+  isAdapterOfficial,
+  isAdapterUsable,
+  isAdapterVerified,
+  parseAdapterRecord,
+  supportsOperation,
+  supportsScopeType,
+} from '../index';
+
+const BASE_RECORD = {
+  adapter_id: 'adapter-1',
+  display_name: 'Adapter One',
+  adapter_type: 'market_maker' as const,
+  owner_did: 'did:web:aoc.example',
+  marketMakerId: 'mm-1',
+  supported_operations: ['store', 'execute'],
+  supported_scope_types: ['field', 'content'] as const,
+  endpoint_url: 'https://adapter.one/api',
+  documentation_url: 'https://adapter.one/docs',
+  status: 'declared' as const,
+  registry_source: 'official_aoc' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  metadata: { region: 'us' },
+};
+
+describe('adapter registry (optional layer)', () => {
+  it('registers a valid adapter', () => {
+    const registry = createAdapterRegistry();
+    const result = registry.registerAdapter(BASE_RECORD);
+
+    expect(result.adapter_id).toBe('adapter-1');
+    expect(result.status).toBe('declared');
+  });
+
+  it('rejects duplicate adapter_id', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter(BASE_RECORD);
+
+    expect(() => registry.registerAdapter(BASE_RECORD)).toThrow(/already registered/i);
+  });
+
+  it('fails invalid adapter payload', () => {
+    expect(() =>
+      parseAdapterRecord({
+        ...BASE_RECORD,
+        adapter_id: '',
+      }),
+    ).toThrow(/adapter_id/i);
+  });
+
+  it('gets adapter by id when present', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter(BASE_RECORD);
+
+    const result = registry.getAdapterById('adapter-1');
+
+    expect(result).not.toBeNull();
+    expect(result?.display_name).toBe('Adapter One');
+  });
+
+  it('returns null when adapter is missing', () => {
+    const registry = createAdapterRegistry();
+
+    expect(registry.getAdapterById('missing')).toBeNull();
+  });
+
+  it('lists adapters without filters', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter(BASE_RECORD);
+    registry.registerAdapter({
+      ...BASE_RECORD,
+      adapter_id: 'adapter-2',
+      display_name: 'Adapter Two',
+      adapter_type: 'executor',
+      status: 'verified',
+      registry_source: 'self_declared',
+    });
+
+    expect(registry.listAdapters()).toHaveLength(2);
+  });
+
+  it('lists adapters by status filter', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter(BASE_RECORD);
+    registry.registerAdapter({
+      ...BASE_RECORD,
+      adapter_id: 'adapter-2',
+      status: 'verified',
+      adapter_type: 'executor',
+    });
+
+    const filtered = registry.listAdapters({ status: 'verified' });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].adapter_id).toBe('adapter-2');
+  });
+
+  it('lists adapters by adapter_type filter', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter(BASE_RECORD);
+    registry.registerAdapter({
+      ...BASE_RECORD,
+      adapter_id: 'adapter-2',
+      adapter_type: 'executor',
+    });
+
+    const filtered = registry.listAdapters({ adapter_type: 'market_maker' });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].adapter_id).toBe('adapter-1');
+  });
+
+  it('updates status from declared to verified', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter(BASE_RECORD);
+
+    const updated = registry.updateAdapterStatus('adapter-1', 'verified');
+
+    expect(updated.status).toBe('verified');
+  });
+
+  it('updates status from verified to revoked', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter({
+      ...BASE_RECORD,
+      status: 'verified',
+    });
+
+    const updated = registry.updateAdapterStatus('adapter-1', 'revoked');
+
+    expect(updated.status).toBe('revoked');
+  });
+
+  it('fails invalid status transition', () => {
+    const registry = createAdapterRegistry();
+    registry.registerAdapter({
+      ...BASE_RECORD,
+      status: 'revoked',
+    });
+
+    expect(() => registry.updateAdapterStatus('adapter-1', 'verified')).toThrow(
+      /invalid status transition/i,
+    );
+  });
+
+  it('resolveAdapter returns null when missing', () => {
+    const registry = createAdapterRegistry();
+
+    expect(registry.resolveAdapter('not-found')).toBeNull();
+  });
+
+  it('policy helpers return expected values', () => {
+    const revoked = parseAdapterRecord({
+      ...BASE_RECORD,
+      status: 'revoked',
+      registry_source: 'self_declared',
+    });
+
+    const verified = parseAdapterRecord({
+      ...BASE_RECORD,
+      status: 'verified',
+      registry_source: 'official_aoc',
+    });
+
+    expect(isAdapterUsable(revoked)).toBe(false);
+    expect(isAdapterVerified(verified)).toBe(true);
+    expect(isAdapterOfficial(verified)).toBe(true);
+    expect(supportsOperation(verified, 'execute')).toBe(true);
+    expect(supportsScopeType(verified, 'field')).toBe(true);
+  });
+});

--- a/protocol/adapters/adapter-errors.ts
+++ b/protocol/adapters/adapter-errors.ts
@@ -1,0 +1,20 @@
+export class AdapterParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AdapterParseError';
+  }
+}
+
+export class AdapterValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AdapterValidationError';
+  }
+}
+
+export class AdapterRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AdapterRegistryError';
+  }
+}

--- a/protocol/adapters/adapter-object.ts
+++ b/protocol/adapters/adapter-object.ts
@@ -1,0 +1,154 @@
+import type { AOCAdapterRecord, AdapterRecordInput } from './adapter-types';
+import {
+  ADAPTER_REGISTRY_SOURCES,
+  ADAPTER_SCOPE_TYPES,
+  ADAPTER_STATUS,
+  ADAPTER_TYPES,
+} from './adapter-types';
+import { AdapterParseError, AdapterValidationError } from './adapter-errors';
+
+const ISO8601_UTC_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
+const DID_PATTERN = /^did:[a-z0-9]+:[a-zA-Z0-9._:%-]+$/;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isISOStringUtc(value: string): boolean {
+  if (!ISO8601_UTC_PATTERN.test(value)) {
+    return false;
+  }
+
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 19) + 'Z' === value;
+}
+
+function assertStringArray(value: unknown, fieldName: string): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new AdapterParseError(`${fieldName} must be a non-empty array.`);
+  }
+
+  const normalized = value.map((entry, index) => {
+    if (!isNonEmptyString(entry)) {
+      throw new AdapterParseError(`${fieldName}[${index}] must be a non-empty string.`);
+    }
+    return entry.trim();
+  });
+
+  return Array.from(new Set(normalized));
+}
+
+export function parseAdapterRecord(input: unknown): AOCAdapterRecord {
+  if (!isObject(input)) {
+    throw new AdapterParseError('Adapter record must be an object.');
+  }
+
+  const record = input as AdapterRecordInput;
+
+  if (!isNonEmptyString(record.adapter_id)) {
+    throw new AdapterParseError('adapter_id must be a non-empty string.');
+  }
+  if (!isNonEmptyString(record.display_name)) {
+    throw new AdapterParseError('display_name must be a non-empty string.');
+  }
+  if (!isNonEmptyString(record.adapter_type) || !ADAPTER_TYPES.includes(record.adapter_type)) {
+    throw new AdapterParseError('adapter_type is invalid.');
+  }
+
+  const supportedOperations = assertStringArray(record.supported_operations, 'supported_operations');
+
+  if (!Array.isArray(record.supported_scope_types) || record.supported_scope_types.length === 0) {
+    throw new AdapterParseError('supported_scope_types must be a non-empty array.');
+  }
+
+  const supportedScopeTypes = Array.from(new Set(record.supported_scope_types)).map((scopeType, index) => {
+    if (typeof scopeType !== 'string' || !ADAPTER_SCOPE_TYPES.includes(scopeType)) {
+      throw new AdapterParseError(`supported_scope_types[${index}] is invalid.`);
+    }
+    return scopeType;
+  });
+
+  if (!isNonEmptyString(record.status) || !ADAPTER_STATUS.includes(record.status)) {
+    throw new AdapterParseError('status is invalid.');
+  }
+
+  if (
+    !isNonEmptyString(record.registry_source) ||
+    !ADAPTER_REGISTRY_SOURCES.includes(record.registry_source)
+  ) {
+    throw new AdapterParseError('registry_source is invalid.');
+  }
+
+  if (!isNonEmptyString(record.created_at) || !isISOStringUtc(record.created_at)) {
+    throw new AdapterParseError('created_at must be ISO8601 UTC with second precision.');
+  }
+
+  if (!isNonEmptyString(record.updated_at) || !isISOStringUtc(record.updated_at)) {
+    throw new AdapterParseError('updated_at must be ISO8601 UTC with second precision.');
+  }
+
+  if (record.owner_did !== undefined) {
+    if (!isNonEmptyString(record.owner_did) || !DID_PATTERN.test(record.owner_did.trim())) {
+      throw new AdapterParseError('owner_did must be a valid DID.');
+    }
+  }
+
+  if (record.marketMakerId !== undefined && !isNonEmptyString(record.marketMakerId)) {
+    throw new AdapterParseError('marketMakerId must be a non-empty string when provided.');
+  }
+
+  if (record.endpoint_url !== undefined && !isNonEmptyString(record.endpoint_url)) {
+    throw new AdapterParseError('endpoint_url must be a non-empty string when provided.');
+  }
+
+  if (record.documentation_url !== undefined && !isNonEmptyString(record.documentation_url)) {
+    throw new AdapterParseError('documentation_url must be a non-empty string when provided.');
+  }
+
+  if (record.metadata !== undefined && !isObject(record.metadata)) {
+    throw new AdapterParseError('metadata must be an object when provided.');
+  }
+
+  return {
+    adapter_id: record.adapter_id.trim(),
+    display_name: record.display_name.trim(),
+    adapter_type: record.adapter_type,
+    owner_did: record.owner_did?.trim(),
+    marketMakerId: record.marketMakerId?.trim(),
+    supported_operations: supportedOperations,
+    supported_scope_types: supportedScopeTypes,
+    endpoint_url: record.endpoint_url?.trim(),
+    documentation_url: record.documentation_url?.trim(),
+    status: record.status,
+    registry_source: record.registry_source,
+    created_at: record.created_at,
+    updated_at: record.updated_at,
+    metadata: record.metadata,
+  };
+}
+
+export function normalizeAdapterRecord(record: AOCAdapterRecord): AOCAdapterRecord {
+  return {
+    ...record,
+    adapter_id: record.adapter_id.trim(),
+    display_name: record.display_name.trim(),
+    owner_did: record.owner_did?.trim(),
+    marketMakerId: record.marketMakerId?.trim(),
+    endpoint_url: record.endpoint_url?.trim(),
+    documentation_url: record.documentation_url?.trim(),
+    supported_operations: Array.from(new Set(record.supported_operations.map((op) => op.trim()))),
+    supported_scope_types: Array.from(new Set(record.supported_scope_types)),
+  };
+}
+
+export function validateAdapterRecord(record: AOCAdapterRecord): void {
+  const parsed = parseAdapterRecord(record);
+
+  if (parsed.updated_at < parsed.created_at) {
+    throw new AdapterValidationError('updated_at must be greater than or equal to created_at.');
+  }
+}

--- a/protocol/adapters/adapter-policy.ts
+++ b/protocol/adapters/adapter-policy.ts
@@ -1,0 +1,21 @@
+import type { AOCAdapterRecord, AdapterScopeType } from './adapter-types';
+
+export function isAdapterUsable(adapter: AOCAdapterRecord): boolean {
+  return adapter.status !== 'revoked';
+}
+
+export function isAdapterVerified(adapter: AOCAdapterRecord): boolean {
+  return adapter.status === 'verified';
+}
+
+export function isAdapterOfficial(adapter: AOCAdapterRecord): boolean {
+  return adapter.registry_source === 'official_aoc';
+}
+
+export function supportsOperation(adapter: AOCAdapterRecord, operation: string): boolean {
+  return adapter.supported_operations.includes(operation);
+}
+
+export function supportsScopeType(adapter: AOCAdapterRecord, scopeType: AdapterScopeType): boolean {
+  return adapter.supported_scope_types.includes(scopeType);
+}

--- a/protocol/adapters/adapter-registry.ts
+++ b/protocol/adapters/adapter-registry.ts
@@ -1,0 +1,113 @@
+import { normalizeAdapterRecord, parseAdapterRecord, validateAdapterRecord } from './adapter-object';
+import { AdapterRegistryError } from './adapter-errors';
+import type {
+  AOCAdapterRecord,
+  AdapterListFilters,
+  AdapterRegistry,
+  AdapterStatus,
+} from './adapter-types';
+import { resolveAdapter as resolveAdapterWith } from './adapter-resolution';
+
+const ALLOWED_STATUS_TRANSITIONS: Record<AdapterStatus, AdapterStatus[]> = {
+  declared: ['verified', 'revoked'],
+  verified: ['revoked'],
+  revoked: [],
+};
+
+function cloneRecord(record: AOCAdapterRecord): AOCAdapterRecord {
+  return {
+    ...record,
+    supported_operations: [...record.supported_operations],
+    supported_scope_types: [...record.supported_scope_types],
+    metadata: record.metadata ? { ...record.metadata } : undefined,
+  };
+}
+
+// Official AOC registry utility. Optional layer: protocol primitives must work without this registry.
+export function createAdapterRegistry(): AdapterRegistry {
+  const adaptersById = new Map<string, AOCAdapterRecord>();
+
+  function registerAdapter(record: unknown): AOCAdapterRecord {
+    const parsed = parseAdapterRecord(record);
+    validateAdapterRecord(parsed);
+    const normalized = normalizeAdapterRecord(parsed);
+
+    if (adaptersById.has(normalized.adapter_id)) {
+      throw new AdapterRegistryError(`Adapter ${normalized.adapter_id} is already registered.`);
+    }
+
+    adaptersById.set(normalized.adapter_id, normalized);
+    return cloneRecord(normalized);
+  }
+
+  function getAdapterById(adapterId: string): AOCAdapterRecord | null {
+    const adapter = adaptersById.get(adapterId);
+    return adapter ? cloneRecord(adapter) : null;
+  }
+
+  function listAdapters(filters?: AdapterListFilters): AOCAdapterRecord[] {
+    const adapters = [...adaptersById.values()];
+
+    return adapters
+      .filter((adapter) => {
+        if (!filters) {
+          return true;
+        }
+
+        if (filters.status !== undefined && adapter.status !== filters.status) {
+          return false;
+        }
+
+        if (filters.adapter_type !== undefined && adapter.adapter_type !== filters.adapter_type) {
+          return false;
+        }
+
+        if (
+          filters.registry_source !== undefined &&
+          adapter.registry_source !== filters.registry_source
+        ) {
+          return false;
+        }
+
+        return true;
+      })
+      .map((adapter) => cloneRecord(adapter));
+  }
+
+  function updateAdapterStatus(adapterId: string, nextStatus: AdapterStatus): AOCAdapterRecord {
+    const current = adaptersById.get(adapterId);
+    if (!current) {
+      throw new AdapterRegistryError(`Adapter ${adapterId} is not registered.`);
+    }
+
+    if (!ALLOWED_STATUS_TRANSITIONS[current.status].includes(nextStatus)) {
+      throw new AdapterRegistryError(
+        `Invalid status transition: ${current.status} -> ${nextStatus}. Re-registration is required when revoked.`,
+      );
+    }
+
+    const updated: AOCAdapterRecord = {
+      ...current,
+      status: nextStatus,
+      updated_at: new Date().toISOString().slice(0, 19) + 'Z',
+    };
+
+    validateAdapterRecord(updated);
+    const normalized = normalizeAdapterRecord(updated);
+    adaptersById.set(adapterId, normalized);
+
+    return cloneRecord(normalized);
+  }
+
+  function resolveAdapter(adapterId: string): AOCAdapterRecord | null {
+    return resolveAdapterWith(adapterId, getAdapterById);
+  }
+
+  return {
+    registerAdapter,
+    getAdapterById,
+    listAdapters,
+    updateAdapterStatus,
+    resolveAdapter,
+  };
+}

--- a/protocol/adapters/adapter-resolution.ts
+++ b/protocol/adapters/adapter-resolution.ts
@@ -1,0 +1,8 @@
+import type { AOCAdapterRecord } from './adapter-types';
+
+export function resolveAdapter(
+  adapterId: string,
+  resolver: (adapterId: string) => AOCAdapterRecord | null,
+): AOCAdapterRecord | null {
+  return resolver(adapterId);
+}

--- a/protocol/adapters/adapter-types.ts
+++ b/protocol/adapters/adapter-types.ts
@@ -1,0 +1,53 @@
+export const ADAPTER_TYPES = [
+  'market_maker',
+  'storage_provider',
+  'interpreter',
+  'executor',
+  'other',
+] as const;
+
+export const ADAPTER_SCOPE_TYPES = ['field', 'content', 'pack'] as const;
+
+export const ADAPTER_STATUS = ['declared', 'verified', 'revoked'] as const;
+
+export const ADAPTER_REGISTRY_SOURCES = ['self_declared', 'official_aoc'] as const;
+
+export type AdapterType = (typeof ADAPTER_TYPES)[number];
+export type AdapterScopeType = (typeof ADAPTER_SCOPE_TYPES)[number];
+export type AdapterStatus = (typeof ADAPTER_STATUS)[number];
+export type AdapterRegistrySource = (typeof ADAPTER_REGISTRY_SOURCES)[number];
+
+export type AdapterMetadata = Record<string, unknown>;
+
+export type AOCAdapterRecord = {
+  adapter_id: string;
+  display_name: string;
+  adapter_type: AdapterType;
+  owner_did?: string;
+  marketMakerId?: string;
+  supported_operations: string[];
+  supported_scope_types: AdapterScopeType[];
+  endpoint_url?: string;
+  documentation_url?: string;
+  status: AdapterStatus;
+  registry_source: AdapterRegistrySource;
+  created_at: string;
+  updated_at: string;
+  metadata?: AdapterMetadata;
+};
+
+export type AdapterRecordInput = Partial<AOCAdapterRecord> & Record<string, unknown>;
+
+export type AdapterListFilters = {
+  status?: AdapterStatus;
+  adapter_type?: AdapterType;
+  registry_source?: AdapterRegistrySource;
+};
+
+export type AdapterRegistry = {
+  registerAdapter: (record: unknown) => AOCAdapterRecord;
+  getAdapterById: (adapterId: string) => AOCAdapterRecord | null;
+  listAdapters: (filters?: AdapterListFilters) => AOCAdapterRecord[];
+  updateAdapterStatus: (adapterId: string, nextStatus: AdapterStatus) => AOCAdapterRecord;
+  resolveAdapter: (adapterId: string) => AOCAdapterRecord | null;
+};

--- a/protocol/adapters/index.ts
+++ b/protocol/adapters/index.ts
@@ -1,0 +1,12 @@
+export * from './adapter-types';
+export * from './adapter-errors';
+export { parseAdapterRecord, normalizeAdapterRecord, validateAdapterRecord } from './adapter-object';
+export { createAdapterRegistry } from './adapter-registry';
+export { resolveAdapter } from './adapter-resolution';
+export {
+  isAdapterUsable,
+  isAdapterVerified,
+  isAdapterOfficial,
+  supportsOperation,
+  supportsScopeType,
+} from './adapter-policy';


### PR DESCRIPTION
### Motivation

- Provide a canonical adapter identity model and an official but optional registry for discovery, metadata and trust signals while keeping AOC permissionless. 
- Enable future hosted/commercial overlays (discovery, compliance, reputation) without making the protocol dependent on registration.

### Description

- Added a new `protocol/adapters` module containing types (`AOCAdapterRecord`), domain errors, and fail-closed parsing/normalization/validation via `parseAdapterRecord`, `normalizeAdapterRecord` and `validateAdapterRecord`.
- Implemented an official in-memory registry via `createAdapterRegistry()` with `registerAdapter`, `getAdapterById`, `listAdapters`, `updateAdapterStatus` and `resolveAdapter`, including strict allowed status transitions (`declared -> verified|revoked`, `verified -> revoked`, `revoked` terminal).
- Added a minimal resolution layer (`resolveAdapter`), simple policy helpers (`isAdapterUsable`, `isAdapterVerified`, `isAdapterOfficial`, `supportsOperation`, `supportsScopeType`), exports from `protocol/adapters/index.ts` and a README that explicitly states the registry is optional and not a gatekeeper.
- Created unit tests under `protocol/adapters/__tests__/adapterRegistry.test.ts` and exported the adapters module from the package root (`index.ts`).

### Testing

- Ran `npm test -- protocol/adapters/__tests__/adapterRegistry.test.ts` and the adapter registry tests passed (`13 passed`).
- Ran the full suite with `npm test` and all tests passed (`492 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92d258a248325a718471cd764b2d6)