### PR TITLE
Centralize route error codes; refine payout callback handling and SDK types; add consumer-consent test

### DIFF
--- a/runtime/__tests__/payoutHosted.test.ts
+++ b/runtime/__tests__/payoutHosted.test.ts
@@ -45,7 +45,7 @@ describe('payout engine hosted endpoints', () => {
     }
   });
 
-  it('returns INVALID_PAYOUT_REQUEST for malformed payout payload', async () => {
+  it('returns INVALID_REQUEST for malformed payout payload', async () => {
     const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
     const payoutExecutor = new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter());
     const server = createRuntimeServer({
@@ -77,7 +77,7 @@ describe('payout engine hosted endpoints', () => {
       const json = (await response.json()) as { success: boolean; error?: { code: string } };
       expect(response.status).toBe(400);
       expect(json.success).toBe(false);
-      expect(json.error?.code).toBe('INVALID_PAYOUT_REQUEST');
+      expect(json.error?.code).toBe('INVALID_REQUEST');
     } finally {
       await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
     }
@@ -162,8 +162,13 @@ describe('payout engine hosted endpoints', () => {
   it('keeps only one /payout/execute case and no direct enforcePayoutKyc route call', () => {
     const routesSource = readFileSync(join(__dirname, '..', 'api', 'routes.ts'), 'utf8');
     const executeCaseCount = routesSource.split("case '/payout/execute':").length - 1;
+    const defaultCoreBlock = routesSource.match(/export const DEFAULT_RUNTIME_CORE[\s\S]*?};/)?.[0] ?? '';
+    const payoutExecutorKeyCount = defaultCoreBlock.split('payoutExecutor:').length - 1;
 
     expect(executeCaseCount).toBe(1);
+    expect(payoutExecutorKeyCount).toBe(1);
     expect(routesSource.includes('enforcePayoutKyc')).toBe(false);
+    expect(routesSource.includes('INVALID_PAYOUT_REQUEST')).toBe(false);
+    expect(routesSource.includes('PAYOUT_EXECUTION_ERROR')).toBe(false);
   });
 });

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -22,13 +22,21 @@ export type RuntimeCore = {
 };
 
 const defaultTrustService = new InMemoryTrustService();
+const defaultPayoutExecutor = new RlusdPayoutExecutorService(defaultTrustService, new RlusdPayoutAdapter());
+
+const ROUTE_ERRORS = {
+  invalidRequest: 'INVALID_REQUEST',
+  executionError: 'EXECUTION_ERROR',
+  routeNotFound: 'ROUTE_NOT_FOUND',
+  protocolError: 'PROTOCOL_ERROR',
+} as const;
 
 export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
   evaluateEnforcement,
   authorizeExecution,
   mintCapability,
   trustService: defaultTrustService,
-  payoutExecutor: new RlusdPayoutExecutorService(defaultTrustService, new RlusdPayoutAdapter()),
+  payoutExecutor: defaultPayoutExecutor,
 };
 
 
@@ -84,7 +92,8 @@ export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { deci
     return { decision: payout.allowed ? 'allow' : 'deny', reasonCode: payout.reason_code };
   }
   if (endpoint === '/payout/callback') {
-    return { decision: 'allow', reasonCode: 'PAYOUT_CALLBACK_RECEIVED' };
+    const callback = data as { received: true; reason_code: string };
+    return { decision: callback.received ? 'allow' : 'deny', reasonCode: callback.reason_code };
   }
 
   return {
@@ -118,23 +127,23 @@ export function executeRoute(
       case '/payout/execute': {
         const request = payload as Partial<RlusdWithdrawalRequest>;
         if (!isNonEmptyString(request.withdrawal_id)) {
-          return failure('INVALID_PAYOUT_REQUEST', 'withdrawal_id is required.');
+          return failure(ROUTE_ERRORS.invalidRequest, 'withdrawal_id is required.');
         }
         if (!isNonEmptyString(request.subject_hash)) {
-          return failure('INVALID_PAYOUT_REQUEST', 'subject_hash is required.');
+          return failure(ROUTE_ERRORS.invalidRequest, 'subject_hash is required.');
         }
         if (!isNonEmptyString(request.consumer_id)) {
-          return failure('INVALID_PAYOUT_REQUEST', 'consumer_id is required.');
+          return failure(ROUTE_ERRORS.invalidRequest, 'consumer_id is required.');
         }
         if (!isNumericString(request.amount)) {
-          return failure('INVALID_PAYOUT_REQUEST', 'amount must be a numeric string.');
+          return failure(ROUTE_ERRORS.invalidRequest, 'amount must be a numeric string.');
         }
 
         try {
           return success(core.payoutExecutor.execute(request as RlusdWithdrawalRequest));
         } catch (error) {
           return failure(
-            'PAYOUT_EXECUTION_ERROR',
+            ROUTE_ERRORS.executionError,
             error instanceof Error ? error.message : 'Unknown payout execution error.'
           );
         }
@@ -148,9 +157,9 @@ export function executeRoute(
       case '/trust/consent/grant':
         return success(core.trustService.grantConsent(payload as GrantConsentInput));
       default:
-        return failure('ROUTE_NOT_FOUND', `Unsupported endpoint: ${endpoint}`);
+        return failure(ROUTE_ERRORS.routeNotFound, `Unsupported endpoint: ${endpoint}`);
     }
   } catch (error) {
-    return failure('PROTOCOL_ERROR', error instanceof Error ? error.message : 'Unknown protocol error.');
+    return failure(ROUTE_ERRORS.protocolError, error instanceof Error ? error.message : 'Unknown protocol error.');
   }
 }

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -1,5 +1,6 @@
 export { createRuntimeServer } from './api/server';
 export { HostedRuntimeClient } from './sdk/client';
+export type { HostedRuntimeSdk, HostedRuntimeClientOptions, PayoutCallbackResult } from './sdk/client';
 export { InMemoryApiKeyStore, DEFAULT_API_KEYS } from './auth/apiKeys';
 export { InMemoryRateLimiter } from './limits/rateLimiter';
 export { RuntimeLogger } from './logging/logger';

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -23,12 +23,24 @@ export type HostedRuntimeClientOptions = {
 async function parseApiResponse<T>(response: Response): Promise<T> {
   const parsed = (await response.json()) as ApiResponse<T>;
   if (!parsed.success || parsed.data === undefined) {
-    throw new Error(parsed.error?.message ?? parsed.error?.code ?? 'Unknown API error.');
+    const code = parsed.error?.code ?? 'UNKNOWN_API_ERROR';
+    const message = parsed.error?.message ?? 'Unknown API error.';
+    throw new Error(`[${code}] ${message}`);
   }
   return parsed.data;
 }
 
-export class HostedRuntimeClient {
+export type PayoutCallbackResult = { received: true; reason_code: string };
+
+export interface HostedRuntimeSdk {
+  registerCredential(input: RegisterCredentialInput): Promise<AocIdentityCredentialRecord>;
+  verifyIdentity(input: VerifyIdentityInput): Promise<IdentityVerificationResult>;
+  grantIdentityConsent(input: GrantConsentInput): Promise<AocIdentityConsentRecord>;
+  executePayout(input: RlusdWithdrawalRequest): Promise<PayoutExecuteResult>;
+  callbackPayout(input: PayoutCallbackInput): Promise<PayoutCallbackResult>;
+}
+
+export class HostedRuntimeClient implements HostedRuntimeSdk {
   private readonly mode: RuntimeMode;
   private readonly apiKey?: string;
   private readonly baseUrl: string;
@@ -109,7 +121,7 @@ export class HostedRuntimeClient {
     }
     return this.post('/payout/execute', input);
   }
-  async callbackPayout(input: PayoutCallbackInput): Promise<{ received: true; reason_code: string }> {
+  async callbackPayout(input: PayoutCallbackInput): Promise<PayoutCallbackResult> {
     if (this.mode === 'local') {
       throw new Error('Payout callback is only available in hosted mode.');
     }
@@ -117,4 +129,3 @@ export class HostedRuntimeClient {
   }
 
 }
-

--- a/runtime/trust/__tests__/service.test.ts
+++ b/runtime/trust/__tests__/service.test.ts
@@ -3,6 +3,7 @@ import type { RlusdWithdrawalRequest } from '../types';
 
 const SUBJECT_HASH = '0xsubjecthash01';
 const CONSUMER = 'hrkey-v1';
+const CONSUMER_B = 'market-maker-b';
 
 function buildWithdrawalRequest(overrides: Partial<RlusdWithdrawalRequest> = {}): RlusdWithdrawalRequest {
   return {
@@ -79,5 +80,43 @@ describe('InMemoryTrustService', () => {
 
     expect(blocked.allowed).toBe(false);
     expect(blocked.reason_code).toBe('PAYOUT_BLOCKED_NOT_FOUND');
+  });
+
+  it('enforces consumer-specific consent across multiple consumer_id values', () => {
+    const trust = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    trust.registerCredential({
+      credential_ref: 'cred_multi_consumer',
+      subject_hash: SUBJECT_HASH,
+      issuer_id: 'kyc-global-v1',
+      credential_hash: '0xcredentialhash_multi',
+      metadata_hash: '0xmetadatahash_multi',
+      kyc_level: 'basic',
+      issued_at: '2026-01-01T00:00:00Z',
+      expires_at: '2027-01-01T00:00:00Z',
+    });
+
+    trust.grantConsent({
+      consent_id: 'consent_consumer_a',
+      subject_hash: SUBJECT_HASH,
+      consumer_id: CONSUMER,
+      issuer_id: 'kyc-global-v1',
+      granted_at: '2026-02-01T00:00:00Z',
+    });
+
+    const consumerA = trust.verifyIdentity({
+      subject_hash: SUBJECT_HASH,
+      consumer_id: CONSUMER,
+      now: new Date('2026-02-01T00:00:00Z'),
+    });
+    const consumerB = trust.verifyIdentity({
+      subject_hash: SUBJECT_HASH,
+      consumer_id: CONSUMER_B,
+      now: new Date('2026-02-01T00:00:00Z'),
+    });
+
+    expect(consumerA.valid).toBe(true);
+    expect(consumerA.reason_code).toBe('VERIFIED');
+    expect(consumerB.valid).toBe(false);
+    expect(consumerB.reason_code).toBe('CONSENT_REQUIRED');
   });
 });


### PR DESCRIPTION
### Motivation

- Consolidate and standardize API error codes for runtime routes to simplify client/server error handling and avoid scattered literal strings.
- Make the payout callback decision logic explicit and safe by checking the `received` flag on callback payloads.
- Surface SDK types and improve API error messages in the hosted client to make errors easier to inspect programmatically.
- Add a unit test to validate consumer-specific consent enforcement in the trust service.

### Description

- Introduced `ROUTE_ERRORS` in `runtime/api/routes.ts` and replaced scattered literal error codes with `ROUTE_ERRORS` constants for request, execution, route-not-found, and protocol errors via `executeRoute`.
- Created a single `defaultPayoutExecutor` instance and reused it in `DEFAULT_RUNTIME_CORE` to make runtime source checks deterministic.
- Updated `/payout/callback` decision derivation to inspect the callback payload (`received` and `reason_code`) and return corresponding `decision` and `reasonCode`.
- Changed validation failures for `/payout/execute` to return `INVALID_REQUEST` instead of `INVALID_PAYOUT_REQUEST`, and use `EXECUTION_ERROR`/other standardized keys via `ROUTE_ERRORS`.
- Exported additional SDK types from `runtime/index.ts` and added `HostedRuntimeSdk` and `PayoutCallbackResult` types in `runtime/sdk/client.ts`, and made the `HostedRuntimeClient` implement the new interface.
- Improved `parseApiResponse` to include the server error code in thrown exceptions as `[CODE] message` for easier debugging.
- Adjusted tests and assertions in `runtime/__tests__/payoutHosted.test.ts` to expect the new `INVALID_REQUEST` code and added static checks against `routes.ts` source to ensure only one `/payout/execute` case and that old error strings are not present.
- Added a new test in `runtime/trust/__tests__/service.test.ts` to verify consumer-specific consent enforcement across multiple `consumer_id` values.

### Testing

- Ran the updated unit tests in `runtime/__tests__/payoutHosted.test.ts`, which assert HTTP responses and route source contents, and they passed.
- Ran the trust service tests including the new consumer-consent test in `runtime/trust/__tests__/service.test.ts`, and they passed.
- Ran the full test suite for the runtime package (unit tests via the existing test runner), and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc60ade4b88325a5a03ebb8d534cf2)