### PR TITLE
Add trust layer: identity credentials, consent, and payout KYC enforcement (PR17)

### DIFF
--- a/runtime/__tests__/trustHosted.test.ts
+++ b/runtime/__tests__/trustHosted.test.ts
@@ -1,0 +1,145 @@
+import type { AddressInfo } from 'net';
+import { createRuntimeServer } from '../api/server';
+import { DEFAULT_RUNTIME_CORE } from '../api/routes';
+import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+
+describe('trust layer hosted endpoints', () => {
+  it('supports credential registration and verification', async () => {
+    const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    const server = createRuntimeServer({
+      core: {
+        ...DEFAULT_RUNTIME_CORE,
+        trustService,
+      },
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const base = `http://127.0.0.1:${port}`;
+      const headers = { 'content-type': 'application/json', 'x-api-key': 'aoc_free_dev_key' };
+
+      const register = await fetch(`${base}/trust/credential/register`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          credential_ref: 'cred_1',
+          subject_hash: '0xsubjecthash01',
+          issuer_id: 'kyc-global-v1',
+          credential_hash: '0xcredentialhash',
+          metadata_hash: '0xmetadatahash',
+          kyc_level: 'enhanced',
+          wallet_address: '0xabc123',
+          issued_at: '2026-01-01T00:00:00Z',
+        }),
+      });
+      expect(register.status).toBe(200);
+
+      const verify = await fetch(`${base}/trust/verify`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          subject_hash: '0xsubjecthash01',
+          now: '2026-01-02T00:00:00Z',
+        }),
+      });
+      const verifyJson = (await verify.json()) as { success: boolean; data?: { valid: boolean; issuer?: string } };
+      expect(verify.status).toBe(200);
+      expect(verifyJson.success).toBe(true);
+      expect(verifyJson.data?.valid).toBe(true);
+      expect(verifyJson.data?.issuer).toBe('kyc-global-v1');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('enforces consent and blocks payout without KYC', async () => {
+    const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    const server = createRuntimeServer({
+      core: {
+        ...DEFAULT_RUNTIME_CORE,
+        trustService,
+      },
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const base = `http://127.0.0.1:${port}`;
+      const headers = { 'content-type': 'application/json', 'x-api-key': 'aoc_free_dev_key' };
+
+      const blocked = await fetch(`${base}/payout/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          withdrawal_id: 'wd_1',
+          subject_hash: '0xsubjecthash01',
+          consumer_id: 'hrkey-v1',
+          amount: '100.00',
+          wallet_address: '0xabc123',
+        }),
+      });
+      const blockedJson = (await blocked.json()) as { data?: { allowed: boolean; reason_code: string } };
+      expect(blocked.status).toBe(200);
+      expect(blockedJson.data?.allowed).toBe(false);
+      expect(blockedJson.data?.reason_code).toBe('PAYOUT_BLOCKED_NOT_FOUND');
+
+      await fetch(`${base}/trust/credential/register`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          credential_ref: 'cred_1',
+          subject_hash: '0xsubjecthash01',
+          issuer_id: 'kyc-global-v1',
+          credential_hash: '0xcredentialhash',
+          metadata_hash: '0xmetadatahash',
+          kyc_level: 'basic',
+          issued_at: '2026-01-01T00:00:00Z',
+        }),
+      });
+
+      const missingConsent = await fetch(`${base}/trust/verify`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          subject_hash: '0xsubjecthash01',
+          consumer_id: 'hrkey-v1',
+          now: '2026-01-02T00:00:00Z',
+        }),
+      });
+      const missingConsentJson = (await missingConsent.json()) as { data?: { valid: boolean; reason_code: string } };
+      expect(missingConsentJson.data?.valid).toBe(false);
+      expect(missingConsentJson.data?.reason_code).toBe('CONSENT_REQUIRED');
+
+      await fetch(`${base}/trust/consent/grant`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          consent_id: 'consent_1',
+          subject_hash: '0xsubjecthash01',
+          consumer_id: 'hrkey-v1',
+          issuer_id: 'kyc-global-v1',
+          granted_at: '2026-01-02T00:00:00Z',
+        }),
+      });
+
+      const allowed = await fetch(`${base}/payout/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          withdrawal_id: 'wd_2',
+          subject_hash: '0xsubjecthash01',
+          consumer_id: 'hrkey-v1',
+          amount: '100.00',
+          wallet_address: '0xabc123',
+          identity_issuer: 'kyc-global-v1',
+        }),
+      });
+      const allowedJson = (await allowed.json()) as { data?: { allowed: boolean; reason_code: string } };
+      expect(allowedJson.data?.allowed).toBe(true);
+      expect(allowedJson.data?.reason_code).toBe('PAYOUT_ALLOWED');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+});

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -1,18 +1,27 @@
 import { authorizeExecution, type ExecutionAuthorizationResult } from '../../protocol/execution';
 import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
 import { mintCapability, type ProtocolCapability } from '../../protocol/capability';
+import { InMemoryTrustService, type GrantConsentInput, type RegisterCredentialInput, type VerifyIdentityInput } from '../trust/service';
+import type {
+  AocIdentityConsentRecord,
+  AocIdentityCredentialRecord,
+  IdentityVerificationResult,
+  RlusdWithdrawalRequest,
+} from '../trust/types';
 import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
 
 export type RuntimeCore = {
   evaluateEnforcement: typeof evaluateEnforcement;
   authorizeExecution: typeof authorizeExecution;
   mintCapability: typeof mintCapability;
+  trustService: InMemoryTrustService;
 };
 
 export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
   evaluateEnforcement,
   authorizeExecution,
   mintCapability,
+  trustService: new InMemoryTrustService(),
 };
 
 
@@ -45,6 +54,20 @@ export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { deci
     const execution = data as ExecutionAuthorizationResult;
     return { decision: execution.authorized ? 'allow' : 'deny', reasonCode: execution.reason_code };
   }
+  if (endpoint === '/trust/verify') {
+    const verification = data as IdentityVerificationResult;
+    return { decision: verification.valid ? 'allow' : 'deny', reasonCode: verification.reason_code };
+  }
+  if (endpoint === '/trust/credential/register') {
+    return { decision: 'allow', reasonCode: 'CREDENTIAL_REGISTERED' };
+  }
+  if (endpoint === '/trust/consent/grant') {
+    return { decision: 'allow', reasonCode: 'CONSENT_GRANTED' };
+  }
+  if (endpoint === '/payout/execute') {
+    const payout = data as { allowed: boolean; reason_code: string };
+    return { decision: payout.allowed ? 'allow' : 'deny', reasonCode: payout.reason_code };
+  }
 
   return {
     decision: 'allow',
@@ -56,7 +79,15 @@ export function executeRoute(
   endpoint: RuntimeEndpoint,
   payload: unknown,
   core: RuntimeCore = DEFAULT_RUNTIME_CORE
-): ApiResponse<EnforcementDecision | ExecutionAuthorizationResult | ProtocolCapability> {
+): ApiResponse<
+  | EnforcementDecision
+  | ExecutionAuthorizationResult
+  | ProtocolCapability
+  | AocIdentityCredentialRecord
+  | IdentityVerificationResult
+  | AocIdentityConsentRecord
+  | { allowed: boolean; reason_code: string }
+> {
   try {
     switch (endpoint) {
       case '/enforcement/evaluate':
@@ -65,6 +96,14 @@ export function executeRoute(
         return success(core.authorizeExecution(reviveNow(payload as Parameters<typeof authorizeExecution>[0])));
       case '/capability/mint':
         return success(core.mintCapability(payload as Parameters<typeof mintCapability>[0]));
+      case '/payout/execute':
+        return success(core.trustService.enforcePayoutKyc(payload as RlusdWithdrawalRequest));
+      case '/trust/credential/register':
+        return success(core.trustService.registerCredential(payload as RegisterCredentialInput));
+      case '/trust/verify':
+        return success(core.trustService.verifyIdentity(reviveNow(payload as VerifyIdentityInput)));
+      case '/trust/consent/grant':
+        return success(core.trustService.grantConsent(payload as GrantConsentInput));
       default:
         return failure('ROUTE_NOT_FOUND', `Unsupported endpoint: ${endpoint}`);
     }

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -7,7 +7,15 @@ import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
 import { authAndLimit } from './middleware';
 import { DEFAULT_RUNTIME_CORE, deriveDecision, executeRoute, type RuntimeCore } from './routes';
 
-const ENDPOINTS: RuntimeEndpoint[] = ['/enforcement/evaluate', '/execution/authorize', '/capability/mint'];
+const ENDPOINTS: RuntimeEndpoint[] = [
+  '/enforcement/evaluate',
+  '/execution/authorize',
+  '/capability/mint',
+  '/payout/execute',
+  '/trust/credential/register',
+  '/trust/verify',
+  '/trust/consent/grant',
+];
 
 export type RuntimeServerDeps = {
   apiKeyStore?: InMemoryApiKeyStore;

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -3,4 +3,13 @@ export { HostedRuntimeClient } from './sdk/client';
 export { InMemoryApiKeyStore, DEFAULT_API_KEYS } from './auth/apiKeys';
 export { InMemoryRateLimiter } from './limits/rateLimiter';
 export { RuntimeLogger } from './logging/logger';
+export { InMemoryTrustService, DEFAULT_TRUST_ISSUERS } from './trust/service';
+export type {
+  AocIdentityConsentRecord,
+  AocIdentityCredentialRecord,
+  AocIdentityIssuerRecord,
+  IdentityVerificationResult,
+  RlusdWithdrawalRequest,
+  TrustAuditEvent,
+} from './trust/types';
 export type { ApiRequest, ApiResponse, ErrorResponse, RuntimeEndpoint } from './types/api-types';

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -1,6 +1,13 @@
 import { authorizeExecution, type ExecutionAuthorizationResult } from '../../protocol/execution';
 import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
 import { mintCapability, type MintCapabilityInput, type ProtocolCapability } from '../../protocol/capability';
+import type { GrantConsentInput, RegisterCredentialInput, VerifyIdentityInput } from '../trust/service';
+import type {
+  AocIdentityConsentRecord,
+  AocIdentityCredentialRecord,
+  IdentityVerificationResult,
+  RlusdWithdrawalRequest,
+} from '../trust/types';
 import type { ApiResponse, RuntimeMode } from '../types/api-types';
 
 type FetchLike = typeof fetch;
@@ -72,5 +79,33 @@ export class HostedRuntimeClient {
     }
 
     return this.post('/capability/mint', input);
+  }
+
+  async registerCredential(input: RegisterCredentialInput): Promise<AocIdentityCredentialRecord> {
+    if (this.mode === 'local') {
+      throw new Error('Credential registration is only available in hosted mode.');
+    }
+    return this.post('/trust/credential/register', input);
+  }
+
+  async verifyIdentity(input: VerifyIdentityInput): Promise<IdentityVerificationResult> {
+    if (this.mode === 'local') {
+      throw new Error('Identity verification is only available in hosted mode.');
+    }
+    return this.post('/trust/verify', input);
+  }
+
+  async grantIdentityConsent(input: GrantConsentInput): Promise<AocIdentityConsentRecord> {
+    if (this.mode === 'local') {
+      throw new Error('Consent grant is only available in hosted mode.');
+    }
+    return this.post('/trust/consent/grant', input);
+  }
+
+  async executePayout(input: RlusdWithdrawalRequest): Promise<{ allowed: boolean; reason_code: string }> {
+    if (this.mode === 'local') {
+      throw new Error('Payout execution is only available in hosted mode.');
+    }
+    return this.post('/payout/execute', input);
   }
 }

--- a/runtime/trust/__tests__/service.test.ts
+++ b/runtime/trust/__tests__/service.test.ts
@@ -1,0 +1,83 @@
+import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../service';
+import type { RlusdWithdrawalRequest } from '../types';
+
+const SUBJECT_HASH = '0xsubjecthash01';
+const CONSUMER = 'hrkey-v1';
+
+function buildWithdrawalRequest(overrides: Partial<RlusdWithdrawalRequest> = {}): RlusdWithdrawalRequest {
+  return {
+    withdrawal_id: 'wd_1',
+    subject_hash: SUBJECT_HASH,
+    consumer_id: CONSUMER,
+    amount: '100.00',
+    wallet_address: '0xabc123',
+    ...overrides,
+  };
+}
+
+describe('InMemoryTrustService', () => {
+  it('registers credential with non-sensitive hashed metadata only', () => {
+    const trust = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    const credential = trust.registerCredential({
+      credential_ref: 'cred_1',
+      subject_hash: SUBJECT_HASH,
+      issuer_id: 'kyc-global-v1',
+      credential_hash: '0xcredentialhash',
+      metadata_hash: '0xmetadatahash',
+      kyc_level: 'enhanced',
+      wallet_address: '0xabc123',
+      issued_at: '2026-01-01T00:00:00Z',
+    });
+
+    expect(credential.credential_hash).toBe('0xcredentialhash');
+    expect(credential.metadata_hash).toBe('0xmetadatahash');
+    expect((credential as Record<string, unknown>).pii).toBeUndefined();
+  });
+
+  it('verifies identity only with granted consent', () => {
+    const trust = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    trust.registerCredential({
+      credential_ref: 'cred_1',
+      subject_hash: SUBJECT_HASH,
+      issuer_id: 'kyc-global-v1',
+      credential_hash: '0xcredentialhash',
+      metadata_hash: '0xmetadatahash',
+      kyc_level: 'basic',
+      issued_at: '2026-01-01T00:00:00Z',
+      expires_at: '2027-01-01T00:00:00Z',
+    });
+
+    const withoutConsent = trust.verifyIdentity({
+      subject_hash: SUBJECT_HASH,
+      consumer_id: CONSUMER,
+      now: new Date('2026-02-01T00:00:00Z'),
+    });
+    expect(withoutConsent.valid).toBe(false);
+    expect(withoutConsent.reason_code).toBe('CONSENT_REQUIRED');
+
+    trust.grantConsent({
+      consent_id: 'consent_1',
+      subject_hash: SUBJECT_HASH,
+      consumer_id: CONSUMER,
+      issuer_id: 'kyc-global-v1',
+      granted_at: '2026-02-01T00:00:00Z',
+    });
+
+    const withConsent = trust.verifyIdentity({
+      subject_hash: SUBJECT_HASH,
+      consumer_id: CONSUMER,
+      now: new Date('2026-02-01T00:00:00Z'),
+    });
+    expect(withConsent.valid).toBe(true);
+    expect(withConsent.issuer).toBe('kyc-global-v1');
+    expect(withConsent.kyc_level).toBe('basic');
+  });
+
+  it('blocks payout when valid KYC is missing', () => {
+    const trust = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    const blocked = trust.enforcePayoutKyc(buildWithdrawalRequest(), new Date('2026-02-01T00:00:00Z'));
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.reason_code).toBe('PAYOUT_BLOCKED_NOT_FOUND');
+  });
+});

--- a/runtime/trust/service.ts
+++ b/runtime/trust/service.ts
@@ -1,0 +1,225 @@
+import {
+  type AocIdentityConsentRecord,
+  type AocIdentityCredentialRecord,
+  type AocIdentityIssuerRecord,
+  type IdentityVerificationResult,
+  type RlusdWithdrawalRequest,
+  type TrustAuditEvent,
+} from './types';
+
+export type RegisterCredentialInput = {
+  credential_ref: string;
+  subject_hash: string;
+  issuer_id: string;
+  credential_hash: string;
+  metadata_hash: string;
+  kyc_level: AocIdentityCredentialRecord['kyc_level'];
+  wallet_address?: string;
+  issued_at: string;
+  expires_at?: string;
+};
+
+export type GrantConsentInput = {
+  consent_id: string;
+  subject_hash: string;
+  consumer_id: string;
+  issuer_id: string;
+  granted_at: string;
+};
+
+export type VerifyIdentityInput = {
+  subject_hash: string;
+  consumer_id?: string;
+  issuer_id?: string;
+  now?: Date;
+};
+
+export class InMemoryTrustService {
+  private readonly issuers = new Map<string, AocIdentityIssuerRecord>();
+  private readonly credentials = new Map<string, AocIdentityCredentialRecord>();
+  private readonly consents = new Map<string, AocIdentityConsentRecord>();
+  private readonly auditEvents: TrustAuditEvent[] = [];
+
+  constructor(initialIssuers: readonly AocIdentityIssuerRecord[] = []) {
+    for (const issuer of initialIssuers) {
+      this.issuers.set(issuer.issuer_id, issuer);
+    }
+  }
+
+  getAuditEvents(): readonly TrustAuditEvent[] {
+    return [...this.auditEvents];
+  }
+
+  registerCredential(input: RegisterCredentialInput): AocIdentityCredentialRecord {
+    const issuer = this.issuers.get(input.issuer_id);
+    if (issuer === undefined || !issuer.active) {
+      throw new Error(`Issuer is invalid or inactive: ${input.issuer_id}`);
+    }
+    if (!issuer.supported_kyc_levels.includes(input.kyc_level)) {
+      throw new Error(`Issuer does not support KYC level: ${input.kyc_level}`);
+    }
+
+    const record: AocIdentityCredentialRecord = {
+      credential_ref: input.credential_ref,
+      subject_hash: input.subject_hash,
+      issuer_id: input.issuer_id,
+      credential_hash: input.credential_hash,
+      kyc_level: input.kyc_level,
+      metadata_hash: input.metadata_hash,
+      wallet_address: input.wallet_address,
+      issued_at: input.issued_at,
+      expires_at: input.expires_at,
+    };
+    this.credentials.set(record.credential_ref, record);
+    this.auditEvents.push({
+      event_type: 'CREDENTIAL_REGISTERED',
+      at: input.issued_at,
+      subject_hash: input.subject_hash,
+      issuer_id: input.issuer_id,
+      credential_ref: input.credential_ref,
+    });
+    if (input.wallet_address !== undefined) {
+      this.auditEvents.push({
+        event_type: 'WALLET_LINKED',
+        at: input.issued_at,
+        subject_hash: input.subject_hash,
+        issuer_id: input.issuer_id,
+        credential_ref: input.credential_ref,
+      });
+    }
+    return record;
+  }
+
+  grantConsent(input: GrantConsentInput): AocIdentityConsentRecord {
+    const issuer = this.issuers.get(input.issuer_id);
+    if (issuer === undefined || !issuer.active) {
+      throw new Error(`Issuer is invalid or inactive: ${input.issuer_id}`);
+    }
+    const consent: AocIdentityConsentRecord = {
+      consent_id: input.consent_id,
+      subject_hash: input.subject_hash,
+      consumer_id: input.consumer_id,
+      issuer_id: input.issuer_id,
+      granted_at: input.granted_at,
+    };
+    this.consents.set(input.consent_id, consent);
+    this.auditEvents.push({
+      event_type: 'CONSENT_GRANTED',
+      at: input.granted_at,
+      subject_hash: input.subject_hash,
+      consumer_id: input.consumer_id,
+      issuer_id: input.issuer_id,
+    });
+    return consent;
+  }
+
+  verifyIdentity(input: VerifyIdentityInput): IdentityVerificationResult {
+    const now = input.now ?? new Date();
+    const candidates = [...this.credentials.values()].filter(
+      (credential) =>
+        credential.subject_hash === input.subject_hash &&
+        (input.issuer_id === undefined || credential.issuer_id === input.issuer_id)
+    );
+    if (candidates.length === 0) {
+      const result: IdentityVerificationResult = { valid: false, reason_code: 'NOT_FOUND' };
+      this.pushVerificationAudit(input, result);
+      return result;
+    }
+    const latest = candidates.sort((a, b) => Date.parse(b.issued_at) - Date.parse(a.issued_at))[0];
+    const issuer = this.issuers.get(latest.issuer_id);
+    if (issuer === undefined || !issuer.active) {
+      const result: IdentityVerificationResult = { valid: false, reason_code: 'ISSUER_INACTIVE' };
+      this.pushVerificationAudit(input, result, latest);
+      return result;
+    }
+    if (latest.revoked_at !== undefined) {
+      const result: IdentityVerificationResult = { valid: false, reason_code: 'REVOKED' };
+      this.pushVerificationAudit(input, result, latest);
+      return result;
+    }
+    if (latest.expires_at !== undefined && Date.parse(latest.expires_at) <= now.getTime()) {
+      const result: IdentityVerificationResult = { valid: false, reason_code: 'EXPIRED' };
+      this.pushVerificationAudit(input, result, latest);
+      return result;
+    }
+    if (input.consumer_id !== undefined) {
+      const consentExists = [...this.consents.values()].some(
+        (consent) =>
+          consent.subject_hash === input.subject_hash &&
+          consent.consumer_id === input.consumer_id &&
+          consent.issuer_id === latest.issuer_id &&
+          consent.revoked_at === undefined
+      );
+      if (!consentExists) {
+        const result: IdentityVerificationResult = { valid: false, reason_code: 'CONSENT_REQUIRED' };
+        this.pushVerificationAudit(input, result, latest);
+        return result;
+      }
+    }
+
+    const result: IdentityVerificationResult = {
+      valid: true,
+      issuer: latest.issuer_id,
+      kyc_level: latest.kyc_level,
+      reason_code: 'VERIFIED',
+    };
+    this.pushVerificationAudit(input, result, latest);
+    return result;
+  }
+
+  enforcePayoutKyc(request: RlusdWithdrawalRequest, now: Date = new Date()): { allowed: boolean; reason_code: string } {
+    const verification = this.verifyIdentity({
+      subject_hash: request.subject_hash,
+      consumer_id: request.consumer_id,
+      issuer_id: request.identity_issuer,
+      now,
+    });
+    if (!verification.valid) {
+      this.auditEvents.push({
+        event_type: 'PAYOUT_BLOCKED',
+        at: now.toISOString(),
+        subject_hash: request.subject_hash,
+        consumer_id: request.consumer_id,
+        issuer_id: request.identity_issuer,
+        credential_ref: request.identity_ref,
+        reason_code: verification.reason_code,
+      });
+      return { allowed: false, reason_code: `PAYOUT_BLOCKED_${verification.reason_code}` };
+    }
+    this.auditEvents.push({
+      event_type: 'PAYOUT_ALLOWED',
+      at: now.toISOString(),
+      subject_hash: request.subject_hash,
+      consumer_id: request.consumer_id,
+      issuer_id: verification.issuer,
+      credential_ref: request.identity_ref,
+      reason_code: verification.reason_code,
+    });
+    return { allowed: true, reason_code: 'PAYOUT_ALLOWED' };
+  }
+
+  private pushVerificationAudit(
+    input: VerifyIdentityInput,
+    result: IdentityVerificationResult,
+    credential?: AocIdentityCredentialRecord
+  ): void {
+    this.auditEvents.push({
+      event_type: 'VERIFICATION_PERFORMED',
+      at: (input.now ?? new Date()).toISOString(),
+      subject_hash: input.subject_hash,
+      consumer_id: input.consumer_id,
+      issuer_id: credential?.issuer_id,
+      credential_ref: credential?.credential_ref,
+      reason_code: result.reason_code,
+    });
+  }
+}
+
+export const DEFAULT_TRUST_ISSUERS: readonly AocIdentityIssuerRecord[] = [
+  {
+    issuer_id: 'kyc-global-v1',
+    display_name: 'KYC Global',
+    active: true,
+    supported_kyc_levels: ['basic', 'enhanced', 'institutional'],
+  },
+];

--- a/runtime/trust/types.ts
+++ b/runtime/trust/types.ts
@@ -1,0 +1,70 @@
+export type KycLevel = 'basic' | 'enhanced' | 'institutional';
+
+export type IdentityIssuer = {
+  issuer_id: string;
+  display_name: string;
+  active: boolean;
+  supported_kyc_levels: readonly KycLevel[];
+};
+
+// aoc_identity_issuers
+export type AocIdentityIssuerRecord = IdentityIssuer;
+
+// aoc_identity_credentials
+export type AocIdentityCredentialRecord = {
+  credential_ref: string;
+  subject_hash: string;
+  issuer_id: string;
+  credential_hash: string;
+  kyc_level: KycLevel;
+  metadata_hash: string;
+  wallet_address?: string;
+  issued_at: string;
+  expires_at?: string;
+  revoked_at?: string;
+};
+
+// aoc_identity_consents
+export type AocIdentityConsentRecord = {
+  consent_id: string;
+  subject_hash: string;
+  consumer_id: string;
+  issuer_id: string;
+  granted_at: string;
+  revoked_at?: string;
+};
+
+// Compatibility extension of rlusd_withdrawal_requests
+export type RlusdWithdrawalRequest = {
+  withdrawal_id: string;
+  subject_hash: string;
+  consumer_id: string;
+  amount: string;
+  wallet_address: string;
+  identity_ref?: string;
+  identity_issuer?: string;
+  kyc_level?: KycLevel;
+};
+
+export type IdentityVerificationResult = {
+  valid: boolean;
+  issuer?: string;
+  kyc_level?: KycLevel;
+  reason_code: 'VERIFIED' | 'NOT_FOUND' | 'ISSUER_INACTIVE' | 'EXPIRED' | 'REVOKED' | 'CONSENT_REQUIRED';
+};
+
+export type TrustAuditEvent = {
+  event_type:
+    | 'CREDENTIAL_REGISTERED'
+    | 'VERIFICATION_PERFORMED'
+    | 'CONSENT_GRANTED'
+    | 'WALLET_LINKED'
+    | 'PAYOUT_BLOCKED'
+    | 'PAYOUT_ALLOWED';
+  at: string;
+  subject_hash: string;
+  consumer_id?: string;
+  issuer_id?: string;
+  credential_ref?: string;
+  reason_code?: string;
+};

--- a/runtime/types/api-types.ts
+++ b/runtime/types/api-types.ts
@@ -1,7 +1,11 @@
 export type RuntimeEndpoint =
   | '/enforcement/evaluate'
   | '/execution/authorize'
-  | '/capability/mint';
+  | '/capability/mint'
+  | '/payout/execute'
+  | '/trust/credential/register'
+  | '/trust/verify'
+  | '/trust/consent/grant';
 
 export type ApiRequest<T> = {
   requestId?: string;


### PR DESCRIPTION
### Motivation
- Introduce a deterministic, auditable trust layer to accept issuer-backed identity credentials while avoiding PII custody. 
- Allow consent-based reuse of identity attestations so consumers can be granted access without re-submitting sensitive material. 
- Enforce identity validation as a precondition for payout execution to prevent withdrawals when no valid/consented credential exists. 

### Description
- Add typed runtime model for issuers, credentials, consents, and an extended `RlusdWithdrawalRequest` (`runtime/trust/types.ts`).
- Implement an in-memory `InMemoryTrustService` that supports credential registration, identity verification, consent grants, deterministic checks (expiry/revocation/issuer activity), wallet linking, audit events, and payout KYC enforcement (`runtime/trust/service.ts`).
- Wire new hosted runtime endpoints and decision mapping for `POST /trust/credential/register`, `POST /trust/verify`, `POST /trust/consent/grant`, and `POST /payout/execute` and expose them via the runtime server and routes (`runtime/api/routes.ts`, `runtime/api/server.ts`, `runtime/types/api-types.ts`).
- Extend the hosted SDK with `registerCredential`, `verifyIdentity`, `grantIdentityConsent`, and `executePayout` client methods and export the trust service/types from the runtime public surface (`runtime/sdk/client.ts`, `runtime/index.ts`).
- Add unit and integration tests covering credential registration, verification, consent enforcement, and payout blocking behavior (`runtime/trust/__tests__/service.test.ts`, `runtime/__tests__/trustHosted.test.ts`).

### Testing
- Ran the full test suite with `npm test -- --runInBand` and all tests passed.
- Test summary from run: `Test Suites: 33 passed, 33 total`, `Tests: 501 passed, 501 total`.
- New trust unit tests (`runtime/trust/__tests__/service.test.ts`) and hosted integration tests (`runtime/__tests__/trustHosted.test.ts`) passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4d7040448325ad792b0f3f48cfcd)