### PR TITLE
Add data access + audit endpoints, in-memory services, SDK client methods, and tests

### DIFF
--- a/runtime/__tests__/dataAccessHosted.test.ts
+++ b/runtime/__tests__/dataAccessHosted.test.ts
@@ -1,0 +1,217 @@
+import type { AddressInfo } from 'net';
+import { DataAccessService } from '../access/service';
+import { RuntimeAuditService } from '../audit/service';
+import { DEFAULT_RUNTIME_CORE } from '../api/routes';
+import { createRuntimeServer } from '../api/server';
+import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
+import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
+import { HostedRuntimeClient } from '../sdk/client';
+import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+
+function buildCore() {
+  const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+  const payoutExecutor = new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter());
+  const dataAccessService = new DataAccessService(trustService);
+  const auditService = new RuntimeAuditService(trustService, payoutExecutor, dataAccessService);
+
+  return {
+    ...DEFAULT_RUNTIME_CORE,
+    trustService,
+    payoutExecutor,
+    dataAccessService,
+    auditService,
+  };
+}
+
+describe('data access + audit endpoints', () => {
+  it('allows data access with valid credential + consent and emits audit events', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const client = new HostedRuntimeClient({ baseUrl: `http://127.0.0.1:${port}`, apiKey: 'aoc_free_dev_key' });
+
+      await client.registerCredential({
+        credential_ref: 'cred_allowed_1',
+        subject_hash: '0xsubject_a',
+        issuer_id: 'kyc-global-v1',
+        credential_hash: '0xcredhash',
+        metadata_hash: '0xmeta',
+        kyc_level: 'enhanced',
+        issued_at: '2026-01-01T00:00:00Z',
+      });
+      await client.grantIdentityConsent({
+        consent_id: 'consent_allowed_1',
+        subject_hash: '0xsubject_a',
+        consumer_id: 'mm-alpha',
+        issuer_id: 'kyc-global-v1',
+        granted_at: '2026-01-02T00:00:00Z',
+      });
+
+      const decision = await client.requestDataAccess({
+        subject_hash: '0xsubject_a',
+        consumer_id: 'mm-alpha',
+        dataset_id: 'dataset-001',
+        purpose: 'risk_scoring',
+        requested_scope: ['summary'],
+        now: new Date('2026-01-03T00:00:00Z'),
+      });
+
+      expect(decision.allowed).toBe(true);
+      expect(decision.reason_code).toBe('ACCESS_ALLOWED');
+      expect(decision.access_token).toContain('aoc_access_');
+      expect(decision.expires_at).toBeDefined();
+      expect(decision.audit_ref).toBeDefined();
+
+      const events = await client.listAuditEvents({
+        subject_hash: '0xsubject_a',
+        consumer_id: 'mm-alpha',
+      });
+      const accessRequested = events.find((event) => event.event_type === 'DATA_ACCESS_REQUESTED');
+      const accessAllowed = events.find((event) => event.event_type === 'DATA_ACCESS_ALLOWED');
+
+      expect(accessRequested).toBeDefined();
+      expect(accessAllowed).toBeDefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('denies access when consent is missing', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const client = new HostedRuntimeClient({ baseUrl: `http://127.0.0.1:${port}`, apiKey: 'aoc_free_dev_key' });
+
+      await client.registerCredential({
+        credential_ref: 'cred_noconsent_1',
+        subject_hash: '0xsubject_b',
+        issuer_id: 'kyc-global-v1',
+        credential_hash: '0xcredhashb',
+        metadata_hash: '0xmetab',
+        kyc_level: 'basic',
+        issued_at: '2026-02-01T00:00:00Z',
+      });
+
+      const decision = await client.requestDataAccess({
+        subject_hash: '0xsubject_b',
+        consumer_id: 'mm-beta',
+        dataset_id: 'dataset-001',
+        purpose: 'analytics',
+      });
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason_code).toBe('ACCESS_DENIED_CONSENT_REQUIRED');
+
+      const deniedEvents = await client.listAuditEvents({ event_type: 'DATA_ACCESS_DENIED', consumer_id: 'mm-beta' });
+      expect(deniedEvents.length).toBeGreaterThan(0);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('denies access when trust/credential is missing and keeps market-maker separation', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const client = new HostedRuntimeClient({ baseUrl: `http://127.0.0.1:${port}`, apiKey: 'aoc_free_dev_key' });
+
+      await client.registerCredential({
+        credential_ref: 'cred_mm_scope_1',
+        subject_hash: '0xsubject_c',
+        issuer_id: 'kyc-global-v1',
+        credential_hash: '0xcredhashc',
+        metadata_hash: '0xmetac',
+        kyc_level: 'basic',
+        issued_at: '2026-03-01T00:00:00Z',
+      });
+      await client.grantIdentityConsent({
+        consent_id: 'consent_mm_scope_1',
+        subject_hash: '0xsubject_c',
+        consumer_id: 'mm-gamma',
+        issuer_id: 'kyc-global-v1',
+        granted_at: '2026-03-02T00:00:00Z',
+      });
+
+      const missingTrust = await client.requestDataAccess({
+        subject_hash: '0xsubject_missing',
+        consumer_id: 'mm-gamma',
+        dataset_id: 'dataset-009',
+        purpose: 'risk_scoring',
+      });
+      expect(missingTrust.allowed).toBe(false);
+      expect(missingTrust.reason_code).toBe('ACCESS_DENIED_NOT_FOUND');
+
+      const wrongMarketMaker = await client.requestDataAccess({
+        subject_hash: '0xsubject_c',
+        consumer_id: 'mm-delta',
+        dataset_id: 'dataset-009',
+        purpose: 'risk_scoring',
+      });
+      expect(wrongMarketMaker.allowed).toBe(false);
+      expect(wrongMarketMaker.reason_code).toBe('ACCESS_DENIED_CONSENT_REQUIRED');
+
+      const gammaEvents = await client.listAuditEvents({ consumer_id: 'mm-gamma', event_type: 'DATA_ACCESS_DENIED' });
+      const deltaEvents = await client.listAuditEvents({ consumer_id: 'mm-delta', event_type: 'DATA_ACCESS_DENIED' });
+
+      expect(gammaEvents.every((event) => !('consumer_id' in event) || event.consumer_id === 'mm-gamma')).toBe(true);
+      expect(deltaEvents.every((event) => !('consumer_id' in event) || event.consumer_id === 'mm-delta')).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('supports direct GET filter queries for audit events', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const base = `http://127.0.0.1:${port}`;
+      const headers = { 'x-api-key': 'aoc_free_dev_key' };
+
+      await fetch(`${base}/trust/credential/register`, {
+        method: 'POST',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          credential_ref: 'cred_query_1',
+          subject_hash: '0xsubject_d',
+          issuer_id: 'kyc-global-v1',
+          credential_hash: '0xcredhashd',
+          metadata_hash: '0xmetad',
+          kyc_level: 'basic',
+          issued_at: '2026-04-01T00:00:00Z',
+        }),
+      });
+
+      await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          subject_hash: '0xsubject_d',
+          consumer_id: 'mm-epsilon',
+          dataset_id: 'dataset-777',
+          purpose: 'fraud_detection',
+          now: '2026-04-03T00:00:00Z',
+        }),
+      });
+
+      const response = await fetch(
+        `${base}/audit/events?event_type=DATA_ACCESS_DENIED&subject_hash=0xsubject_d&from=2026-04-02T00:00:00Z`,
+        { method: 'GET', headers }
+      );
+
+      const json = (await response.json()) as { success: boolean; data?: { events: Array<{ event_type: string }> } };
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data?.events.every((event) => event.event_type === 'DATA_ACCESS_DENIED')).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+});

--- a/runtime/__tests__/deriveDecision.test.ts
+++ b/runtime/__tests__/deriveDecision.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { deriveDecision } from '../api/routes';
+
+describe('deriveDecision hardening', () => {
+  it('handles /data/access allowed and denied decisions', () => {
+    const allowed = deriveDecision('/data/access', { allowed: true, reason_code: 'ACCESS_ALLOWED' });
+    const denied = deriveDecision('/data/access', { allowed: false, reason_code: 'ACCESS_DENIED_CONSENT_REQUIRED' });
+
+    expect(allowed).toEqual({ decision: 'allow', reasonCode: 'ACCESS_ALLOWED' });
+    expect(denied).toEqual({ decision: 'deny', reasonCode: 'ACCESS_DENIED_CONSENT_REQUIRED' });
+  });
+
+  it('handles /audit/events explicitly', () => {
+    const decision = deriveDecision('/audit/events', { events: [] });
+
+    expect(decision).toEqual({ decision: 'allow', reasonCode: 'AUDIT_EVENTS_LISTED' });
+  });
+
+  it('denies unknown endpoints defensively', () => {
+    const decision = deriveDecision('/unknown/endpoint' as never, {});
+
+    expect(decision).toEqual({ decision: 'deny', reasonCode: 'UNKNOWN_ENDPOINT' });
+  });
+
+  it('does not contain duplicate reasonCode keys in return object literals', () => {
+    const routesSource = readFileSync(join(__dirname, '..', 'api', 'routes.ts'), 'utf8');
+    const returnObjects = routesSource.match(/return\s*\{[\s\S]*?\};/g) ?? [];
+
+    for (const objectLiteral of returnObjects) {
+      expect(objectLiteral.match(/reasonCode:/g)?.length ?? 0).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/runtime/access/service.ts
+++ b/runtime/access/service.ts
@@ -1,0 +1,112 @@
+import { createHash, randomUUID } from 'crypto';
+import type { InMemoryTrustService } from '../trust/service';
+import type { DataAccessAuditEvent, DataAccessDecision, DataAccessRequestInput, AccessTokenRecord } from './types';
+
+const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
+
+const TRUST_REASON_TO_ACCESS_REASON: Record<string, DataAccessDecision['reason_code']> = {
+  VERIFIED: 'ACCESS_ALLOWED',
+  NOT_FOUND: 'ACCESS_DENIED_NOT_FOUND',
+  ISSUER_INACTIVE: 'ACCESS_DENIED_ISSUER_INACTIVE',
+  EXPIRED: 'ACCESS_DENIED_EXPIRED',
+  REVOKED: 'ACCESS_DENIED_REVOKED',
+  CONSENT_REQUIRED: 'ACCESS_DENIED_CONSENT_REQUIRED',
+};
+
+export class DataAccessService {
+  private readonly auditEvents: DataAccessAuditEvent[] = [];
+  private readonly tokens = new Map<string, AccessTokenRecord>();
+
+  constructor(
+    private readonly trustService: InMemoryTrustService,
+    private readonly tokenTtlMs: number = DEFAULT_TOKEN_TTL_MS
+  ) {}
+
+  requestAccess(input: DataAccessRequestInput): DataAccessDecision {
+    const now = input.now ?? new Date();
+    const requestedAt = now.toISOString();
+    const requestRef = randomUUID();
+
+    this.auditEvents.push({
+      event_type: 'DATA_ACCESS_REQUESTED',
+      at: requestedAt,
+      subject_hash: input.subject_hash,
+      consumer_id: input.consumer_id,
+      dataset_id: input.dataset_id,
+      reason_code: 'ACCESS_REQUEST_RECEIVED',
+      audit_ref: requestRef,
+    });
+
+    const verification = this.trustService.verifyIdentity({
+      subject_hash: input.subject_hash,
+      consumer_id: input.consumer_id,
+      now,
+    });
+
+    const reasonCode = TRUST_REASON_TO_ACCESS_REASON[verification.reason_code] ?? 'ACCESS_DENIED_NOT_FOUND';
+
+    if (!verification.valid) {
+      const deniedRef = randomUUID();
+      this.auditEvents.push({
+        event_type: 'DATA_ACCESS_DENIED',
+        at: requestedAt,
+        subject_hash: input.subject_hash,
+        consumer_id: input.consumer_id,
+        dataset_id: input.dataset_id,
+        reason_code: reasonCode,
+        audit_ref: deniedRef,
+      });
+      return {
+        allowed: false,
+        reason_code: reasonCode,
+        audit_ref: deniedRef,
+      };
+    }
+
+    const auditRef = randomUUID();
+    const expiresAt = new Date(now.getTime() + this.tokenTtlMs).toISOString();
+    const token = this.generateToken(auditRef, input, requestedAt, expiresAt);
+
+    this.tokens.set(token, {
+      token,
+      audit_ref: auditRef,
+      subject_hash: input.subject_hash,
+      consumer_id: input.consumer_id,
+      dataset_id: input.dataset_id,
+      purpose: input.purpose,
+      requested_scope: input.requested_scope ?? [],
+      issued_at: requestedAt,
+      expires_at: expiresAt,
+    });
+
+    this.auditEvents.push({
+      event_type: 'DATA_ACCESS_ALLOWED',
+      at: requestedAt,
+      subject_hash: input.subject_hash,
+      consumer_id: input.consumer_id,
+      dataset_id: input.dataset_id,
+      reason_code: 'ACCESS_ALLOWED',
+      audit_ref: auditRef,
+    });
+
+    return {
+      allowed: true,
+      reason_code: 'ACCESS_ALLOWED',
+      access_token: token,
+      expires_at: expiresAt,
+      audit_ref: auditRef,
+    };
+  }
+
+  getAuditEvents(): readonly DataAccessAuditEvent[] {
+    return [...this.auditEvents];
+  }
+
+  private generateToken(auditRef: string, input: DataAccessRequestInput, issuedAt: string, expiresAt: string): string {
+    const digest = createHash('sha256')
+      .update(`${auditRef}:${input.subject_hash}:${input.consumer_id}:${input.dataset_id}:${issuedAt}:${expiresAt}`)
+      .digest('base64url');
+
+    return `aoc_access_${digest}`;
+  }
+}

--- a/runtime/access/types.ts
+++ b/runtime/access/types.ts
@@ -1,0 +1,44 @@
+export type DataAccessRequestInput = {
+  subject_hash: string;
+  consumer_id: string;
+  dataset_id: string;
+  purpose: string;
+  requested_scope?: string[];
+  now?: Date;
+};
+
+export type DataAccessDecision = {
+  allowed: boolean;
+  reason_code:
+    | 'ACCESS_ALLOWED'
+    | 'ACCESS_DENIED_NOT_FOUND'
+    | 'ACCESS_DENIED_ISSUER_INACTIVE'
+    | 'ACCESS_DENIED_EXPIRED'
+    | 'ACCESS_DENIED_REVOKED'
+    | 'ACCESS_DENIED_CONSENT_REQUIRED';
+  access_token?: string;
+  expires_at?: string;
+  audit_ref: string;
+};
+
+export type DataAccessAuditEvent = {
+  event_type: 'DATA_ACCESS_REQUESTED' | 'DATA_ACCESS_ALLOWED' | 'DATA_ACCESS_DENIED';
+  at: string;
+  subject_hash: string;
+  consumer_id: string;
+  dataset_id: string;
+  reason_code: string;
+  audit_ref: string;
+};
+
+export type AccessTokenRecord = {
+  token: string;
+  audit_ref: string;
+  subject_hash: string;
+  consumer_id: string;
+  dataset_id: string;
+  purpose: string;
+  requested_scope: string[];
+  issued_at: string;
+  expires_at: string;
+};

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -1,6 +1,9 @@
 import { authorizeExecution, type ExecutionAuthorizationResult } from '../../protocol/execution';
 import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
 import { mintCapability, type ProtocolCapability } from '../../protocol/capability';
+import { DataAccessService } from '../access/service';
+import type { DataAccessDecision, DataAccessRequestInput } from '../access/types';
+import { RuntimeAuditService, type AuditEvent, type ListAuditEventsInput } from '../audit/service';
 import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
 import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
 import type { PayoutCallbackInput, PayoutExecuteResult } from '../payout/types';
@@ -19,10 +22,14 @@ export type RuntimeCore = {
   mintCapability: typeof mintCapability;
   trustService: InMemoryTrustService;
   payoutExecutor: RlusdPayoutExecutorService;
+  dataAccessService: DataAccessService;
+  auditService: RuntimeAuditService;
 };
 
 const defaultTrustService = new InMemoryTrustService();
 const defaultPayoutExecutor = new RlusdPayoutExecutorService(defaultTrustService, new RlusdPayoutAdapter());
+const defaultDataAccessService = new DataAccessService(defaultTrustService);
+const defaultAuditService = new RuntimeAuditService(defaultTrustService, defaultPayoutExecutor, defaultDataAccessService);
 
 const ROUTE_ERRORS = {
   invalidRequest: 'INVALID_REQUEST',
@@ -37,8 +44,9 @@ export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
   mintCapability,
   trustService: defaultTrustService,
   payoutExecutor: defaultPayoutExecutor,
+  dataAccessService: defaultDataAccessService,
+  auditService: defaultAuditService,
 };
-
 
 function reviveNow<T extends Record<string, unknown>>(payload: T): T {
   if (typeof payload.now === 'string') {
@@ -65,6 +73,24 @@ function isNonEmptyString(value: unknown): value is string {
 
 function isNumericString(value: unknown): value is string {
   return typeof value === 'string' && /^\d+(\.\d+)?$/.test(value.trim());
+}
+
+function parseOptionalDate(input: unknown): Date | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (input instanceof Date) {
+    return input;
+  }
+  if (typeof input !== 'string') {
+    return undefined;
+  }
+
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
 }
 
 export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { decision: 'allow' | 'deny'; reasonCode: string } {
@@ -95,10 +121,40 @@ export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { deci
     const callback = data as { received: true; reason_code: string };
     return { decision: callback.received ? 'allow' : 'deny', reasonCode: callback.reason_code };
   }
+  if (endpoint === '/data/access') {
+    const access = data as { allowed: boolean; reason_code: string };
+    return { decision: access.allowed ? 'allow' : 'deny', reasonCode: access.reason_code };
+  }
+  if (endpoint === '/capability/mint') {
+    return { decision: 'allow', reasonCode: 'CAPABILITY_MINTED' };
+  }
+  if (endpoint === '/audit/events') {
+    return { decision: 'allow', reasonCode: 'AUDIT_EVENTS_LISTED' };
+  }
+
+  const knownEndpoints: RuntimeEndpoint[] = [
+    '/enforcement/evaluate',
+    '/execution/authorize',
+    '/capability/mint',
+    '/payout/execute',
+    '/payout/callback',
+    '/trust/credential/register',
+    '/trust/verify',
+    '/trust/consent/grant',
+    '/data/access',
+    '/audit/events',
+  ];
+
+  if (!knownEndpoints.includes(endpoint)) {
+    return {
+      decision: 'deny',
+      reasonCode: 'UNKNOWN_ENDPOINT',
+    };
+  }
 
   return {
     decision: 'allow',
-    reasonCode: 'CAPABILITY_MINTED',
+    reasonCode: 'UNHANDLED_ENDPOINT',
   };
 }
 
@@ -114,7 +170,9 @@ export function executeRoute(
   | IdentityVerificationResult
   | AocIdentityConsentRecord
   | PayoutExecuteResult
+  | DataAccessDecision
   | { received: true; reason_code: string }
+  | { events: AuditEvent[] }
 > {
   try {
     switch (endpoint) {
@@ -156,6 +214,47 @@ export function executeRoute(
         return success(core.trustService.verifyIdentity(reviveNow(payload as VerifyIdentityInput)));
       case '/trust/consent/grant':
         return success(core.trustService.grantConsent(payload as GrantConsentInput));
+      case '/data/access': {
+        const request = reviveNow(payload as Partial<DataAccessRequestInput>);
+        if (!isNonEmptyString(request.subject_hash)) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'subject_hash is required.');
+        }
+        if (!isNonEmptyString(request.consumer_id)) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'consumer_id is required.');
+        }
+        if (!isNonEmptyString(request.dataset_id)) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'dataset_id is required.');
+        }
+        if (!isNonEmptyString(request.purpose)) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'purpose is required.');
+        }
+        if (request.requested_scope !== undefined && !Array.isArray(request.requested_scope)) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'requested_scope must be an array when provided.');
+        }
+
+        return success(core.dataAccessService.requestAccess(request as DataAccessRequestInput));
+      }
+      case '/audit/events': {
+        const request = payload as Partial<ListAuditEventsInput>;
+        const from = parseOptionalDate(request.from);
+        const to = parseOptionalDate(request.to);
+        if (request.from !== undefined && from === undefined) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'from must be a valid ISO-8601 date string.');
+        }
+        if (request.to !== undefined && to === undefined) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'to must be a valid ISO-8601 date string.');
+        }
+
+        const events = core.auditService.listEvents({
+          subject_hash: request.subject_hash,
+          consumer_id: request.consumer_id,
+          event_type: request.event_type,
+          from,
+          to,
+        });
+
+        return success({ events });
+      }
       default:
         return failure(ROUTE_ERRORS.routeNotFound, `Unsupported endpoint: ${endpoint}`);
     }

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -7,7 +7,7 @@ import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
 import { authAndLimit } from './middleware';
 import { DEFAULT_RUNTIME_CORE, deriveDecision, executeRoute, type RuntimeCore } from './routes';
 
-const ENDPOINTS: RuntimeEndpoint[] = [
+const POST_ENDPOINTS: RuntimeEndpoint[] = [
   '/enforcement/evaluate',
   '/execution/authorize',
   '/capability/mint',
@@ -16,7 +16,10 @@ const ENDPOINTS: RuntimeEndpoint[] = [
   '/trust/credential/register',
   '/trust/verify',
   '/trust/consent/grant',
+  '/data/access',
 ];
+
+const GET_ENDPOINTS: RuntimeEndpoint[] = ['/audit/events'];
 
 export type RuntimeServerDeps = {
   apiKeyStore?: InMemoryApiKeyStore;
@@ -45,6 +48,14 @@ async function parseJson(request: IncomingMessage): Promise<unknown> {
   return JSON.parse(raw);
 }
 
+function parseGetPayload(url: URL): Record<string, string> {
+  const payload: Record<string, string> = {};
+  for (const [key, value] of url.searchParams.entries()) {
+    payload[key] = value;
+  }
+  return payload;
+}
+
 export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
   const apiKeyStore = deps.apiKeyStore ?? new InMemoryApiKeyStore(DEFAULT_API_KEYS);
   const rateLimiter = deps.rateLimiter ?? new InMemoryRateLimiter();
@@ -52,15 +63,20 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
   const core = deps.core ?? DEFAULT_RUNTIME_CORE;
 
   return createServer(async (request, response) => {
-    if (request.method !== 'POST' || request.url === undefined) {
+    if (request.url === undefined) {
       return sendJson(response, 404, {
         success: false,
-        error: { code: 'ROUTE_NOT_FOUND', message: 'Only POST endpoints are supported.' },
+        error: { code: 'ROUTE_NOT_FOUND', message: 'Unknown endpoint.' },
       });
     }
 
-    const pathname = new URL(request.url, 'http://localhost').pathname as RuntimeEndpoint;
-    if (!ENDPOINTS.includes(pathname)) {
+    const url = new URL(request.url, 'http://localhost');
+    const pathname = url.pathname as RuntimeEndpoint;
+    const method = request.method ?? 'GET';
+
+    const isPost = method === 'POST' && POST_ENDPOINTS.includes(pathname);
+    const isGet = method === 'GET' && GET_ENDPOINTS.includes(pathname);
+    if (!isPost && !isGet) {
       return sendJson(response, 404, {
         success: false,
         error: { code: 'ROUTE_NOT_FOUND', message: `Unknown endpoint: ${pathname}` },
@@ -81,17 +97,21 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
     const { requestId } = authResult.data;
 
     let payload: unknown;
-    try {
-      payload = await parseJson(request);
-    } catch (error) {
-      logger.log({ requestId, endpoint: pathname, decision: 'deny', reason_code: 'REQUEST_PARSE_ERROR' });
-      return sendJson(response, 400, {
-        success: false,
-        error: {
-          code: 'REQUEST_PARSE_ERROR',
-          message: error instanceof Error ? error.message : 'Invalid JSON payload.',
-        },
-      });
+    if (method === 'GET') {
+      payload = parseGetPayload(url);
+    } else {
+      try {
+        payload = await parseJson(request);
+      } catch (error) {
+        logger.log({ requestId, endpoint: pathname, decision: 'deny', reason_code: 'REQUEST_PARSE_ERROR' });
+        return sendJson(response, 400, {
+          success: false,
+          error: {
+            code: 'REQUEST_PARSE_ERROR',
+            message: error instanceof Error ? error.message : 'Invalid JSON payload.',
+          },
+        });
+      }
     }
 
     const routeResult = executeRoute(pathname, payload, core);

--- a/runtime/audit/service.ts
+++ b/runtime/audit/service.ts
@@ -1,0 +1,64 @@
+import type { DataAccessService } from '../access/service';
+import type { DataAccessAuditEvent } from '../access/types';
+import type { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
+import type { PayoutAuditEvent } from '../payout/types';
+import type { InMemoryTrustService } from '../trust/service';
+import type { TrustAuditEvent } from '../trust/types';
+
+export type AuditEvent = TrustAuditEvent | PayoutAuditEvent | DataAccessAuditEvent;
+
+export type ListAuditEventsInput = {
+  subject_hash?: string;
+  consumer_id?: string;
+  event_type?: string;
+  from?: Date;
+  to?: Date;
+};
+
+export class RuntimeAuditService {
+  constructor(
+    private readonly trustService: InMemoryTrustService,
+    private readonly payoutExecutor: RlusdPayoutExecutorService,
+    private readonly dataAccessService: DataAccessService
+  ) {}
+
+  listEvents(input: ListAuditEventsInput): AuditEvent[] {
+    const all = [
+      ...this.trustService.getAuditEvents(),
+      ...this.payoutExecutor.getAuditEvents(),
+      ...this.dataAccessService.getAuditEvents(),
+    ];
+
+    return all
+      .filter((event) => this.matchesFilters(event, input))
+      .sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+  }
+
+  private matchesFilters(event: AuditEvent, input: ListAuditEventsInput): boolean {
+    if (input.subject_hash !== undefined) {
+      if (!('subject_hash' in event) || event.subject_hash !== input.subject_hash) {
+        return false;
+      }
+    }
+
+    if (input.consumer_id !== undefined) {
+      if (!('consumer_id' in event) || event.consumer_id !== input.consumer_id) {
+        return false;
+      }
+    }
+
+    if (input.event_type !== undefined && event.event_type !== input.event_type) {
+      return false;
+    }
+
+    const eventAt = Date.parse(event.at);
+    if (input.from !== undefined && eventAt < input.from.getTime()) {
+      return false;
+    }
+    if (input.to !== undefined && eventAt > input.to.getTime()) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -16,3 +16,7 @@ export type {
 export type { ApiRequest, ApiResponse, ErrorResponse, RuntimeEndpoint } from './types/api-types';
 
 export type { PayoutCallbackInput, PayoutExecuteResult, PayoutAuditEvent } from './payout/types';
+
+export type { DataAccessAuditEvent, DataAccessDecision, DataAccessRequestInput, AccessTokenRecord } from './access/types';
+export type { AuditEvent } from './audit/service';
+export type { ListAuditEventsInput } from './sdk/client';

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -1,6 +1,8 @@
 import { authorizeExecution, type ExecutionAuthorizationResult } from '../../protocol/execution';
 import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
 import { mintCapability, type MintCapabilityInput, type ProtocolCapability } from '../../protocol/capability';
+import type { DataAccessDecision, DataAccessRequestInput } from '../access/types';
+import type { AuditEvent } from '../audit/service';
 import type { GrantConsentInput, RegisterCredentialInput, VerifyIdentityInput } from '../trust/service';
 import type {
   AocIdentityConsentRecord,
@@ -18,6 +20,14 @@ export type HostedRuntimeClientOptions = {
   baseUrl?: string;
   mode?: RuntimeMode;
   fetchImpl?: FetchLike;
+};
+
+export type ListAuditEventsInput = {
+  subject_hash?: string;
+  consumer_id?: string;
+  event_type?: string;
+  from?: string;
+  to?: string;
 };
 
 async function parseApiResponse<T>(response: Response): Promise<T> {
@@ -38,6 +48,8 @@ export interface HostedRuntimeSdk {
   grantIdentityConsent(input: GrantConsentInput): Promise<AocIdentityConsentRecord>;
   executePayout(input: RlusdWithdrawalRequest): Promise<PayoutExecuteResult>;
   callbackPayout(input: PayoutCallbackInput): Promise<PayoutCallbackResult>;
+  requestDataAccess(input: DataAccessRequestInput): Promise<DataAccessDecision>;
+  listAuditEvents(input?: ListAuditEventsInput): Promise<AuditEvent[]>;
 }
 
 export class HostedRuntimeClient implements HostedRuntimeSdk {
@@ -65,6 +77,28 @@ export class HostedRuntimeClient implements HostedRuntimeSdk {
         'x-api-key': this.apiKey,
       },
       body: JSON.stringify(payload),
+    });
+
+    return parseApiResponse<TResponse>(response);
+  }
+
+  private async get<TResponse>(path: string, params: Record<string, string | undefined>): Promise<TResponse> {
+    if (this.apiKey === undefined || this.apiKey.trim() === '') {
+      throw new Error('HostedRuntimeClient remote mode requires apiKey.');
+    }
+
+    const url = new URL(`${this.baseUrl}${path}`);
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value.trim() !== '') {
+        url.searchParams.set(key, value);
+      }
+    });
+
+    const response = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        'x-api-key': this.apiKey,
+      },
     });
 
     return parseApiResponse<TResponse>(response);
@@ -128,4 +162,18 @@ export class HostedRuntimeClient implements HostedRuntimeSdk {
     return this.post('/payout/callback', input);
   }
 
+  async requestDataAccess(input: DataAccessRequestInput): Promise<DataAccessDecision> {
+    if (this.mode === 'local') {
+      throw new Error('Data access requests are only available in hosted mode.');
+    }
+    return this.post('/data/access', input);
+  }
+
+  async listAuditEvents(input: ListAuditEventsInput = {}): Promise<AuditEvent[]> {
+    if (this.mode === 'local') {
+      throw new Error('Audit event listing is only available in hosted mode.');
+    }
+    const result = await this.get<{ events: AuditEvent[] }>('/audit/events', input);
+    return result.events;
+  }
 }

--- a/runtime/types/api-types.ts
+++ b/runtime/types/api-types.ts
@@ -6,7 +6,9 @@ export type RuntimeEndpoint =
   | '/payout/callback'
   | '/trust/credential/register'
   | '/trust/verify'
-  | '/trust/consent/grant';
+  | '/trust/consent/grant'
+  | '/data/access'
+  | '/audit/events';
 
 export type ApiRequest<T> = {
   requestId?: string;


### PR DESCRIPTION
### Motivation

- Introduce a first-class data access flow with access decisions, short-lived access tokens, and audit event emission to support runtime data sharing and observability.  
- Provide an audit aggregation API to query events across trust, payout, and data-access subsystems.  
- Expose the new functionality through the hosted SDK and make the runtime server accept GET filters for audit queries.

### Description

- Add new in-memory data access implementation: `runtime/access/service.ts` and types in `runtime/access/types.ts` which generate access tokens, emit `DATA_ACCESS_REQUESTED`, `DATA_ACCESS_ALLOWED`, and `DATA_ACCESS_DENIED` audit events, and map trust verification results to access reason codes.  
- Add `RuntimeAuditService` in `runtime/audit/service.ts` that aggregates audit events from trust, payout, and data access and supports filtering by `subject_hash`, `consumer_id`, `event_type`, `from`, and `to`.  
- Wire services into the runtime core by updating `runtime/api/routes.ts`, adding request validation and handling for `'/data/access'` and `'/audit/events'`, enhancing `deriveDecision` for the new endpoints, and implementing `parseOptionalDate` for GET date parsing.  
- Extend `createRuntimeServer` in `runtime/api/server.ts` to support POST `'/data/access'` and GET `'/audit/events'` with query parsing via `parseGetPayload`, split endpoint lists into `POST_ENDPOINTS` / `GET_ENDPOINTS`, and improved route/parse error handling.  
- Extend the hosted SDK in `runtime/sdk/client.ts` with `requestDataAccess` and `listAuditEvents` (including a `get` helper that builds query params) and add exported types in `runtime/index.ts` and `runtime/types/api-types.ts`.  
- Add unit tests: `runtime/__tests__/dataAccessHosted.test.ts` for end-to-end hosted behavior (access allowed/denied flows, audit event emission, GET filter queries) and `runtime/__tests__/deriveDecision.test.ts` to harden `deriveDecision` and check for duplicate `reasonCode` keys in route return literals.

### Testing

- Ran the test suite including the new tests; `runtime/__tests__/dataAccessHosted.test.ts` and `runtime/__tests__/deriveDecision.test.ts` executed against the in-memory server and passed.  
- Exercise of the new endpoints was done via the `HostedRuntimeClient` in tests which validated request/response shapes, audit event listings, and date-filtered GET queries (all assertions succeeded).  
- No automated tests failed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6d32a4588325ad58c426b01d260a)