### PR TITLE
PR24: Add protocol-level capability token layer on top of consent decisions

### DIFF
--- a/protocol/consent/__tests__/capabilityToken.test.ts
+++ b/protocol/consent/__tests__/capabilityToken.test.ts
@@ -1,0 +1,278 @@
+import {
+  authorizeWithCapability,
+  CAPABILITY_REASON_CODES,
+  CONSENT_DECISION_REASON_CODES,
+  issueCapabilityToken,
+  type ConsentDecision,
+  type ConsentRecord,
+  type ConsentRequest,
+  validateCapabilityToken,
+} from '..';
+
+const SECRET = 'test-secret';
+
+function buildConsent(overrides: Partial<ConsentRecord> = {}): ConsentRecord {
+  return {
+    consent_id: 'consent-1',
+    subject_id: 'subject-1',
+    requester_id: 'requester-1',
+    resource: 'resource:profile',
+    actions: ['read', 'share'],
+    granted: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+    expires_at: '2026-12-31T00:00:00.000Z',
+    revoked_at: null,
+    consent_hash: 'consent-hash-1',
+    ...overrides,
+  };
+}
+
+function buildRequest(overrides: Partial<ConsentRequest> = {}): ConsentRequest {
+  return {
+    subject_id: 'subject-1',
+    requester_id: 'requester-1',
+    resource: 'resource:profile',
+    action: 'read',
+    requested_at: '2026-05-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildDecision(overrides: Partial<ConsentDecision> = {}): ConsentDecision {
+  return {
+    allowed: true,
+    reason_code: CONSENT_DECISION_REASON_CODES.ALLOW,
+    evaluated_at: '2026-05-01T00:00:00.000Z',
+    consent_id: 'consent-1',
+    ...overrides,
+  };
+}
+
+describe('capability token issuance', () => {
+  it('issues a capability token from valid consent + request + allowed decision', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    expect(token.capability_id).toBe(token.capability_hash);
+    expect(token.signature).toHaveLength(64);
+    expect(token.action).toBe('read');
+  });
+
+  it('refuses issuance when decision.allowed is false', () => {
+    expect(() =>
+      issueCapabilityToken(
+        {
+          consent: buildConsent(),
+          request: buildRequest(),
+          decision: buildDecision({
+            allowed: false,
+            reason_code: CONSENT_DECISION_REASON_CODES.DENY_NOT_GRANTED,
+          }),
+        },
+        SECRET
+      )
+    ).toThrow(CAPABILITY_REASON_CODES.DECISION_NOT_ALLOWED);
+  });
+
+  it('refuses issuance when consent/request mismatch', () => {
+    expect(() =>
+      issueCapabilityToken(
+        {
+          consent: buildConsent(),
+          request: buildRequest({ resource: 'resource:billing' }),
+          decision: buildDecision(),
+        },
+        SECRET
+      )
+    ).toThrow(CAPABILITY_REASON_CODES.RESOURCE_MISMATCH);
+  });
+});
+
+describe('capability token validation', () => {
+  it('validates a correctly issued token', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    expect(validateCapabilityToken(token, SECRET)).toEqual({
+      valid: true,
+      reason_code: CAPABILITY_REASON_CODES.VALID,
+    });
+  });
+
+  it('fails on malformed token', () => {
+    expect(validateCapabilityToken({ invalid: true }, SECRET)).toEqual({
+      valid: false,
+      reason_code: CAPABILITY_REASON_CODES.INVALID_INPUT,
+    });
+  });
+
+  it('fails when hash is tampered', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    const tampered = { ...token, resource: 'resource:billing' };
+
+    expect(validateCapabilityToken(tampered, SECRET)).toEqual({
+      valid: false,
+      reason_code: CAPABILITY_REASON_CODES.INVALID_HASH,
+    });
+  });
+
+  it('fails when signature is tampered', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    expect(validateCapabilityToken({ ...token, signature: 'abc' }, SECRET)).toEqual({
+      valid: false,
+      reason_code: CAPABILITY_REASON_CODES.INVALID_SIGNATURE,
+    });
+  });
+
+  it('fails when token is expired at exact boundary timestamp', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-12-31T00:00:00.000Z'));
+
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent({ expires_at: '2026-12-31T00:00:00.000Z' }),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    expect(validateCapabilityToken(token, SECRET)).toEqual({
+      valid: false,
+      reason_code: CAPABILITY_REASON_CODES.EXPIRED,
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('fails when metadata is invalid', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    expect(validateCapabilityToken({ ...token, metadata: [] }, SECRET)).toEqual({
+      valid: false,
+      reason_code: CAPABILITY_REASON_CODES.INVALID_INPUT,
+    });
+  });
+});
+
+describe('capability token authorization', () => {
+  it('allows when request exactly matches a valid capability token', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    const result = authorizeWithCapability(buildRequest(), token, SECRET);
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason_code).toBe(CAPABILITY_REASON_CODES.ALLOW);
+    expect(result.capability_id).toBe(token.capability_id);
+  });
+
+  it('denies on requester mismatch', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    const result = authorizeWithCapability(
+      buildRequest({ requester_id: 'requester-2' }),
+      token,
+      SECRET
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason_code).toBe(CAPABILITY_REASON_CODES.REQUESTER_MISMATCH);
+  });
+
+  it('denies on resource mismatch', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    const result = authorizeWithCapability(buildRequest({ resource: 'resource:billing' }), token, SECRET);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason_code).toBe(CAPABILITY_REASON_CODES.RESOURCE_MISMATCH);
+  });
+
+  it('denies on action mismatch', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    const result = authorizeWithCapability(buildRequest({ action: 'delete' }), token, SECRET);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason_code).toBe(CAPABILITY_REASON_CODES.ACTION_MISMATCH);
+  });
+
+  it('denies when token validation fails', () => {
+    const token = issueCapabilityToken(
+      {
+        consent: buildConsent(),
+        request: buildRequest(),
+        decision: buildDecision(),
+      },
+      SECRET
+    );
+
+    const result = authorizeWithCapability(buildRequest(), { ...token, signature: 'tampered' }, SECRET);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason_code).toBe(CAPABILITY_REASON_CODES.DENY_INVALID_CAPABILITY);
+    expect(result.capability_id).toBeNull();
+  });
+});

--- a/protocol/consent/capability-authorize.ts
+++ b/protocol/consent/capability-authorize.ts
@@ -1,0 +1,58 @@
+import { validateCapabilityToken } from './capability-validate';
+import {
+  CAPABILITY_REASON_CODES,
+  type CapabilityAuthorizationRequest,
+  type CapabilityAuthorizationResult,
+  type CapabilityReasonCode,
+  type CapabilityToken,
+} from './capability-types';
+
+function deny(reason_code: CapabilityReasonCode, capability_id: string | null): CapabilityAuthorizationResult {
+  return {
+    allowed: false,
+    reason_code,
+    evaluated_at: new Date().toISOString(),
+    capability_id,
+  };
+}
+
+export function authorizeWithCapability(
+  request: CapabilityAuthorizationRequest,
+  token: unknown,
+  secret: string
+): CapabilityAuthorizationResult {
+  const validation = validateCapabilityToken(token, secret);
+
+  if (!validation.valid || !token || typeof token !== 'object') {
+    return deny(CAPABILITY_REASON_CODES.DENY_INVALID_CAPABILITY, null);
+  }
+
+  const capability = token as CapabilityToken;
+
+  if (request.consent_id !== undefined && request.consent_id !== capability.consent_id) {
+    return deny(CAPABILITY_REASON_CODES.CONSENT_MISMATCH, capability.capability_id);
+  }
+
+  if (request.subject_id !== capability.subject_id) {
+    return deny(CAPABILITY_REASON_CODES.SUBJECT_MISMATCH, capability.capability_id);
+  }
+
+  if (request.requester_id !== capability.requester_id) {
+    return deny(CAPABILITY_REASON_CODES.REQUESTER_MISMATCH, capability.capability_id);
+  }
+
+  if (request.resource !== capability.resource) {
+    return deny(CAPABILITY_REASON_CODES.RESOURCE_MISMATCH, capability.capability_id);
+  }
+
+  if (request.action !== capability.action) {
+    return deny(CAPABILITY_REASON_CODES.ACTION_MISMATCH, capability.capability_id);
+  }
+
+  return {
+    allowed: true,
+    reason_code: CAPABILITY_REASON_CODES.ALLOW,
+    evaluated_at: new Date().toISOString(),
+    capability_id: capability.capability_id,
+  };
+}

--- a/protocol/consent/capability-hash.ts
+++ b/protocol/consent/capability-hash.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'crypto';
+import type { CanonicalCapabilityPayload, CapabilityToken } from './capability-types';
+
+function canonicalizeCapabilityPayload(payload: CanonicalCapabilityPayload): string {
+  return JSON.stringify([
+    payload.consent_id,
+    payload.subject_id,
+    payload.requester_id,
+    payload.resource,
+    payload.action,
+    payload.issued_at,
+    payload.expires_at,
+    payload.nonce,
+  ]);
+}
+
+export function buildCanonicalCapabilityPayload(
+  token: Pick<CapabilityToken, keyof CanonicalCapabilityPayload>
+): CanonicalCapabilityPayload {
+  return {
+    consent_id: token.consent_id,
+    subject_id: token.subject_id,
+    requester_id: token.requester_id,
+    resource: token.resource,
+    action: token.action,
+    issued_at: token.issued_at,
+    expires_at: token.expires_at,
+    nonce: token.nonce,
+  };
+}
+
+export function hashCapabilityPayload(payload: CanonicalCapabilityPayload): string {
+  return createHash('sha256').update(canonicalizeCapabilityPayload(payload)).digest('hex');
+}

--- a/protocol/consent/capability-index.ts
+++ b/protocol/consent/capability-index.ts
@@ -1,0 +1,17 @@
+export { issueCapabilityToken } from './capability-issue';
+export { validateCapabilityToken } from './capability-validate';
+export { authorizeWithCapability } from './capability-authorize';
+export { hashCapabilityPayload, buildCanonicalCapabilityPayload } from './capability-hash';
+export { signCapabilityHash } from './capability-sign';
+
+export { CAPABILITY_REASON_CODES } from './capability-types';
+
+export type {
+  CapabilityToken,
+  CapabilityIssuanceInput,
+  CapabilityValidationResult,
+  CapabilityAuthorizationRequest,
+  CapabilityAuthorizationResult,
+  CapabilityReasonCode,
+  CanonicalCapabilityPayload,
+} from './capability-types';

--- a/protocol/consent/capability-issue.ts
+++ b/protocol/consent/capability-issue.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'crypto';
+import { buildCanonicalCapabilityPayload, hashCapabilityPayload } from './capability-hash';
+import { signCapabilityHash } from './capability-sign';
+import {
+  CAPABILITY_REASON_CODES,
+  type CapabilityIssuanceInput,
+  type CapabilityToken,
+} from './capability-types';
+import { CONSENT_DECISION_REASON_CODES } from './types';
+import { isValidConsentRecord, isValidConsentRequest } from './validate';
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidIsoDateString(value: unknown): value is string {
+  return isNonEmptyString(value) && Number.isFinite(Date.parse(value));
+}
+
+function deriveNonce(input: CapabilityIssuanceInput): string {
+  const fingerprint = JSON.stringify([
+    input.consent.consent_id,
+    input.request.subject_id,
+    input.request.requester_id,
+    input.request.resource,
+    input.request.action,
+    input.request.requested_at,
+    input.decision.evaluated_at,
+  ]);
+
+  return createHash('sha256').update(fingerprint).digest('hex');
+}
+
+function assertIssuable(input: CapabilityIssuanceInput, secret: string): void {
+  if (!isValidConsentRecord(input.consent) || !isValidConsentRequest(input.request)) {
+    throw new Error(CAPABILITY_REASON_CODES.INVALID_INPUT);
+  }
+
+  if (!isNonEmptyString(secret)) {
+    throw new Error(CAPABILITY_REASON_CODES.INVALID_INPUT);
+  }
+
+  if (!isValidIsoDateString(input.decision.evaluated_at)) {
+    throw new Error(CAPABILITY_REASON_CODES.INVALID_INPUT);
+  }
+
+  if (input.decision.allowed !== true || input.decision.reason_code !== CONSENT_DECISION_REASON_CODES.ALLOW) {
+    throw new Error(CAPABILITY_REASON_CODES.DECISION_NOT_ALLOWED);
+  }
+
+  if (input.decision.consent_id !== input.consent.consent_id) {
+    throw new Error(CAPABILITY_REASON_CODES.CONSENT_MISMATCH);
+  }
+
+  if (input.request.subject_id !== input.consent.subject_id) {
+    throw new Error(CAPABILITY_REASON_CODES.SUBJECT_MISMATCH);
+  }
+
+  if (input.request.requester_id !== input.consent.requester_id) {
+    throw new Error(CAPABILITY_REASON_CODES.REQUESTER_MISMATCH);
+  }
+
+  if (input.request.resource !== input.consent.resource) {
+    throw new Error(CAPABILITY_REASON_CODES.RESOURCE_MISMATCH);
+  }
+
+  if (!input.consent.actions.includes(input.request.action)) {
+    throw new Error(CAPABILITY_REASON_CODES.ACTION_MISMATCH);
+  }
+}
+
+export function issueCapabilityToken(input: CapabilityIssuanceInput, secret: string): CapabilityToken {
+  assertIssuable(input, secret);
+
+  const issuedAt = new Date(input.decision.evaluated_at).toISOString();
+  const nonce = deriveNonce(input);
+
+  const payload = buildCanonicalCapabilityPayload({
+    consent_id: input.consent.consent_id,
+    subject_id: input.request.subject_id,
+    requester_id: input.request.requester_id,
+    resource: input.request.resource,
+    action: input.request.action,
+    issued_at: issuedAt,
+    expires_at: input.consent.expires_at,
+    nonce,
+  });
+
+  const capabilityHash = hashCapabilityPayload(payload);
+  const signature = signCapabilityHash(capabilityHash, secret);
+
+  return {
+    capability_id: capabilityHash,
+    ...payload,
+    capability_hash: capabilityHash,
+    signature,
+  };
+}

--- a/protocol/consent/capability-sign.ts
+++ b/protocol/consent/capability-sign.ts
@@ -1,0 +1,5 @@
+import { createHmac } from 'crypto';
+
+export function signCapabilityHash(capabilityHash: string, secret: string): string {
+  return createHmac('sha256', secret).update(capabilityHash).digest('hex');
+}

--- a/protocol/consent/capability-types.ts
+++ b/protocol/consent/capability-types.ts
@@ -1,0 +1,72 @@
+import type { ConsentDecision, ConsentRecord, ConsentRequest } from './types';
+
+export const CAPABILITY_REASON_CODES = {
+  VALID: 'VALID',
+  INVALID_INPUT: 'INVALID_INPUT',
+  INVALID_SIGNATURE: 'INVALID_SIGNATURE',
+  INVALID_HASH: 'INVALID_HASH',
+  EXPIRED: 'EXPIRED',
+  SUBJECT_MISMATCH: 'SUBJECT_MISMATCH',
+  REQUESTER_MISMATCH: 'REQUESTER_MISMATCH',
+  RESOURCE_MISMATCH: 'RESOURCE_MISMATCH',
+  ACTION_MISMATCH: 'ACTION_MISMATCH',
+  CONSENT_MISMATCH: 'CONSENT_MISMATCH',
+  DECISION_NOT_ALLOWED: 'DECISION_NOT_ALLOWED',
+  DENY_INVALID_CAPABILITY: 'DENY_INVALID_CAPABILITY',
+  ALLOW: 'ALLOW',
+} as const;
+
+export type CapabilityReasonCode =
+  (typeof CAPABILITY_REASON_CODES)[keyof typeof CAPABILITY_REASON_CODES];
+
+export type CapabilityToken = {
+  capability_id: string;
+  consent_id: string;
+  subject_id: string;
+  requester_id: string;
+  resource: string;
+  action: string;
+  issued_at: string;
+  expires_at: string | null;
+  nonce: string;
+  capability_hash: string;
+  signature: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type CapabilityIssuanceInput = {
+  consent: ConsentRecord;
+  request: ConsentRequest;
+  decision: ConsentDecision;
+};
+
+export type CapabilityValidationResult = {
+  valid: boolean;
+  reason_code: CapabilityReasonCode;
+};
+
+export type CapabilityAuthorizationRequest = {
+  consent_id?: string;
+  subject_id: string;
+  requester_id: string;
+  resource: string;
+  action: string;
+};
+
+export type CapabilityAuthorizationResult = {
+  allowed: boolean;
+  reason_code: CapabilityReasonCode;
+  evaluated_at: string;
+  capability_id: string | null;
+};
+
+export type CanonicalCapabilityPayload = {
+  consent_id: string;
+  subject_id: string;
+  requester_id: string;
+  resource: string;
+  action: string;
+  issued_at: string;
+  expires_at: string | null;
+  nonce: string;
+};

--- a/protocol/consent/capability-validate.ts
+++ b/protocol/consent/capability-validate.ts
@@ -1,0 +1,66 @@
+import { buildCanonicalCapabilityPayload, hashCapabilityPayload } from './capability-hash';
+import { signCapabilityHash } from './capability-sign';
+import {
+  CAPABILITY_REASON_CODES,
+  type CapabilityToken,
+  type CapabilityValidationResult,
+} from './capability-types';
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidIsoDateString(value: unknown): value is string {
+  return isNonEmptyString(value) && Number.isFinite(Date.parse(value));
+}
+
+function hasValidMetadata(value: unknown): boolean {
+  return value === undefined || (value !== null && typeof value === 'object' && !Array.isArray(value));
+}
+
+function isCapabilityTokenShape(token: unknown): token is CapabilityToken {
+  if (!token || typeof token !== 'object') {
+    return false;
+  }
+
+  const candidate = token as Partial<CapabilityToken>;
+
+  return (
+    isNonEmptyString(candidate.capability_id) &&
+    isNonEmptyString(candidate.consent_id) &&
+    isNonEmptyString(candidate.subject_id) &&
+    isNonEmptyString(candidate.requester_id) &&
+    isNonEmptyString(candidate.resource) &&
+    isNonEmptyString(candidate.action) &&
+    isValidIsoDateString(candidate.issued_at) &&
+    (candidate.expires_at === null || isValidIsoDateString(candidate.expires_at)) &&
+    isNonEmptyString(candidate.nonce) &&
+    isNonEmptyString(candidate.capability_hash) &&
+    isNonEmptyString(candidate.signature) &&
+    hasValidMetadata(candidate.metadata)
+  );
+}
+
+export function validateCapabilityToken(token: unknown, secret: string): CapabilityValidationResult {
+  if (!isCapabilityTokenShape(token) || !isNonEmptyString(secret)) {
+    return { valid: false, reason_code: CAPABILITY_REASON_CODES.INVALID_INPUT };
+  }
+
+  const payload = buildCanonicalCapabilityPayload(token);
+  const expectedHash = hashCapabilityPayload(payload);
+
+  if (expectedHash !== token.capability_hash) {
+    return { valid: false, reason_code: CAPABILITY_REASON_CODES.INVALID_HASH };
+  }
+
+  const expectedSignature = signCapabilityHash(expectedHash, secret);
+  if (expectedSignature !== token.signature) {
+    return { valid: false, reason_code: CAPABILITY_REASON_CODES.INVALID_SIGNATURE };
+  }
+
+  if (token.expires_at !== null && Date.now() >= new Date(token.expires_at).getTime()) {
+    return { valid: false, reason_code: CAPABILITY_REASON_CODES.EXPIRED };
+  }
+
+  return { valid: true, reason_code: CAPABILITY_REASON_CODES.VALID };
+}

--- a/protocol/consent/index.ts
+++ b/protocol/consent/index.ts
@@ -24,3 +24,5 @@ export type {
   ConsentDecision,
   ConsentDecisionReasonCode,
 } from './types';
+
+export * from './capability-index';


### PR DESCRIPTION
### Motivation
- Provide a reusable, protocol-level capability token layer in AOC that produces portable, signed permission artifacts derived from consent decisions.
- Ensure tokens are deterministic, tamper-evident, fail-closed, and only issued when `decision.allowed === true` from the consent engine.
- Keep capability token concerns in the AOC protocol core (not in HRKey) so tokens can be reused by multiple market-makers.

### Description
- Added a typed capability model and reason codes in `protocol/consent/capability-types.ts` and a canonical payload shape for deterministic hashing. 
- Implemented canonicalization + hashing (`protocol/consent/capability-hash.ts`) and deterministic HMAC signing (`protocol/consent/capability-sign.ts`).
- Implemented issuance, validation, and authorization flows as `issueCapabilityToken(...)` (`protocol/consent/capability-issue.ts`), `validateCapabilityToken(...)` (`protocol/consent/capability-validate.ts`), and `authorizeWithCapability(...)` (`protocol/consent/capability-authorize.ts`) with strict fail-closed rules and exact-match authorization semantics.
- Exported the capability APIs via `protocol/consent/capability-index.ts` and added them to the consent barrel (`protocol/consent/index.ts`) without altering existing consent APIs.

### Testing
- Ran the new unit suite `protocol/consent/__tests__/capabilityToken.test.ts` using `npm test -- --runInBand protocol/consent/__tests__/capabilityToken.test.ts`, covering issuance, validation (expiry/tamper/metadata cases), and authorization mismatch cases; all 14 tests passed.
- Re-ran related consent tests with `npm test -- --runInBand protocol/consent/__tests__/evaluateConsent.test.ts protocol/consent/__tests__/consentEngine.test.ts`; both suites passed.
- Any initial TypeScript type issue encountered during the first run was corrected and subsequent automated test runs passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1ec3bdb083259ecb4fb03df94d50)