### PR TITLE
Add hosted payout execution (RLUSD adapter), HRKey payout engine, and related routes/tests

### DIFF
--- a/integration/hrkey/__tests__/payoutEngine.test.ts
+++ b/integration/hrkey/__tests__/payoutEngine.test.ts
@@ -1,0 +1,47 @@
+import { HrkeyPayoutEngine } from '../payoutEngine';
+
+describe('HrkeyPayoutEngine', () => {
+  it('uses local execution path when USE_AOC_PAYOUT_ENGINE is disabled', async () => {
+    const engine = new HrkeyPayoutEngine({
+      useAocPayoutEngine: false,
+      localExecute: () => ({ allowed: true, reason_code: 'LOCAL_OK' }),
+    });
+
+    const result = await engine.execute({
+      withdrawal_id: 'wd_1',
+      subject_hash: '0xsubjecthash01',
+      consumer_id: 'hrkey-v1',
+      amount: '100.00',
+      wallet_address: '0xabc123',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason_code).toBe('LOCAL_OK');
+  });
+
+  it('calls AOC payout endpoint when USE_AOC_PAYOUT_ENGINE is enabled', async () => {
+    const engine = new HrkeyPayoutEngine({
+      useAocPayoutEngine: true,
+      client: {
+        executePayout: async () => ({
+          allowed: true,
+          reason_code: 'PAYOUT_ALLOWED',
+          payout_id: 'rlusd_wd_1',
+          provider_status: 'queued',
+        }),
+      } as never,
+    });
+
+    const result = await engine.execute({
+      withdrawal_id: 'wd_1',
+      subject_hash: '0xsubjecthash01',
+      consumer_id: 'hrkey-v1',
+      amount: '100.00',
+      wallet_address: '0xabc123',
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason_code).toBe('PAYOUT_ALLOWED');
+    expect(result.payout_id).toBe('rlusd_wd_1');
+  });
+});

--- a/integration/hrkey/index.ts
+++ b/integration/hrkey/index.ts
@@ -26,3 +26,6 @@ export type {
   ResolvedField,
   UnresolvedField,
 } from './types';
+
+export { HrkeyPayoutEngine } from './payoutEngine';
+export type { HrkeyPayoutEngineOptions } from './payoutEngine';

--- a/integration/hrkey/payoutEngine.ts
+++ b/integration/hrkey/payoutEngine.ts
@@ -1,0 +1,41 @@
+import { HostedRuntimeClient } from '../../runtime';
+import type { PayoutExecuteResult, RlusdWithdrawalRequest } from '../../runtime';
+
+export type HrkeyPayoutEngineOptions = {
+  useAocPayoutEngine?: boolean;
+  client?: HostedRuntimeClient;
+  localExecute?: (request: RlusdWithdrawalRequest) => PayoutExecuteResult;
+};
+
+function parseUseAocPayoutEngine(flag?: boolean): boolean {
+  if (flag !== undefined) {
+    return flag;
+  }
+
+  return process.env.USE_AOC_PAYOUT_ENGINE === 'true';
+}
+
+export class HrkeyPayoutEngine {
+  private readonly useAocPayoutEngine: boolean;
+  private readonly client: HostedRuntimeClient;
+  private readonly localExecute: (request: RlusdWithdrawalRequest) => PayoutExecuteResult;
+
+  constructor(options: HrkeyPayoutEngineOptions = {}) {
+    this.useAocPayoutEngine = parseUseAocPayoutEngine(options.useAocPayoutEngine);
+    this.client = options.client ?? new HostedRuntimeClient();
+    this.localExecute =
+      options.localExecute ??
+      ((request) => ({
+        allowed: false,
+        reason_code: `LOCAL_PAYOUT_ENGINE_UNAVAILABLE_${request.withdrawal_id}`,
+      }));
+  }
+
+  async execute(request: RlusdWithdrawalRequest): Promise<PayoutExecuteResult> {
+    if (!this.useAocPayoutEngine) {
+      return this.localExecute(request);
+    }
+
+    return this.client.executePayout(request);
+  }
+}

--- a/runtime/__tests__/payoutHosted.test.ts
+++ b/runtime/__tests__/payoutHosted.test.ts
@@ -1,0 +1,169 @@
+import type { AddressInfo } from 'net';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { createRuntimeServer } from '../api/server';
+import { DEFAULT_RUNTIME_CORE } from '../api/routes';
+import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
+import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
+import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+
+describe('payout engine hosted endpoints', () => {
+  it('supports payout callback endpoint', async () => {
+    const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    const payoutExecutor = new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter());
+    const server = createRuntimeServer({
+      core: {
+        ...DEFAULT_RUNTIME_CORE,
+        trustService,
+        payoutExecutor,
+      },
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/payout/callback`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+        },
+        body: JSON.stringify({
+          payout_id: 'rlusd_wd_1',
+          provider_status: 'completed',
+          reason_code: 'SETTLED',
+        }),
+      });
+
+      const json = (await response.json()) as { success: boolean; data?: { received: boolean; reason_code: string } };
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data?.received).toBe(true);
+      expect(json.data?.reason_code).toBe('SETTLED');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('returns INVALID_PAYOUT_REQUEST for malformed payout payload', async () => {
+    const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    const payoutExecutor = new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter());
+    const server = createRuntimeServer({
+      core: {
+        ...DEFAULT_RUNTIME_CORE,
+        trustService,
+        payoutExecutor,
+      },
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/payout/execute`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+        },
+        body: JSON.stringify({
+          withdrawal_id: '',
+          subject_hash: '0xsubjecthash01',
+          consumer_id: 'hrkey-v1',
+          amount: 'not-a-number',
+          wallet_address: '0xabc123',
+        }),
+      });
+
+      const json = (await response.json()) as { success: boolean; error?: { code: string } };
+      expect(response.status).toBe(400);
+      expect(json.success).toBe(false);
+      expect(json.error?.code).toBe('INVALID_PAYOUT_REQUEST');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('preserves idempotent response for repeated payout execution', () => {
+    const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    trustService.registerCredential({
+      credential_ref: 'cred_1',
+      subject_hash: '0xsubjecthash01',
+      issuer_id: 'kyc-global-v1',
+      credential_hash: '0xcredentialhash',
+      metadata_hash: '0xmetadatahash',
+      kyc_level: 'basic',
+      issued_at: '2026-01-01T00:00:00Z',
+    });
+    trustService.grantConsent({
+      consent_id: 'consent_1',
+      subject_hash: '0xsubjecthash01',
+      consumer_id: 'hrkey-v1',
+      issuer_id: 'kyc-global-v1',
+      granted_at: '2026-01-02T00:00:00Z',
+    });
+
+    const payoutExecutor = new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter());
+    const request = {
+      withdrawal_id: 'wd_1',
+      subject_hash: '0xsubjecthash01',
+      consumer_id: 'hrkey-v1',
+      amount: '100.00',
+      wallet_address: '0xabc123',
+      identity_issuer: 'kyc-global-v1',
+    };
+
+    const first = payoutExecutor.execute(request, new Date('2026-01-03T00:00:00Z'));
+    const second = payoutExecutor.execute(request, new Date('2026-01-04T00:00:00Z'));
+
+    expect(first).toEqual(second);
+    expect(first.allowed).toBe(true);
+    expect(first.reason_code).toBe('PAYOUT_ALLOWED');
+  });
+
+  it('routes /payout/execute through payoutExecutor (single execution path)', async () => {
+    const server = createRuntimeServer({
+      core: {
+        ...DEFAULT_RUNTIME_CORE,
+        payoutExecutor: {
+          execute: () => ({ allowed: true, reason_code: 'PAYOUT_ALLOWED' }),
+          callback: DEFAULT_RUNTIME_CORE.payoutExecutor.callback.bind(DEFAULT_RUNTIME_CORE.payoutExecutor),
+        } as never,
+      },
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/payout/execute`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+        },
+        body: JSON.stringify({
+          withdrawal_id: 'wd_route_1',
+          subject_hash: '0xsubjecthash01',
+          consumer_id: 'hrkey-v1',
+          amount: '100.00',
+          wallet_address: '0xabc123',
+        }),
+      });
+
+      const json = (await response.json()) as { success: boolean; data?: { allowed: boolean; reason_code: string } };
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data?.allowed).toBe(true);
+      expect(json.data?.reason_code).toBe('PAYOUT_ALLOWED');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('keeps only one /payout/execute case and no direct enforcePayoutKyc route call', () => {
+    const routesSource = readFileSync(join(__dirname, '..', 'api', 'routes.ts'), 'utf8');
+    const executeCaseCount = routesSource.split("case '/payout/execute':").length - 1;
+
+    expect(executeCaseCount).toBe(1);
+    expect(routesSource.includes('enforcePayoutKyc')).toBe(false);
+  });
+});

--- a/runtime/__tests__/trustHosted.test.ts
+++ b/runtime/__tests__/trustHosted.test.ts
@@ -2,6 +2,8 @@ import type { AddressInfo } from 'net';
 import { createRuntimeServer } from '../api/server';
 import { DEFAULT_RUNTIME_CORE } from '../api/routes';
 import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
+import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
 
 describe('trust layer hosted endpoints', () => {
   it('supports credential registration and verification', async () => {
@@ -10,6 +12,7 @@ describe('trust layer hosted endpoints', () => {
       core: {
         ...DEFAULT_RUNTIME_CORE,
         trustService,
+        payoutExecutor: new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter()),
       },
     });
     await new Promise<void>((resolve) => server.listen(0, resolve));
@@ -59,6 +62,7 @@ describe('trust layer hosted endpoints', () => {
       core: {
         ...DEFAULT_RUNTIME_CORE,
         trustService,
+        payoutExecutor: new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter()),
       },
     });
     await new Promise<void>((resolve) => server.listen(0, resolve));

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -1,6 +1,9 @@
 import { authorizeExecution, type ExecutionAuthorizationResult } from '../../protocol/execution';
 import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
 import { mintCapability, type ProtocolCapability } from '../../protocol/capability';
+import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
+import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
+import type { PayoutCallbackInput, PayoutExecuteResult } from '../payout/types';
 import { InMemoryTrustService, type GrantConsentInput, type RegisterCredentialInput, type VerifyIdentityInput } from '../trust/service';
 import type {
   AocIdentityConsentRecord,
@@ -15,13 +18,17 @@ export type RuntimeCore = {
   authorizeExecution: typeof authorizeExecution;
   mintCapability: typeof mintCapability;
   trustService: InMemoryTrustService;
+  payoutExecutor: RlusdPayoutExecutorService;
 };
+
+const defaultTrustService = new InMemoryTrustService();
 
 export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
   evaluateEnforcement,
   authorizeExecution,
   mintCapability,
-  trustService: new InMemoryTrustService(),
+  trustService: defaultTrustService,
+  payoutExecutor: new RlusdPayoutExecutorService(defaultTrustService, new RlusdPayoutAdapter()),
 };
 
 
@@ -42,6 +49,14 @@ function success<T>(data: T): ApiResponse<T> {
 
 function failure(code: string, message: string): ApiResponse<never> {
   return { success: false, error: { code, message } };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isNumericString(value: unknown): value is string {
+  return typeof value === 'string' && /^\d+(\.\d+)?$/.test(value.trim());
 }
 
 export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { decision: 'allow' | 'deny'; reasonCode: string } {
@@ -68,6 +83,9 @@ export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { deci
     const payout = data as { allowed: boolean; reason_code: string };
     return { decision: payout.allowed ? 'allow' : 'deny', reasonCode: payout.reason_code };
   }
+  if (endpoint === '/payout/callback') {
+    return { decision: 'allow', reasonCode: 'PAYOUT_CALLBACK_RECEIVED' };
+  }
 
   return {
     decision: 'allow',
@@ -86,7 +104,8 @@ export function executeRoute(
   | AocIdentityCredentialRecord
   | IdentityVerificationResult
   | AocIdentityConsentRecord
-  | { allowed: boolean; reason_code: string }
+  | PayoutExecuteResult
+  | { received: true; reason_code: string }
 > {
   try {
     switch (endpoint) {
@@ -96,8 +115,32 @@ export function executeRoute(
         return success(core.authorizeExecution(reviveNow(payload as Parameters<typeof authorizeExecution>[0])));
       case '/capability/mint':
         return success(core.mintCapability(payload as Parameters<typeof mintCapability>[0]));
-      case '/payout/execute':
-        return success(core.trustService.enforcePayoutKyc(payload as RlusdWithdrawalRequest));
+      case '/payout/execute': {
+        const request = payload as Partial<RlusdWithdrawalRequest>;
+        if (!isNonEmptyString(request.withdrawal_id)) {
+          return failure('INVALID_PAYOUT_REQUEST', 'withdrawal_id is required.');
+        }
+        if (!isNonEmptyString(request.subject_hash)) {
+          return failure('INVALID_PAYOUT_REQUEST', 'subject_hash is required.');
+        }
+        if (!isNonEmptyString(request.consumer_id)) {
+          return failure('INVALID_PAYOUT_REQUEST', 'consumer_id is required.');
+        }
+        if (!isNumericString(request.amount)) {
+          return failure('INVALID_PAYOUT_REQUEST', 'amount must be a numeric string.');
+        }
+
+        try {
+          return success(core.payoutExecutor.execute(request as RlusdWithdrawalRequest));
+        } catch (error) {
+          return failure(
+            'PAYOUT_EXECUTION_ERROR',
+            error instanceof Error ? error.message : 'Unknown payout execution error.'
+          );
+        }
+      }
+      case '/payout/callback':
+        return success(core.payoutExecutor.callback(payload as PayoutCallbackInput));
       case '/trust/credential/register':
         return success(core.trustService.registerCredential(payload as RegisterCredentialInput));
       case '/trust/verify':

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -12,6 +12,7 @@ const ENDPOINTS: RuntimeEndpoint[] = [
   '/execution/authorize',
   '/capability/mint',
   '/payout/execute',
+  '/payout/callback',
   '/trust/credential/register',
   '/trust/verify',
   '/trust/consent/grant',

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -13,3 +13,5 @@ export type {
   TrustAuditEvent,
 } from './trust/types';
 export type { ApiRequest, ApiResponse, ErrorResponse, RuntimeEndpoint } from './types/api-types';
+
+export type { PayoutCallbackInput, PayoutExecuteResult, PayoutAuditEvent } from './payout/types';

--- a/runtime/payout/payoutAdapters/rlusd.adapter.ts
+++ b/runtime/payout/payoutAdapters/rlusd.adapter.ts
@@ -1,0 +1,17 @@
+import type { PayoutAdapter, PayoutAdapterResult, PayoutExecutionContext } from '../types';
+
+/**
+ * Deterministic in-memory RLUSD adapter. Mirrors provider queue semantics while
+ * preserving response shape required by existing clients.
+ */
+export class RlusdPayoutAdapter implements PayoutAdapter {
+  execute(context: PayoutExecutionContext): PayoutAdapterResult {
+    const { withdrawal_id } = context.request;
+
+    return {
+      payout_id: `rlusd_${withdrawal_id}`,
+      provider_status: 'queued',
+      reason_code: 'PAYOUT_ALLOWED',
+    };
+  }
+}

--- a/runtime/payout/rlusdPayoutExecutor.service.ts
+++ b/runtime/payout/rlusdPayoutExecutor.service.ts
@@ -1,0 +1,83 @@
+import type { InMemoryTrustService } from '../trust/service';
+import type { PayoutAdapter } from './types';
+import type { PayoutAuditEvent, PayoutCallbackInput, PayoutExecuteResult } from './types';
+import type { RlusdWithdrawalRequest } from '../trust/types';
+
+export class RlusdPayoutExecutorService {
+  private readonly auditEvents: PayoutAuditEvent[] = [];
+  private readonly idempotentResults = new Map<string, PayoutExecuteResult>();
+
+  constructor(
+    private readonly trustService: InMemoryTrustService,
+    private readonly adapter: PayoutAdapter
+  ) {}
+
+  getAuditEvents(): readonly PayoutAuditEvent[] {
+    return [...this.auditEvents];
+  }
+
+  execute(request: RlusdWithdrawalRequest, now: Date = new Date()): PayoutExecuteResult {
+    const cached = this.idempotentResults.get(request.withdrawal_id);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    this.auditEvents.push({
+      event_type: 'PAYOUT_EXECUTION_REQUESTED',
+      at: now.toISOString(),
+      withdrawal_id: request.withdrawal_id,
+      reason_code: 'PAYOUT_REQUEST_RECEIVED',
+    });
+
+    const kycDecision = this.trustService.enforcePayoutKyc(request, now);
+    if (!kycDecision.allowed) {
+      const blocked: PayoutExecuteResult = {
+        allowed: false,
+        reason_code: kycDecision.reason_code,
+      };
+      this.idempotentResults.set(request.withdrawal_id, blocked);
+      this.auditEvents.push({
+        event_type: 'PAYOUT_EXECUTION_RESULT',
+        at: now.toISOString(),
+        withdrawal_id: request.withdrawal_id,
+        reason_code: blocked.reason_code,
+        provider_status: 'failed',
+      });
+      return blocked;
+    }
+
+    const adapterResult = this.adapter.execute({ request, kycDecision });
+    const allowed: PayoutExecuteResult = {
+      allowed: true,
+      reason_code: adapterResult.reason_code,
+      payout_id: adapterResult.payout_id,
+      provider_status: adapterResult.provider_status,
+    };
+    this.idempotentResults.set(request.withdrawal_id, allowed);
+    this.auditEvents.push({
+      event_type: 'PAYOUT_EXECUTION_RESULT',
+      at: now.toISOString(),
+      withdrawal_id: request.withdrawal_id,
+      payout_id: adapterResult.payout_id,
+      reason_code: adapterResult.reason_code,
+      provider_status: adapterResult.provider_status,
+    });
+
+    return allowed;
+  }
+
+  callback(input: PayoutCallbackInput, now: Date = new Date()): { received: true; reason_code: string } {
+    this.auditEvents.push({
+      event_type: 'PAYOUT_CALLBACK_RECEIVED',
+      at: input.occurred_at ?? now.toISOString(),
+      payout_id: input.payout_id,
+      reason_code: input.reason_code ?? 'PAYOUT_CALLBACK_RECEIVED',
+      provider_status: input.provider_status,
+    });
+
+    return {
+      received: true,
+      reason_code: input.reason_code ?? 'PAYOUT_CALLBACK_RECEIVED',
+    };
+  }
+}

--- a/runtime/payout/types.ts
+++ b/runtime/payout/types.ts
@@ -1,0 +1,40 @@
+import type { RlusdWithdrawalRequest } from '../trust/types';
+
+export type PayoutExecuteResult = {
+  allowed: boolean;
+  reason_code: string;
+  payout_id?: string;
+  provider_status?: 'queued' | 'completed' | 'failed';
+};
+
+export type PayoutCallbackInput = {
+  payout_id: string;
+  provider_status: 'queued' | 'completed' | 'failed';
+  provider_ref?: string;
+  reason_code?: string;
+  occurred_at?: string;
+};
+
+export type PayoutAuditEvent = {
+  event_type: 'PAYOUT_EXECUTION_REQUESTED' | 'PAYOUT_EXECUTION_RESULT' | 'PAYOUT_CALLBACK_RECEIVED';
+  at: string;
+  withdrawal_id?: string;
+  payout_id?: string;
+  reason_code: string;
+  provider_status?: 'queued' | 'completed' | 'failed';
+};
+
+export type PayoutExecutionContext = {
+  request: RlusdWithdrawalRequest;
+  kycDecision: { allowed: boolean; reason_code: string };
+};
+
+export type PayoutAdapterResult = {
+  payout_id: string;
+  provider_status: 'queued' | 'completed' | 'failed';
+  reason_code: string;
+};
+
+export interface PayoutAdapter {
+  execute(context: PayoutExecutionContext): PayoutAdapterResult;
+}

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -9,6 +9,7 @@ import type {
   RlusdWithdrawalRequest,
 } from '../trust/types';
 import type { ApiResponse, RuntimeMode } from '../types/api-types';
+import type { PayoutCallbackInput, PayoutExecuteResult } from '../payout/types';
 
 type FetchLike = typeof fetch;
 
@@ -102,10 +103,18 @@ export class HostedRuntimeClient {
     return this.post('/trust/consent/grant', input);
   }
 
-  async executePayout(input: RlusdWithdrawalRequest): Promise<{ allowed: boolean; reason_code: string }> {
+  async executePayout(input: RlusdWithdrawalRequest): Promise<PayoutExecuteResult> {
     if (this.mode === 'local') {
       throw new Error('Payout execution is only available in hosted mode.');
     }
     return this.post('/payout/execute', input);
   }
+  async callbackPayout(input: PayoutCallbackInput): Promise<{ received: true; reason_code: string }> {
+    if (this.mode === 'local') {
+      throw new Error('Payout callback is only available in hosted mode.');
+    }
+    return this.post('/payout/callback', input);
+  }
+
 }
+

--- a/runtime/types/api-types.ts
+++ b/runtime/types/api-types.ts
@@ -3,6 +3,7 @@ export type RuntimeEndpoint =
   | '/execution/authorize'
   | '/capability/mint'
   | '/payout/execute'
+  | '/payout/callback'
   | '/trust/credential/register'
   | '/trust/verify'
   | '/trust/consent/grant';


### PR DESCRIPTION
### Motivation

- Introduce a hosted payout execution subsystem to route RLUSD-style withdrawals through the runtime and accept provider callbacks. 
- Provide an HRKey-side payout engine abstraction that can either call the hosted AOC payout endpoint or execute a local fallback path based on configuration. 
- Add validation, idempotency and audit hooks to ensure predictable, testable payout behavior.

### Description

- Added a payout domain with types and interfaces in `runtime/payout/types.ts` and a deterministic in-memory RLUSD adapter at `runtime/payout/payoutAdapters/rlusd.adapter.ts`.
- Implemented `RlusdPayoutExecutorService` in `runtime/payout/rlusdPayoutExecutor.service.ts` to perform KYC enforcement via the trust service, produce idempotent execution results, maintain audit events, and handle callbacks.
- Extended runtime API to support `/payout/execute` and `/payout/callback` endpoints and added request validation and error handling in `runtime/api/routes.ts`, plus included the new executor in `DEFAULT_RUNTIME_CORE` and endpoint list in `runtime/api/server.ts`.
- Updated the hosted client in `runtime/sdk/client.ts` to return typed `PayoutExecuteResult` from `executePayout` and added `callbackPayout`, and exported payout types from `runtime/index.ts`.
- Added an `HrkeyPayoutEngine` wrapper (`integration/hrkey/payoutEngine.ts`) with a `useAocPayoutEngine` flag (also controlled by `USE_AOC_PAYOUT_ENGINE` env var) and re-exported it from `integration/hrkey/index.ts`.
- Added unit/integration tests: `integration/hrkey/__tests__/payoutEngine.test.ts`, `runtime/__tests__/payoutHosted.test.ts`, and extended `runtime/__tests__/trustHosted.test.ts` to exercise hosted payout paths, validation, callback handling, routing behavior, and idempotency.

### Testing

- Ran the added tests `integration/hrkey/__tests__/payoutEngine.test.ts`, `runtime/__tests__/payoutHosted.test.ts`, and updated `runtime/__tests__/trustHosted.test.ts`, which exercise local vs hosted engine selection, `/payout/execute` validation and routing, callback handling, and idempotent results; all tests passed.
- Executed the project test suite via `npm test` to validate integrations and runtime routes, and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc55a147a08325a9d0f9802b52069f)