### PR TITLE
Add consent evaluation, validation, types and unit tests

### DIFF
--- a/protocol/consent/__tests__/evaluateConsent.test.ts
+++ b/protocol/consent/__tests__/evaluateConsent.test.ts
@@ -1,0 +1,154 @@
+import {
+  evaluateConsent,
+  CONSENT_DECISION_REASON_CODES,
+  type ConsentRecord,
+  type ConsentRequest,
+} from '..';
+
+function buildValidConsent(overrides: Partial<ConsentRecord> = {}): ConsentRecord {
+  return {
+    consent_id: 'consent-123',
+    subject_id: 'subject-1',
+    requester_id: 'requester-1',
+    resource: 'resource:profile',
+    actions: ['read', 'share'],
+    granted: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+    expires_at: '2026-12-31T00:00:00.000Z',
+    revoked_at: null,
+    consent_hash: 'hash-abc',
+    metadata: { source: 'test' },
+    ...overrides,
+  };
+}
+
+function buildValidRequest(overrides: Partial<ConsentRequest> = {}): ConsentRequest {
+  return {
+    subject_id: 'subject-1',
+    requester_id: 'requester-1',
+    resource: 'resource:profile',
+    action: 'read',
+    requested_at: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('evaluateConsent', () => {
+  it('allows when request exactly matches a granted active consent', () => {
+    const decision = evaluateConsent(buildValidRequest(), buildValidConsent());
+
+    expect(decision).toEqual({
+      allowed: true,
+      reason_code: CONSENT_DECISION_REASON_CODES.ALLOW,
+      evaluated_at: '2026-06-01T00:00:00.000Z',
+      consent_id: 'consent-123',
+    });
+  });
+
+  it('denies when consent is missing', () => {
+    const decision = evaluateConsent(buildValidRequest(), null);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_NO_CONSENT);
+    expect(decision.consent_id).toBeNull();
+  });
+
+  it('denies when subject does not match', () => {
+    const decision = evaluateConsent(buildValidRequest({ subject_id: 'subject-2' }), buildValidConsent());
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_SUBJECT_MISMATCH);
+  });
+
+  it('denies when requester does not match', () => {
+    const decision = evaluateConsent(
+      buildValidRequest({ requester_id: 'requester-2' }),
+      buildValidConsent()
+    );
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_REQUESTER_MISMATCH);
+  });
+
+  it('denies when resource does not match', () => {
+    const decision = evaluateConsent(
+      buildValidRequest({ resource: 'resource:billing' }),
+      buildValidConsent()
+    );
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_RESOURCE_MISMATCH);
+  });
+
+  it('denies when action is not granted', () => {
+    const decision = evaluateConsent(buildValidRequest({ action: 'delete' }), buildValidConsent());
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_ACTION_NOT_GRANTED);
+  });
+
+  it('denies when consent exists but is not granted', () => {
+    const decision = evaluateConsent(buildValidRequest(), buildValidConsent({ granted: false }));
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_NOT_GRANTED);
+  });
+
+  it('prioritizes not-granted denial before action checks', () => {
+    const decision = evaluateConsent(
+      buildValidRequest({ action: 'delete' }),
+      buildValidConsent({ granted: false })
+    );
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_NOT_GRANTED);
+  });
+
+  it('denies when consent is expired', () => {
+    const decision = evaluateConsent(
+      buildValidRequest({ requested_at: '2027-01-01T00:00:00.000Z' }),
+      buildValidConsent({ expires_at: '2026-12-31T00:00:00.000Z' })
+    );
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_EXPIRED);
+  });
+
+  it('denies when request is exactly at expiration timestamp', () => {
+    const decision = evaluateConsent(
+      buildValidRequest({ requested_at: '2026-12-31T00:00:00.000Z' }),
+      buildValidConsent({ expires_at: '2026-12-31T00:00:00.000Z' })
+    );
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_EXPIRED);
+  });
+
+  it('denies when consent has been revoked', () => {
+    const decision = evaluateConsent(
+      buildValidRequest({ requested_at: '2026-06-02T00:00:00.000Z' }),
+      buildValidConsent({ revoked_at: '2026-06-01T12:00:00.000Z' })
+    );
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_REVOKED);
+  });
+
+  it('denies when request predates consent creation', () => {
+    const decision = evaluateConsent(
+      buildValidRequest({ requested_at: '2025-12-31T23:59:59.000Z' }),
+      buildValidConsent({ created_at: '2026-01-01T00:00:00.000Z' })
+    );
+
+    expect(decision.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_INVALID_INPUT);
+  });
+
+  it('denies with invalid input for malformed request or consent', () => {
+    const malformedRequest = {
+      ...buildValidRequest(),
+      requested_at: 'not-a-date',
+    };
+
+    const decisionFromBadRequest = evaluateConsent(malformedRequest, buildValidConsent());
+    expect(decisionFromBadRequest.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_INVALID_INPUT);
+
+    const malformedConsent = {
+      ...buildValidConsent(),
+      actions: [],
+    };
+
+    const decisionFromBadConsent = evaluateConsent(buildValidRequest(), malformedConsent);
+    expect(decisionFromBadConsent.reason_code).toBe(CONSENT_DECISION_REASON_CODES.DENY_INVALID_INPUT);
+  });
+});

--- a/protocol/consent/evaluate.ts
+++ b/protocol/consent/evaluate.ts
@@ -1,0 +1,113 @@
+import {
+  CONSENT_DECISION_REASON_CODES,
+  type ConsentDecision,
+  type ConsentDecisionReasonCode,
+  type ConsentRecord,
+  type ConsentRequest,
+} from './types';
+import { isValidConsentRecord, isValidConsentRequest } from './validate';
+
+const FALLBACK_EVALUATED_AT = '1970-01-01T00:00:00.000Z';
+
+function toTimeMs(value: string): number {
+  return new Date(value).getTime();
+}
+
+function toDecision(
+  allowed: boolean,
+  reason_code: ConsentDecisionReasonCode,
+  evaluated_at: string,
+  consent_id: string | null
+): ConsentDecision {
+  return {
+    allowed,
+    reason_code,
+    evaluated_at,
+    consent_id,
+  };
+}
+
+function resolveEvaluatedAt(request: unknown): string {
+  if (request && typeof request === 'object') {
+    const requestedAt = (request as Partial<ConsentRequest>).requested_at;
+
+    if (typeof requestedAt === 'string' && Number.isFinite(Date.parse(requestedAt))) {
+      return new Date(requestedAt).toISOString();
+    }
+  }
+
+  return FALLBACK_EVALUATED_AT;
+}
+
+function resolveConsentId(consent: unknown): string | null {
+  if (consent && typeof consent === 'object') {
+    const consentId = (consent as Partial<ConsentRecord>).consent_id;
+    if (typeof consentId === 'string' && consentId.trim().length > 0) {
+      return consentId;
+    }
+  }
+
+  return null;
+}
+
+export function evaluateConsent(
+  request: ConsentRequest | unknown,
+  consent: ConsentRecord | null | undefined | unknown
+): ConsentDecision {
+  const evaluatedAt = resolveEvaluatedAt(request);
+  const consentId = resolveConsentId(consent);
+
+  if (!isValidConsentRequest(request)) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_INVALID_INPUT, evaluatedAt, consentId);
+  }
+
+  if (consent == null) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_NO_CONSENT, evaluatedAt, null);
+  }
+
+  if (!isValidConsentRecord(consent)) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_INVALID_INPUT, evaluatedAt, consentId);
+  }
+
+  if (request.subject_id !== consent.subject_id) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_SUBJECT_MISMATCH, evaluatedAt, consent.consent_id);
+  }
+
+  if (request.requester_id !== consent.requester_id) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_REQUESTER_MISMATCH, evaluatedAt, consent.consent_id);
+  }
+
+  if (request.resource !== consent.resource) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_RESOURCE_MISMATCH, evaluatedAt, consent.consent_id);
+  }
+
+  if (!consent.granted) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_NOT_GRANTED, evaluatedAt, consent.consent_id);
+  }
+
+  if (!consent.actions.includes(request.action)) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_ACTION_NOT_GRANTED, evaluatedAt, consent.consent_id);
+  }
+
+  const requestedAtMs = toTimeMs(request.requested_at);
+  const createdAtMs = toTimeMs(consent.created_at);
+
+  // Fail closed when a request predates consent issuance. A consent cannot authorize
+  // access that was requested before the consent itself existed.
+  if (requestedAtMs < createdAtMs) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_INVALID_INPUT, evaluatedAt, consent.consent_id);
+  }
+
+  // Revocation takes effect at the exact timestamp (`>=`) and afterwards.
+  if (consent.revoked_at !== null && requestedAtMs >= toTimeMs(consent.revoked_at)) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_REVOKED, evaluatedAt, consent.consent_id);
+  }
+
+  // Expiration is inclusive (`>=`) to match revocation semantics and keep
+  // time-bound policy checks deterministic at exact boundary instants.
+  if (consent.expires_at !== null && requestedAtMs >= toTimeMs(consent.expires_at)) {
+    return toDecision(false, CONSENT_DECISION_REASON_CODES.DENY_EXPIRED, evaluatedAt, consent.consent_id);
+  }
+
+  return toDecision(true, CONSENT_DECISION_REASON_CODES.ALLOW, evaluatedAt, consent.consent_id);
+}

--- a/protocol/consent/index.ts
+++ b/protocol/consent/index.ts
@@ -3,6 +3,9 @@ export { normalizeConsent } from './consent-normalizer';
 export { validateConsent } from './consent-validator';
 export { evaluateConsentState, isConsentActive, isConsentRevoked } from './consent-state';
 export { doesConsentAllowScope } from './consent-machine';
+export { evaluateConsent } from './evaluate';
+export { isValidConsentRecord, isValidConsentRequest } from './validate';
+export { CONSENT_DECISION_REASON_CODES } from './types';
 
 export { ConsentParseError, ConsentValidationError } from './consent-errors';
 
@@ -14,3 +17,10 @@ export type {
   ConsentEvaluationOptions,
   ConsentScopeRequest,
 } from './consent-types';
+
+export type {
+  ConsentRecord,
+  ConsentRequest,
+  ConsentDecision,
+  ConsentDecisionReasonCode,
+} from './types';

--- a/protocol/consent/types.ts
+++ b/protocol/consent/types.ts
@@ -1,0 +1,44 @@
+export type ConsentRecord = {
+  consent_id: string;
+  subject_id: string;
+  requester_id: string;
+  resource: string;
+  actions: string[];
+  granted: boolean;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  consent_hash: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export type ConsentRequest = {
+  subject_id: string;
+  requester_id: string;
+  resource: string;
+  action: string;
+  requested_at: string;
+};
+
+export const CONSENT_DECISION_REASON_CODES = {
+  ALLOW: 'ALLOW',
+  DENY_NO_CONSENT: 'DENY_NO_CONSENT',
+  DENY_SUBJECT_MISMATCH: 'DENY_SUBJECT_MISMATCH',
+  DENY_REQUESTER_MISMATCH: 'DENY_REQUESTER_MISMATCH',
+  DENY_RESOURCE_MISMATCH: 'DENY_RESOURCE_MISMATCH',
+  DENY_ACTION_NOT_GRANTED: 'DENY_ACTION_NOT_GRANTED',
+  DENY_NOT_GRANTED: 'DENY_NOT_GRANTED',
+  DENY_EXPIRED: 'DENY_EXPIRED',
+  DENY_REVOKED: 'DENY_REVOKED',
+  DENY_INVALID_INPUT: 'DENY_INVALID_INPUT',
+} as const;
+
+export type ConsentDecisionReasonCode =
+  (typeof CONSENT_DECISION_REASON_CODES)[keyof typeof CONSENT_DECISION_REASON_CODES];
+
+export type ConsentDecision = {
+  allowed: boolean;
+  reason_code: ConsentDecisionReasonCode;
+  evaluated_at: string;
+  consent_id: string | null;
+};

--- a/protocol/consent/validate.ts
+++ b/protocol/consent/validate.ts
@@ -1,0 +1,77 @@
+import type { ConsentRecord, ConsentRequest } from './types';
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidIsoDateString(value: unknown): value is string {
+  if (!isNonEmptyString(value)) {
+    return false;
+  }
+
+  return Number.isFinite(Date.parse(value));
+}
+
+export function isValidConsentRequest(request: unknown): request is ConsentRequest {
+  if (!request || typeof request !== 'object') {
+    return false;
+  }
+
+  const candidate = request as Partial<ConsentRequest>;
+
+  return (
+    isNonEmptyString(candidate.subject_id) &&
+    isNonEmptyString(candidate.requester_id) &&
+    isNonEmptyString(candidate.resource) &&
+    isNonEmptyString(candidate.action) &&
+    isValidIsoDateString(candidate.requested_at)
+  );
+}
+
+export function isValidConsentRecord(consent: unknown): consent is ConsentRecord {
+  if (!consent || typeof consent !== 'object') {
+    return false;
+  }
+
+  const candidate = consent as Partial<ConsentRecord>;
+
+  if (
+    !isNonEmptyString(candidate.consent_id) ||
+    !isNonEmptyString(candidate.subject_id) ||
+    !isNonEmptyString(candidate.requester_id) ||
+    !isNonEmptyString(candidate.resource) ||
+    typeof candidate.granted !== 'boolean' ||
+    !isValidIsoDateString(candidate.created_at)
+  ) {
+    return false;
+  }
+
+  if (
+    !Array.isArray(candidate.actions) ||
+    candidate.actions.length === 0 ||
+    candidate.actions.some((action) => !isNonEmptyString(action))
+  ) {
+    return false;
+  }
+
+  if (candidate.expires_at !== null && !isValidIsoDateString(candidate.expires_at)) {
+    return false;
+  }
+
+  if (candidate.revoked_at !== null && !isValidIsoDateString(candidate.revoked_at)) {
+    return false;
+  }
+
+  if (candidate.consent_hash !== null && !isNonEmptyString(candidate.consent_hash)) {
+    return false;
+  }
+
+  if (
+    candidate.metadata !== undefined &&
+    (candidate.metadata === null || typeof candidate.metadata !== 'object' || Array.isArray(candidate.metadata))
+  ) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
### Motivation
- Implement a deterministic consent evaluation engine and related types to decide whether a request is allowed based on stored consents.
- Provide robust input validation to fail closed on malformed requests or consent records.
- Expose the evaluation API and reason codes from the consent protocol surface for consumers and testing.

### Description
- Add `protocol/consent/types.ts` defining `ConsentRecord`, `ConsentRequest`, `ConsentDecision`, and `CONSENT_DECISION_REASON_CODES`.
- Add `protocol/consent/validate.ts` with `isValidConsentRequest` and `isValidConsentRecord` helper functions for input validation.
- Add `protocol/consent/evaluate.ts` implementing `evaluateConsent` which enforces subject/requester/resource matching, granted/actions checks, creation/revocation/expiration semantics, and produces typed decisions with `evaluated_at` and `consent_id` resolution.
- Export the new APIs and types from `protocol/consent/index.ts` and add comprehensive unit tests in `protocol/consent/__tests__/evaluateConsent.test.ts` covering allow/deny branches and edge time-bound cases.

### Testing
- Added unit tests in `protocol/consent/__tests__/evaluateConsent.test.ts` exercising matching, mismatches, not-granted, action checks, expiration, revocation, creation-time validation, and malformed inputs.
- Ran the test suite with `yarn test` and the new consent evaluation tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd049500c0832586deb298ac19baad)