### PR TITLE
PR 6: Add optional hosted runtime infrastructure layer for AOC

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,3 +16,5 @@ export * from './aoc/sdk';
 export * from './interpreter';
 
 export * from './enforcement';
+
+export * from './runtime';

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,73 @@
+# Hosted Runtime (Optional Infrastructure Layer)
+
+This `runtime/` package is the **optional hosted infrastructure layer** for AOC.
+
+- The protocol core remains permissionless and can be used directly.
+- The hosted runtime adds an API layer, API keys, basic rate limits, and structured logs.
+- This is a first functional hosted runtime foundation for future monetization.
+
+## Scope of this version
+
+Included now:
+- API-first runtime with 3 endpoints:
+  - `POST /enforcement/evaluate`
+  - `POST /execution/authorize`
+  - `POST /capability/mint`
+- API key auth via `x-api-key` (in-memory key store).
+- Per-key in-memory rate limiting:
+  - `free`: 100 req/min
+  - `pro`: 1000 req/min
+- JSON structured logs with:
+  - `requestId`
+  - `endpoint`
+  - `decision` (`allow`/`deny`)
+  - `reason_code`
+- SDK thin wrapper supporting:
+  - **remote mode** (HTTP API)
+  - **local mode** (direct protocol core calls)
+
+Not included yet:
+- real billing and invoicing (only hooks/foundation)
+- dashboards
+- multi-region infra
+- complex async/queue execution
+- real adapter execution runtime
+- distributed persistence
+
+## Separation: protocol vs infrastructure
+
+- `protocol/*` and core modules keep canonical business logic.
+- `runtime/api/*` only parses requests, validates auth/rate limits, routes to core, and wraps responses.
+- No business rule duplication in API handlers.
+
+## Unified response format
+
+All endpoints return:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
+
+or on failure:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable message"
+  }
+}
+```
+
+## Fail-closed behavior
+
+- missing/invalid API key => deny
+- rate limit exceeded => deny
+- JSON parsing errors => deny
+- protocol errors => deny
+
+The runtime never defaults to allow on error paths.

--- a/runtime/__tests__/runtimeHosted.test.ts
+++ b/runtime/__tests__/runtimeHosted.test.ts
@@ -1,0 +1,138 @@
+import type { AddressInfo } from 'net';
+import { buildConsentObject } from '../../consent';
+import { createRuntimeServer } from '../api/server';
+import { InMemoryApiKeyStore } from '../auth/apiKeys';
+import { InMemoryRateLimiter } from '../limits/rateLimiter';
+import { HostedRuntimeClient } from '../sdk/client';
+
+const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const REF_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function buildMintInput() {
+  const consent = buildConsentObject(SUBJECT, GRANTEE, 'grant', [{ type: 'content', ref: REF_A }], ['read'], {
+    now: new Date('2026-01-01T00:00:00Z'),
+    expires_at: '2026-12-31T00:00:00Z',
+    marketMakerId: 'mm-01',
+  });
+
+  return {
+    consent,
+    requested_scope: [{ type: 'content' as const, ref: REF_A }],
+    requested_permissions: ['read'],
+    issued_at: '2026-02-01T00:00:00Z',
+    expires_at: '2026-03-01T00:00:00Z',
+    marketMakerId: 'mm-01',
+  };
+}
+
+describe('hosted runtime API + SDK', () => {
+  it('endpoint success: /execution/authorize', async () => {
+    const server = createRuntimeServer();
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const baseUrl = `http://127.0.0.1:${port}`;
+      const client = new HostedRuntimeClient({ baseUrl, apiKey: 'aoc_free_dev_key' });
+
+      const capability = await client.mintCapability(buildMintInput());
+      const result = await client.authorizeExecution({
+        capability,
+        requested_scope: [{ type: 'content' as const, ref: REF_A }],
+        requested_permissions: ['read'],
+        subject: SUBJECT,
+        grantee: GRANTEE,
+        marketMakerId: 'mm-01',
+        execution_target: { adapter: 'hrkey', operation: 'read_content' },
+        now: new Date('2026-02-15T00:00:00Z'),
+      });
+
+      expect(result.authorized).toBe(true);
+      expect(result.reason_code).toBe('EXECUTION_AUTHORIZED');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('invalid API key -> reject fail-closed', async () => {
+    const server = createRuntimeServer();
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/enforcement/evaluate`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'bad_key',
+        },
+        body: JSON.stringify({}),
+      });
+
+      const json = (await response.json()) as { success: boolean; error?: { code: string } };
+      expect(response.status).toBe(401);
+      expect(json.success).toBe(false);
+      expect(json.error?.code).toBe('AUTH_INVALID_API_KEY');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('rate limit exceeded -> reject', async () => {
+    const apiKeys = new InMemoryApiKeyStore([{ apiKey: 'tiny-free', owner: 'test', tier: 'free' }]);
+    const server = createRuntimeServer({
+      apiKeyStore: apiKeys,
+      rateLimiter: new InMemoryRateLimiter({ free: 1 }),
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const url = `http://127.0.0.1:${port}/enforcement/evaluate`;
+      const payload = {
+        capability: {},
+        requested_scope: [{ type: 'content' as const, ref: REF_A }],
+        requested_permissions: ['read'],
+      };
+
+      const first = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': 'tiny-free' },
+        body: JSON.stringify(payload),
+      });
+      expect(first.status).toBe(200);
+
+      const second = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': 'tiny-free' },
+        body: JSON.stringify(payload),
+      });
+      const json = (await second.json()) as { success: boolean; error?: { code: string } };
+
+      expect(second.status).toBe(401);
+      expect(json.success).toBe(false);
+      expect(json.error?.code).toBe('RATE_LIMIT_EXCEEDED');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('valid end-to-end flow + SDK local mode', async () => {
+    const localClient = new HostedRuntimeClient({ mode: 'local' });
+    const capability = await localClient.mintCapability(buildMintInput());
+
+    const decision = await localClient.evaluateEnforcement({
+      capability,
+      requested_scope: [{ type: 'content' as const, ref: REF_A }],
+      requested_permissions: ['read'],
+      subject: SUBJECT,
+      grantee: GRANTEE,
+      marketMakerId: 'mm-01',
+      now: new Date('2026-02-15T00:00:00Z'),
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason_code).toBe('ENFORCEMENT_ALLOW');
+  });
+});

--- a/runtime/api/middleware.ts
+++ b/runtime/api/middleware.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'crypto';
+import type { IncomingHttpHeaders } from 'http';
+import type { ApiResponse } from '../types/api-types';
+import type { InMemoryApiKeyStore, ApiKeyRecord } from '../auth/apiKeys';
+import type { InMemoryRateLimiter } from '../limits/rateLimiter';
+
+export type RuntimeRequestContext = {
+  requestId: string;
+  apiKey: ApiKeyRecord;
+};
+
+export function createRequestId(): string {
+  return randomUUID();
+}
+
+export function readApiKey(headers: IncomingHttpHeaders): string | undefined {
+  const value = headers['x-api-key'];
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value.trim();
+  }
+  return undefined;
+}
+
+export function authAndLimit(
+  headers: IncomingHttpHeaders,
+  apiKeyStore: InMemoryApiKeyStore,
+  rateLimiter: InMemoryRateLimiter
+): ApiResponse<RuntimeRequestContext> {
+  const key = readApiKey(headers);
+  if (key === undefined) {
+    return {
+      success: false,
+      error: {
+        code: 'AUTH_MISSING_API_KEY',
+        message: 'Missing required x-api-key header.',
+      },
+    };
+  }
+
+  const record = apiKeyStore.get(key);
+  if (record === undefined) {
+    return {
+      success: false,
+      error: {
+        code: 'AUTH_INVALID_API_KEY',
+        message: 'Invalid API key.',
+      },
+    };
+  }
+
+  const limit = rateLimiter.check(record.apiKey, record.tier);
+  if (!limit.allowed) {
+    return {
+      success: false,
+      error: {
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: `Rate limit exceeded for tier ${record.tier}. Limit=${limit.limit}/min.`,
+      },
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      requestId: createRequestId(),
+      apiKey: record,
+    },
+  };
+}

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -1,0 +1,74 @@
+import { authorizeExecution, type ExecutionAuthorizationResult } from '../../protocol/execution';
+import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
+import { mintCapability, type ProtocolCapability } from '../../protocol/capability';
+import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
+
+export type RuntimeCore = {
+  evaluateEnforcement: typeof evaluateEnforcement;
+  authorizeExecution: typeof authorizeExecution;
+  mintCapability: typeof mintCapability;
+};
+
+export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
+  evaluateEnforcement,
+  authorizeExecution,
+  mintCapability,
+};
+
+
+function reviveNow<T extends Record<string, unknown>>(payload: T): T {
+  if (typeof payload.now === 'string') {
+    return {
+      ...payload,
+      now: new Date(payload.now),
+    } as T;
+  }
+
+  return payload;
+}
+
+function success<T>(data: T): ApiResponse<T> {
+  return { success: true, data };
+}
+
+function failure(code: string, message: string): ApiResponse<never> {
+  return { success: false, error: { code, message } };
+}
+
+export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { decision: 'allow' | 'deny'; reasonCode: string } {
+  if (endpoint === '/enforcement/evaluate') {
+    const enforcement = data as EnforcementDecision;
+    return { decision: enforcement.allowed ? 'allow' : 'deny', reasonCode: enforcement.reason_code };
+  }
+
+  if (endpoint === '/execution/authorize') {
+    const execution = data as ExecutionAuthorizationResult;
+    return { decision: execution.authorized ? 'allow' : 'deny', reasonCode: execution.reason_code };
+  }
+
+  return {
+    decision: 'allow',
+    reasonCode: 'CAPABILITY_MINTED',
+  };
+}
+
+export function executeRoute(
+  endpoint: RuntimeEndpoint,
+  payload: unknown,
+  core: RuntimeCore = DEFAULT_RUNTIME_CORE
+): ApiResponse<EnforcementDecision | ExecutionAuthorizationResult | ProtocolCapability> {
+  try {
+    switch (endpoint) {
+      case '/enforcement/evaluate':
+        return success(core.evaluateEnforcement(reviveNow(payload as Parameters<typeof evaluateEnforcement>[0])));
+      case '/execution/authorize':
+        return success(core.authorizeExecution(reviveNow(payload as Parameters<typeof authorizeExecution>[0])));
+      case '/capability/mint':
+        return success(core.mintCapability(payload as Parameters<typeof mintCapability>[0]));
+      default:
+        return failure('ROUTE_NOT_FOUND', `Unsupported endpoint: ${endpoint}`);
+    }
+  } catch (error) {
+    return failure('PROTOCOL_ERROR', error instanceof Error ? error.message : 'Unknown protocol error.');
+  }
+}

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -1,0 +1,109 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'http';
+import { URL } from 'url';
+import { DEFAULT_API_KEYS, InMemoryApiKeyStore } from '../auth/apiKeys';
+import { InMemoryRateLimiter } from '../limits/rateLimiter';
+import { RuntimeLogger } from '../logging/logger';
+import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
+import { authAndLimit } from './middleware';
+import { DEFAULT_RUNTIME_CORE, deriveDecision, executeRoute, type RuntimeCore } from './routes';
+
+const ENDPOINTS: RuntimeEndpoint[] = ['/enforcement/evaluate', '/execution/authorize', '/capability/mint'];
+
+export type RuntimeServerDeps = {
+  apiKeyStore?: InMemoryApiKeyStore;
+  rateLimiter?: InMemoryRateLimiter;
+  logger?: RuntimeLogger;
+  core?: RuntimeCore;
+};
+
+function sendJson(response: ServerResponse, statusCode: number, body: ApiResponse<unknown>): void {
+  response.statusCode = statusCode;
+  response.setHeader('content-type', 'application/json');
+  response.end(JSON.stringify(body));
+}
+
+async function parseJson(request: IncomingMessage): Promise<unknown> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of request) {
+    chunks.push(chunk as Uint8Array);
+  }
+
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (raw.trim() === '') {
+    throw new Error('Request body cannot be empty.');
+  }
+
+  return JSON.parse(raw);
+}
+
+export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
+  const apiKeyStore = deps.apiKeyStore ?? new InMemoryApiKeyStore(DEFAULT_API_KEYS);
+  const rateLimiter = deps.rateLimiter ?? new InMemoryRateLimiter();
+  const logger = deps.logger ?? new RuntimeLogger();
+  const core = deps.core ?? DEFAULT_RUNTIME_CORE;
+
+  return createServer(async (request, response) => {
+    if (request.method !== 'POST' || request.url === undefined) {
+      return sendJson(response, 404, {
+        success: false,
+        error: { code: 'ROUTE_NOT_FOUND', message: 'Only POST endpoints are supported.' },
+      });
+    }
+
+    const pathname = new URL(request.url, 'http://localhost').pathname as RuntimeEndpoint;
+    if (!ENDPOINTS.includes(pathname)) {
+      return sendJson(response, 404, {
+        success: false,
+        error: { code: 'ROUTE_NOT_FOUND', message: `Unknown endpoint: ${pathname}` },
+      });
+    }
+
+    const authResult = authAndLimit(request.headers, apiKeyStore, rateLimiter);
+    if (!authResult.success || authResult.data === undefined) {
+      logger.log({
+        requestId: 'unauthenticated',
+        endpoint: pathname,
+        decision: 'deny',
+        reason_code: authResult.error?.code ?? 'AUTH_UNKNOWN',
+      });
+      return sendJson(response, 401, authResult);
+    }
+
+    const { requestId } = authResult.data;
+
+    let payload: unknown;
+    try {
+      payload = await parseJson(request);
+    } catch (error) {
+      logger.log({ requestId, endpoint: pathname, decision: 'deny', reason_code: 'REQUEST_PARSE_ERROR' });
+      return sendJson(response, 400, {
+        success: false,
+        error: {
+          code: 'REQUEST_PARSE_ERROR',
+          message: error instanceof Error ? error.message : 'Invalid JSON payload.',
+        },
+      });
+    }
+
+    const routeResult = executeRoute(pathname, payload, core);
+    if (!routeResult.success || routeResult.data === undefined) {
+      logger.log({
+        requestId,
+        endpoint: pathname,
+        decision: 'deny',
+        reason_code: routeResult.error?.code ?? 'PROTOCOL_ERROR',
+      });
+      return sendJson(response, 400, routeResult);
+    }
+
+    const decisionInfo = deriveDecision(pathname, routeResult.data);
+    logger.log({
+      requestId,
+      endpoint: pathname,
+      decision: decisionInfo.decision,
+      reason_code: decisionInfo.reasonCode,
+    });
+
+    return sendJson(response, 200, routeResult);
+  });
+}

--- a/runtime/auth/apiKeys.ts
+++ b/runtime/auth/apiKeys.ts
@@ -1,0 +1,28 @@
+export type ApiTier = 'free' | 'pro';
+
+export type ApiKeyRecord = {
+  apiKey: string;
+  owner: string;
+  tier: ApiTier;
+};
+
+export class InMemoryApiKeyStore {
+  private readonly keys = new Map<string, ApiKeyRecord>();
+
+  constructor(seed: ApiKeyRecord[] = []) {
+    seed.forEach((entry) => this.keys.set(entry.apiKey, entry));
+  }
+
+  get(apiKey: string): ApiKeyRecord | undefined {
+    return this.keys.get(apiKey);
+  }
+
+  add(record: ApiKeyRecord): void {
+    this.keys.set(record.apiKey, record);
+  }
+}
+
+export const DEFAULT_API_KEYS: ApiKeyRecord[] = [
+  { apiKey: 'aoc_free_dev_key', owner: 'dev-free', tier: 'free' },
+  { apiKey: 'aoc_pro_dev_key', owner: 'dev-pro', tier: 'pro' },
+];

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -1,0 +1,6 @@
+export { createRuntimeServer } from './api/server';
+export { HostedRuntimeClient } from './sdk/client';
+export { InMemoryApiKeyStore, DEFAULT_API_KEYS } from './auth/apiKeys';
+export { InMemoryRateLimiter } from './limits/rateLimiter';
+export { RuntimeLogger } from './logging/logger';
+export type { ApiRequest, ApiResponse, ErrorResponse, RuntimeEndpoint } from './types/api-types';

--- a/runtime/limits/rateLimiter.ts
+++ b/runtime/limits/rateLimiter.ts
@@ -1,0 +1,59 @@
+import type { ApiTier } from '../auth/apiKeys';
+
+export type RateLimitDecision = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+};
+
+type WindowCounter = {
+  count: number;
+  resetAt: number;
+};
+
+export class InMemoryRateLimiter {
+  private readonly windows = new Map<string, WindowCounter>();
+
+  private readonly limits: Record<ApiTier, number>;
+
+  constructor(limits?: Partial<Record<ApiTier, number>>) {
+    this.limits = {
+      free: limits?.free ?? 100,
+      pro: limits?.pro ?? 1000,
+    };
+  }
+
+  check(apiKey: string, tier: ApiTier, nowMs = Date.now()): RateLimitDecision {
+    const limit = this.limits[tier];
+    const current = this.windows.get(apiKey);
+
+    if (current === undefined || nowMs >= current.resetAt) {
+      const resetAt = nowMs + 60_000;
+      this.windows.set(apiKey, { count: 1, resetAt });
+      return {
+        allowed: true,
+        limit,
+        remaining: limit - 1,
+        resetAt,
+      };
+    }
+
+    if (current.count >= limit) {
+      return {
+        allowed: false,
+        limit,
+        remaining: 0,
+        resetAt: current.resetAt,
+      };
+    }
+
+    current.count += 1;
+    return {
+      allowed: true,
+      limit,
+      remaining: limit - current.count,
+      resetAt: current.resetAt,
+    };
+  }
+}

--- a/runtime/logging/logger.ts
+++ b/runtime/logging/logger.ts
@@ -1,0 +1,15 @@
+export type RuntimeLogDecision = 'allow' | 'deny';
+
+export type RuntimeLogEntry = {
+  requestId: string;
+  endpoint: string;
+  decision: RuntimeLogDecision;
+  reason_code: string;
+};
+
+export class RuntimeLogger {
+  log(entry: RuntimeLogEntry): void {
+    // Structured JSON logs for ingestion by future observability pipeline.
+    console.log(JSON.stringify(entry));
+  }
+}

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -1,0 +1,76 @@
+import { authorizeExecution, type ExecutionAuthorizationResult } from '../../protocol/execution';
+import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
+import { mintCapability, type MintCapabilityInput, type ProtocolCapability } from '../../protocol/capability';
+import type { ApiResponse, RuntimeMode } from '../types/api-types';
+
+type FetchLike = typeof fetch;
+
+export type HostedRuntimeClientOptions = {
+  apiKey?: string;
+  baseUrl?: string;
+  mode?: RuntimeMode;
+  fetchImpl?: FetchLike;
+};
+
+async function parseApiResponse<T>(response: Response): Promise<T> {
+  const parsed = (await response.json()) as ApiResponse<T>;
+  if (!parsed.success || parsed.data === undefined) {
+    throw new Error(parsed.error?.message ?? parsed.error?.code ?? 'Unknown API error.');
+  }
+  return parsed.data;
+}
+
+export class HostedRuntimeClient {
+  private readonly mode: RuntimeMode;
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(options: HostedRuntimeClientOptions = {}) {
+    this.mode = options.mode ?? 'remote';
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl ?? 'http://localhost:8787';
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  private async post<TRequest, TResponse>(path: string, payload: TRequest): Promise<TResponse> {
+    if (this.apiKey === undefined || this.apiKey.trim() === '') {
+      throw new Error('HostedRuntimeClient remote mode requires apiKey.');
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': this.apiKey,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    return parseApiResponse<TResponse>(response);
+  }
+
+  async evaluateEnforcement(input: Parameters<typeof evaluateEnforcement>[0]): Promise<EnforcementDecision> {
+    if (this.mode === 'local') {
+      return evaluateEnforcement(input);
+    }
+
+    return this.post('/enforcement/evaluate', input);
+  }
+
+  async authorizeExecution(input: Parameters<typeof authorizeExecution>[0]): Promise<ExecutionAuthorizationResult> {
+    if (this.mode === 'local') {
+      return authorizeExecution(input);
+    }
+
+    return this.post('/execution/authorize', input);
+  }
+
+  async mintCapability(input: MintCapabilityInput): Promise<ProtocolCapability> {
+    if (this.mode === 'local') {
+      return mintCapability(input);
+    }
+
+    return this.post('/capability/mint', input);
+  }
+}

--- a/runtime/types/api-types.ts
+++ b/runtime/types/api-types.ts
@@ -1,0 +1,22 @@
+export type RuntimeEndpoint =
+  | '/enforcement/evaluate'
+  | '/execution/authorize'
+  | '/capability/mint';
+
+export type ApiRequest<T> = {
+  requestId?: string;
+  payload: T;
+};
+
+export type ErrorResponse = {
+  code: string;
+  message: string;
+};
+
+export type ApiResponse<T> = {
+  success: boolean;
+  data?: T;
+  error?: ErrorResponse;
+};
+
+export type RuntimeMode = 'remote' | 'local';


### PR DESCRIPTION
### Motivation

- Introduce an OPTIONAL hosted infrastructure layer to accelerate adoption, observability and future monetization while keeping the protocol core permissionless.
- Provide an API-first surface with a thin SDK so integrators can use a hosted service by default and fall back to local protocol execution when needed.
- Ship a minimal, fail-closed runtime that enables auth/rate-limits/logging hooks without implementing billing, dashboards, multi-region infra or complex async execution yet.

### Description

- Added a new `runtime/` package with submodules `api/`, `sdk/`, `auth/`, `limits/`, `logging/`, and `types/` and exported from the repo root via `index.ts`.
- Implemented three POST endpoints (`/enforcement/evaluate`, `/execution/authorize`, `/capability/mint`) in `runtime/api/*` that parse requests, enforce auth/limits, route to the protocol core functions and return a unified `ApiResponse` envelope without duplicating business logic. 
- Implemented `x-api-key` auth with an in-memory `InMemoryApiKeyStore` and a per-key in-memory `InMemoryRateLimiter` (defaults: `free=100/min`, `pro=1000/min`) in `runtime/auth/*` and `runtime/limits/*` and fail-closed behavior on auth/limit failures. 
- Added structured JSON logging (`requestId`, `endpoint`, `decision`, `reason_code`) and a thin SDK `HostedRuntimeClient` that supports `remote` (HTTP + `x-api-key`) and `local` (direct core calls) modes, plus API types and `runtime/README.md` documentation. 

### Testing

- Added integration tests at `runtime/__tests__/runtimeHosted.test.ts` covering endpoint success, invalid API key, rate limit exceeded and local SDK flow; these tests were run during CI. 
- Ran `npm test -- --runInBand runtime/__tests__/runtimeHosted.test.ts` and the new runtime tests passed. 
- Ran the full suite with `npm test -- --runInBand` and all test suites passed (`31` suites, `496` tests passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92ffd84c08325a01a8ca93d3cc354)