### PR TITLE
Add usage metering, /usage/summary endpoint, SDK exports, and test server lifecycle helpers

### DIFF
--- a/runtime/__tests__/dataAccessHosted.test.ts
+++ b/runtime/__tests__/dataAccessHosted.test.ts
@@ -7,6 +7,7 @@ import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
 import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
 import { HostedRuntimeClient } from '../sdk/client';
 import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+import { closeServer, startServer } from './helpers/serverLifecycle';
 
 function buildCore() {
   const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
@@ -26,7 +27,7 @@ function buildCore() {
 describe('data access + audit endpoints', () => {
   it('allows data access with valid credential + consent and emits audit events', async () => {
     const server = createRuntimeServer({ core: buildCore() });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -74,13 +75,13 @@ describe('data access + audit endpoints', () => {
       expect(accessRequested).toBeDefined();
       expect(accessAllowed).toBeDefined();
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
   it('denies access when consent is missing', async () => {
     const server = createRuntimeServer({ core: buildCore() });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -109,13 +110,13 @@ describe('data access + audit endpoints', () => {
       const deniedEvents = await client.listAuditEvents({ event_type: 'DATA_ACCESS_DENIED', consumer_id: 'mm-beta' });
       expect(deniedEvents.length).toBeGreaterThan(0);
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
   it('denies access when trust/credential is missing and keeps market-maker separation', async () => {
     const server = createRuntimeServer({ core: buildCore() });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -162,13 +163,13 @@ describe('data access + audit endpoints', () => {
       expect(gammaEvents.every((event) => !('consumer_id' in event) || event.consumer_id === 'mm-gamma')).toBe(true);
       expect(deltaEvents.every((event) => !('consumer_id' in event) || event.consumer_id === 'mm-delta')).toBe(true);
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
   it('supports direct GET filter queries for audit events', async () => {
     const server = createRuntimeServer({ core: buildCore() });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -211,7 +212,7 @@ describe('data access + audit endpoints', () => {
       expect(json.success).toBe(true);
       expect(json.data?.events.every((event) => event.event_type === 'DATA_ACCESS_DENIED')).toBe(true);
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 });

--- a/runtime/__tests__/helpers/serverLifecycle.ts
+++ b/runtime/__tests__/helpers/serverLifecycle.ts
@@ -1,0 +1,34 @@
+import type { Server } from 'http';
+
+export async function startServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off('error', onError);
+      reject(error);
+    };
+
+    server.once('error', onError);
+    server.listen(0, () => {
+      server.off('error', onError);
+      resolve();
+    });
+  });
+}
+
+export async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    server.removeAllListeners('error');
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      server.removeAllListeners('error');
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/runtime/__tests__/payoutHosted.test.ts
+++ b/runtime/__tests__/payoutHosted.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_RUNTIME_CORE } from '../api/routes';
 import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
 import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
 import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+import { closeServer, startServer } from './helpers/serverLifecycle';
 
 describe('payout engine hosted endpoints', () => {
   it('supports payout callback endpoint', async () => {
@@ -18,7 +19,7 @@ describe('payout engine hosted endpoints', () => {
         payoutExecutor,
       },
     });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -41,7 +42,7 @@ describe('payout engine hosted endpoints', () => {
       expect(json.data?.received).toBe(true);
       expect(json.data?.reason_code).toBe('SETTLED');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
@@ -55,7 +56,7 @@ describe('payout engine hosted endpoints', () => {
         payoutExecutor,
       },
     });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -79,7 +80,7 @@ describe('payout engine hosted endpoints', () => {
       expect(json.success).toBe(false);
       expect(json.error?.code).toBe('INVALID_REQUEST');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
@@ -130,7 +131,7 @@ describe('payout engine hosted endpoints', () => {
         } as never,
       },
     });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -155,7 +156,7 @@ describe('payout engine hosted endpoints', () => {
       expect(json.data?.allowed).toBe(true);
       expect(json.data?.reason_code).toBe('PAYOUT_ALLOWED');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 

--- a/runtime/__tests__/runtimeHosted.test.ts
+++ b/runtime/__tests__/runtimeHosted.test.ts
@@ -4,6 +4,9 @@ import { createRuntimeServer } from '../api/server';
 import { InMemoryApiKeyStore } from '../auth/apiKeys';
 import { InMemoryRateLimiter } from '../limits/rateLimiter';
 import { HostedRuntimeClient } from '../sdk/client';
+import { closeServer, startServer } from './helpers/serverLifecycle';
+
+jest.setTimeout(15000);
 
 const SUBJECT = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
 const GRANTEE = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
@@ -29,7 +32,7 @@ function buildMintInput() {
 describe('hosted runtime API + SDK', () => {
   it('endpoint success: /execution/authorize', async () => {
     const server = createRuntimeServer();
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -51,13 +54,13 @@ describe('hosted runtime API + SDK', () => {
       expect(result.authorized).toBe(true);
       expect(result.reason_code).toBe('EXECUTION_AUTHORIZED');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
   it('invalid API key -> reject fail-closed', async () => {
     const server = createRuntimeServer();
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -75,7 +78,7 @@ describe('hosted runtime API + SDK', () => {
       expect(json.success).toBe(false);
       expect(json.error?.code).toBe('AUTH_INVALID_API_KEY');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
@@ -85,7 +88,7 @@ describe('hosted runtime API + SDK', () => {
       apiKeyStore: apiKeys,
       rateLimiter: new InMemoryRateLimiter({ free: 1 }),
     });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -114,7 +117,7 @@ describe('hosted runtime API + SDK', () => {
       expect(json.success).toBe(false);
       expect(json.error?.code).toBe('RATE_LIMIT_EXCEEDED');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 

--- a/runtime/__tests__/trustHosted.test.ts
+++ b/runtime/__tests__/trustHosted.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_RUNTIME_CORE } from '../api/routes';
 import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
 import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
 import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
+import { closeServer, startServer } from './helpers/serverLifecycle';
 
 describe('trust layer hosted endpoints', () => {
   it('supports credential registration and verification', async () => {
@@ -15,7 +16,7 @@ describe('trust layer hosted endpoints', () => {
         payoutExecutor: new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter()),
       },
     });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -52,7 +53,7 @@ describe('trust layer hosted endpoints', () => {
       expect(verifyJson.data?.valid).toBe(true);
       expect(verifyJson.data?.issuer).toBe('kyc-global-v1');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 
@@ -65,7 +66,7 @@ describe('trust layer hosted endpoints', () => {
         payoutExecutor: new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter()),
       },
     });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
+    await startServer(server);
 
     try {
       const { port } = server.address() as AddressInfo;
@@ -143,7 +144,7 @@ describe('trust layer hosted endpoints', () => {
       expect(allowedJson.data?.allowed).toBe(true);
       expect(allowedJson.data?.reason_code).toBe('PAYOUT_ALLOWED');
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+      await closeServer(server);
     }
   });
 });

--- a/runtime/__tests__/usageMeteringHosted.test.ts
+++ b/runtime/__tests__/usageMeteringHosted.test.ts
@@ -1,0 +1,292 @@
+import type { AddressInfo } from 'net';
+import { DataAccessService } from '../access/service';
+import { DEFAULT_RUNTIME_CORE } from '../api/routes';
+import { createRuntimeServer } from '../api/server';
+import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
+import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
+import { HostedRuntimeClient } from '../sdk/client';
+import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+import { InMemoryUsageService } from '../usage';
+import { RuntimeAuditService } from '../audit/service';
+import { closeServer, startServer } from './helpers/serverLifecycle';
+
+function buildCore() {
+  const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+  const payoutExecutor = new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter());
+  const dataAccessService = new DataAccessService(trustService);
+  const usageService = new InMemoryUsageService();
+  const auditService = new RuntimeAuditService(trustService, payoutExecutor, dataAccessService);
+
+  return {
+    ...DEFAULT_RUNTIME_CORE,
+    trustService,
+    payoutExecutor,
+    dataAccessService,
+    auditService,
+    usageService,
+  };
+}
+
+describe('usage metering + fee estimation', () => {
+  it('increments usage for allowed /data/access', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const client = new HostedRuntimeClient({ baseUrl: `http://127.0.0.1:${port}`, apiKey: 'aoc_free_dev_key' });
+
+      await client.registerCredential({
+        credential_ref: 'cred_usage_allow',
+        subject_hash: '0xusage_subject_allow',
+        issuer_id: 'kyc-global-v1',
+        credential_hash: '0xusage_cred_allow',
+        metadata_hash: '0xusage_meta_allow',
+        kyc_level: 'enhanced',
+        issued_at: '2026-01-01T00:00:00Z',
+      });
+      await client.grantIdentityConsent({
+        consent_id: 'consent_usage_allow',
+        subject_hash: '0xusage_subject_allow',
+        consumer_id: 'mm-usage-a',
+        issuer_id: 'kyc-global-v1',
+        granted_at: '2026-01-02T00:00:00Z',
+      });
+
+      const access = await client.requestDataAccess({
+        subject_hash: '0xusage_subject_allow',
+        consumer_id: 'mm-usage-a',
+        dataset_id: 'dataset-usage-1',
+        purpose: 'risk_scoring',
+        now: new Date('2026-01-03T00:00:00Z'),
+      });
+      expect(access.allowed).toBe(true);
+
+      const summary = await client.getUsageSummary({ consumer_id: 'mm-usage-a' });
+      expect(summary.consumer_id).toBe('mm-usage-a');
+      expect(summary.endpoints).toHaveLength(1);
+      expect(summary.endpoints[0]).toMatchObject({
+        endpoint: '/data/access',
+        count: 1,
+        allowed_count: 1,
+        denied_count: 0,
+        unit_price: 0.05,
+        total_estimated_fee: 0.05,
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('increments usage for denied /data/access', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const client = new HostedRuntimeClient({ baseUrl: `http://127.0.0.1:${port}`, apiKey: 'aoc_free_dev_key' });
+
+      const access = await client.requestDataAccess({
+        subject_hash: '0xusage_subject_deny',
+        consumer_id: 'mm-usage-b',
+        dataset_id: 'dataset-usage-2',
+        purpose: 'analytics',
+      });
+      expect(access.allowed).toBe(false);
+
+      const summary = await client.getUsageSummary({ consumer_id: 'mm-usage-b', endpoint: '/data/access' });
+      expect(summary.endpoints).toHaveLength(1);
+      expect(summary.endpoints[0]).toMatchObject({
+        endpoint: '/data/access',
+        count: 1,
+        allowed_count: 0,
+        denied_count: 1,
+        total_estimated_fee: 0.05,
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('increments usage for /payout/execute and calculates fee', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const client = new HostedRuntimeClient({ baseUrl: `http://127.0.0.1:${port}`, apiKey: 'aoc_free_dev_key' });
+
+      await client.registerCredential({
+        credential_ref: 'cred_usage_payout',
+        subject_hash: '0xusage_subject_payout',
+        issuer_id: 'kyc-global-v1',
+        credential_hash: '0xusage_cred_payout',
+        metadata_hash: '0xusage_meta_payout',
+        kyc_level: 'basic',
+        issued_at: '2026-02-01T00:00:00Z',
+      });
+      await client.grantIdentityConsent({
+        consent_id: 'consent_usage_payout',
+        subject_hash: '0xusage_subject_payout',
+        consumer_id: 'mm-usage-c',
+        issuer_id: 'kyc-global-v1',
+        granted_at: '2026-02-02T00:00:00Z',
+      });
+
+      const payout = await client.executePayout({
+        withdrawal_id: 'wd_usage_1',
+        subject_hash: '0xusage_subject_payout',
+        consumer_id: 'mm-usage-c',
+        amount: '10.00',
+        wallet_address: '0xabc123',
+      });
+      expect(payout.allowed).toBe(true);
+
+      const summary = await client.getUsageSummary({ consumer_id: 'mm-usage-c', endpoint: '/payout/execute' });
+      expect(summary.endpoints).toHaveLength(1);
+      expect(summary.endpoints[0]).toMatchObject({
+        endpoint: '/payout/execute',
+        count: 1,
+        unit_price: 0.25,
+        total_estimated_fee: 0.25,
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('filters usage summary by endpoint and date', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const base = `http://127.0.0.1:${port}`;
+      const headers = { 'x-api-key': 'aoc_free_dev_key', 'content-type': 'application/json' };
+
+      await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          subject_hash: '0xraw_usage_filter_1',
+          consumer_id: 'mm-usage-d',
+          dataset_id: 'dataset-d1',
+          purpose: 'analytics',
+        }),
+      });
+      await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          subject_hash: '0xraw_usage_filter_2',
+          consumer_id: 'mm-usage-d',
+          dataset_id: 'dataset-d2',
+          purpose: 'analytics',
+        }),
+      });
+
+      const response = await fetch(
+        `${base}/usage/summary?consumer_id=mm-usage-d&endpoint=/data/access&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z`,
+        { method: 'GET', headers: { 'x-api-key': 'aoc_free_dev_key' } }
+      );
+      const json = (await response.json()) as {
+        success: boolean;
+        data?: { endpoints: Array<{ endpoint: string; count: number; total_estimated_fee: number }> };
+      };
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+      expect(json.data?.endpoints).toHaveLength(1);
+      expect(json.data?.endpoints[0]).toMatchObject({
+        endpoint: '/data/access',
+        count: 2,
+        total_estimated_fee: 0.1,
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('preserves multi-market-maker separation in usage summaries', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const base = `http://127.0.0.1:${port}`;
+
+      await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers: { 'x-api-key': 'aoc_free_dev_key', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          subject_hash: '0xmm_sep_1',
+          consumer_id: 'mm-usage-x',
+          dataset_id: 'dataset-x',
+          purpose: 'analytics',
+        }),
+      });
+      await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers: { 'x-api-key': 'aoc_free_dev_key', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          subject_hash: '0xmm_sep_2',
+          consumer_id: 'mm-usage-y',
+          dataset_id: 'dataset-y',
+          purpose: 'analytics',
+        }),
+      });
+
+      const xSummaryResponse = await fetch(`${base}/usage/summary?consumer_id=mm-usage-x`, {
+        method: 'GET',
+        headers: { 'x-api-key': 'aoc_free_dev_key' },
+      });
+      const ySummaryResponse = await fetch(`${base}/usage/summary?consumer_id=mm-usage-y`, {
+        method: 'GET',
+        headers: { 'x-api-key': 'aoc_free_dev_key' },
+      });
+
+      const xSummary = (await xSummaryResponse.json()) as { success: boolean; data?: { endpoints: Array<{ count: number }> } };
+      const ySummary = (await ySummaryResponse.json()) as { success: boolean; data?: { endpoints: Array<{ count: number }> } };
+
+      expect(xSummary.success).toBe(true);
+      expect(ySummary.success).toBe(true);
+      expect(xSummary.data?.endpoints[0]?.count).toBe(1);
+      expect(ySummary.data?.endpoints[0]?.count).toBe(1);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('does not meter malformed requests that fail validation', async () => {
+    const server = createRuntimeServer({ core: buildCore() });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const base = `http://127.0.0.1:${port}`;
+
+      const malformed = await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers: { 'x-api-key': 'aoc_free_dev_key', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          subject_hash: '0xmalformed',
+          consumer_id: '',
+          dataset_id: 'dataset-bad',
+          purpose: 'analytics',
+        }),
+      });
+      expect(malformed.status).toBe(400);
+
+      const summaryResponse = await fetch(`${base}/usage/summary?consumer_id=mm-bad`, {
+        method: 'GET',
+        headers: { 'x-api-key': 'aoc_free_dev_key' },
+      });
+      const summary = (await summaryResponse.json()) as { success: boolean; data?: { endpoints: unknown[] } };
+
+      expect(summary.success).toBe(true);
+      expect(summary.data?.endpoints).toEqual([]);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -15,6 +15,8 @@ import type {
   RlusdWithdrawalRequest,
 } from '../trust/types';
 import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
+import { InMemoryUsageService, isMeteredEndpoint } from '../usage';
+import type { MeteredRuntimeEndpoint, UsageSummaryResult } from '../usage';
 
 export type RuntimeCore = {
   evaluateEnforcement: typeof evaluateEnforcement;
@@ -24,12 +26,14 @@ export type RuntimeCore = {
   payoutExecutor: RlusdPayoutExecutorService;
   dataAccessService: DataAccessService;
   auditService: RuntimeAuditService;
+  usageService: InMemoryUsageService;
 };
 
 const defaultTrustService = new InMemoryTrustService();
 const defaultPayoutExecutor = new RlusdPayoutExecutorService(defaultTrustService, new RlusdPayoutAdapter());
 const defaultDataAccessService = new DataAccessService(defaultTrustService);
 const defaultAuditService = new RuntimeAuditService(defaultTrustService, defaultPayoutExecutor, defaultDataAccessService);
+const defaultUsageService = new InMemoryUsageService();
 
 const ROUTE_ERRORS = {
   invalidRequest: 'INVALID_REQUEST',
@@ -46,6 +50,7 @@ export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
   payoutExecutor: defaultPayoutExecutor,
   dataAccessService: defaultDataAccessService,
   auditService: defaultAuditService,
+  usageService: defaultUsageService,
 };
 
 function reviveNow<T extends Record<string, unknown>>(payload: T): T {
@@ -93,6 +98,16 @@ function parseOptionalDate(input: unknown): Date | undefined {
   return parsed;
 }
 
+function parseOptionalMeteredEndpoint(input: unknown): MeteredRuntimeEndpoint | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (input !== '/data/access' && input !== '/payout/execute' && input !== '/trust/verify') {
+    return undefined;
+  }
+  return input;
+}
+
 export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { decision: 'allow' | 'deny'; reasonCode: string } {
   if (endpoint === '/enforcement/evaluate') {
     const enforcement = data as EnforcementDecision;
@@ -131,6 +146,9 @@ export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { deci
   if (endpoint === '/audit/events') {
     return { decision: 'allow', reasonCode: 'AUDIT_EVENTS_LISTED' };
   }
+  if (endpoint === '/usage/summary') {
+    return { decision: 'allow', reasonCode: 'USAGE_SUMMARY_LISTED' };
+  }
 
   const knownEndpoints: RuntimeEndpoint[] = [
     '/enforcement/evaluate',
@@ -143,6 +161,7 @@ export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { deci
     '/trust/consent/grant',
     '/data/access',
     '/audit/events',
+    '/usage/summary',
   ];
 
   if (!knownEndpoints.includes(endpoint)) {
@@ -173,6 +192,7 @@ export function executeRoute(
   | DataAccessDecision
   | { received: true; reason_code: string }
   | { events: AuditEvent[] }
+  | UsageSummaryResult
 > {
   try {
     switch (endpoint) {
@@ -255,10 +275,51 @@ export function executeRoute(
 
         return success({ events });
       }
+      case '/usage/summary': {
+        const request = payload as { consumer_id?: string; endpoint?: string; from?: string; to?: string };
+        if (!isNonEmptyString(request.consumer_id)) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'consumer_id is required.');
+        }
+
+        const endpoint = parseOptionalMeteredEndpoint(request.endpoint);
+        if (request.endpoint !== undefined && endpoint === undefined) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'endpoint must be one of /data/access, /payout/execute, /trust/verify.');
+        }
+
+        const from = parseOptionalDate(request.from);
+        const to = parseOptionalDate(request.to);
+        if (request.from !== undefined && from === undefined) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'from must be a valid ISO-8601 date string.');
+        }
+        if (request.to !== undefined && to === undefined) {
+          return failure(ROUTE_ERRORS.invalidRequest, 'to must be a valid ISO-8601 date string.');
+        }
+
+        return success(
+          core.usageService.getSummary({
+            consumer_id: request.consumer_id,
+            endpoint,
+            from,
+            to,
+          })
+        );
+      }
       default:
         return failure(ROUTE_ERRORS.routeNotFound, `Unsupported endpoint: ${endpoint}`);
     }
   } catch (error) {
     return failure(ROUTE_ERRORS.protocolError, error instanceof Error ? error.message : 'Unknown protocol error.');
   }
+}
+
+export function maybeResolveUsageConsumerId(endpoint: RuntimeEndpoint, payload: unknown): string | undefined {
+  if (!isMeteredEndpoint(endpoint) || payload === null || typeof payload !== 'object') {
+    return undefined;
+  }
+
+  const candidate = (payload as { consumer_id?: unknown }).consumer_id;
+  if (typeof candidate !== 'string' || candidate.trim() === '') {
+    return undefined;
+  }
+  return candidate;
 }

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -5,7 +5,8 @@ import { InMemoryRateLimiter } from '../limits/rateLimiter';
 import { RuntimeLogger } from '../logging/logger';
 import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
 import { authAndLimit } from './middleware';
-import { DEFAULT_RUNTIME_CORE, deriveDecision, executeRoute, type RuntimeCore } from './routes';
+import { DEFAULT_RUNTIME_CORE, deriveDecision, executeRoute, maybeResolveUsageConsumerId, type RuntimeCore } from './routes';
+import { isMeteredEndpoint } from '../usage';
 
 const POST_ENDPOINTS: RuntimeEndpoint[] = [
   '/enforcement/evaluate',
@@ -19,7 +20,7 @@ const POST_ENDPOINTS: RuntimeEndpoint[] = [
   '/data/access',
 ];
 
-const GET_ENDPOINTS: RuntimeEndpoint[] = ['/audit/events'];
+const GET_ENDPOINTS: RuntimeEndpoint[] = ['/audit/events', '/usage/summary'];
 
 export type RuntimeServerDeps = {
   apiKeyStore?: InMemoryApiKeyStore;
@@ -132,6 +133,29 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
       decision: decisionInfo.decision,
       reason_code: decisionInfo.reasonCode,
     });
+
+    if (isMeteredEndpoint(pathname)) {
+      const consumerId = maybeResolveUsageConsumerId(pathname, payload);
+      if (consumerId !== undefined) {
+        Promise.resolve()
+          .then(() => {
+            core.usageService.recordUsage({
+              consumer_id: consumerId,
+              endpoint: pathname,
+              decision: decisionInfo.decision,
+              reason_code: decisionInfo.reasonCode,
+            });
+          })
+          .catch(() => {
+            logger.log({
+              requestId,
+              endpoint: pathname,
+              decision: 'deny',
+              reason_code: 'USAGE_METERING_ERROR',
+            });
+          });
+      }
+    }
 
     return sendJson(response, 200, routeResult);
   });

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -19,4 +19,13 @@ export type { PayoutCallbackInput, PayoutExecuteResult, PayoutAuditEvent } from 
 
 export type { DataAccessAuditEvent, DataAccessDecision, DataAccessRequestInput, AccessTokenRecord } from './access/types';
 export type { AuditEvent } from './audit/service';
-export type { ListAuditEventsInput } from './sdk/client';
+export type { GetUsageSummaryInput, ListAuditEventsInput } from './sdk/client';
+export { InMemoryUsageService, UNIT_PRICES } from './usage';
+export type {
+  MeteredRuntimeEndpoint,
+  UsageDecision,
+  UsageRecord,
+  UsageSummaryItem,
+  UsageSummaryQuery,
+  UsageSummaryResult,
+} from './usage';

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -12,6 +12,7 @@ import type {
 } from '../trust/types';
 import type { ApiResponse, RuntimeMode } from '../types/api-types';
 import type { PayoutCallbackInput, PayoutExecuteResult } from '../payout/types';
+import type { MeteredRuntimeEndpoint, UsageSummaryResult } from '../usage';
 
 type FetchLike = typeof fetch;
 
@@ -26,6 +27,13 @@ export type ListAuditEventsInput = {
   subject_hash?: string;
   consumer_id?: string;
   event_type?: string;
+  from?: string;
+  to?: string;
+};
+
+export type GetUsageSummaryInput = {
+  consumer_id: string;
+  endpoint?: MeteredRuntimeEndpoint;
   from?: string;
   to?: string;
 };
@@ -50,6 +58,7 @@ export interface HostedRuntimeSdk {
   callbackPayout(input: PayoutCallbackInput): Promise<PayoutCallbackResult>;
   requestDataAccess(input: DataAccessRequestInput): Promise<DataAccessDecision>;
   listAuditEvents(input?: ListAuditEventsInput): Promise<AuditEvent[]>;
+  getUsageSummary(input: GetUsageSummaryInput): Promise<UsageSummaryResult>;
 }
 
 export class HostedRuntimeClient implements HostedRuntimeSdk {
@@ -175,5 +184,12 @@ export class HostedRuntimeClient implements HostedRuntimeSdk {
     }
     const result = await this.get<{ events: AuditEvent[] }>('/audit/events', input);
     return result.events;
+  }
+
+  async getUsageSummary(input: GetUsageSummaryInput): Promise<UsageSummaryResult> {
+    if (this.mode === 'local') {
+      throw new Error('Usage summary is only available in hosted mode.');
+    }
+    return this.get('/usage/summary', input);
   }
 }

--- a/runtime/types/api-types.ts
+++ b/runtime/types/api-types.ts
@@ -8,7 +8,8 @@ export type RuntimeEndpoint =
   | '/trust/verify'
   | '/trust/consent/grant'
   | '/data/access'
-  | '/audit/events';
+  | '/audit/events'
+  | '/usage/summary';
 
 export type ApiRequest<T> = {
   requestId?: string;

--- a/runtime/usage/index.ts
+++ b/runtime/usage/index.ts
@@ -1,0 +1,3 @@
+export { InMemoryUsageService, UNIT_PRICES } from './service';
+export type { MeteredRuntimeEndpoint, UsageDecision, UsageRecord, UsageSummaryItem, UsageSummaryQuery, UsageSummaryResult } from './types';
+export { isMeteredEndpoint } from './types';

--- a/runtime/usage/service.ts
+++ b/runtime/usage/service.ts
@@ -1,0 +1,92 @@
+import type {
+  MeteredRuntimeEndpoint,
+  UsageDecision,
+  UsageRecord,
+  UsageSummaryItem,
+  UsageSummaryQuery,
+  UsageSummaryResult,
+} from './types';
+
+const UNIT_PRICES: Record<MeteredRuntimeEndpoint, number> = {
+  '/data/access': 0.05,
+  '/payout/execute': 0.25,
+  '/trust/verify': 0,
+};
+
+type RecordUsageInput = {
+  consumer_id: string;
+  endpoint: MeteredRuntimeEndpoint;
+  decision: UsageDecision;
+  reason_code: string;
+  usedAt?: Date;
+};
+
+export class InMemoryUsageService {
+  private readonly records: UsageRecord[] = [];
+
+  recordUsage(input: RecordUsageInput): void {
+    this.records.push({
+      consumer_id: input.consumer_id,
+      endpoint: input.endpoint,
+      decision: input.decision,
+      reason_code: input.reason_code,
+      used_at: (input.usedAt ?? new Date()).toISOString(),
+    });
+  }
+
+  getSummary(query: UsageSummaryQuery): UsageSummaryResult {
+    const filtered = this.records.filter((record) => {
+      if (record.consumer_id !== query.consumer_id) {
+        return false;
+      }
+      if (query.endpoint !== undefined && record.endpoint !== query.endpoint) {
+        return false;
+      }
+
+      const usedAtTime = Date.parse(record.used_at);
+      if (query.from !== undefined && usedAtTime < query.from.getTime()) {
+        return false;
+      }
+      if (query.to !== undefined && usedAtTime > query.to.getTime()) {
+        return false;
+      }
+
+      return true;
+    });
+
+    const byEndpoint = new Map<MeteredRuntimeEndpoint, UsageSummaryItem>();
+    for (const record of filtered) {
+      const existing = byEndpoint.get(record.endpoint) ?? {
+        endpoint: record.endpoint,
+        count: 0,
+        allowed_count: 0,
+        denied_count: 0,
+        last_used_at: undefined,
+        unit_price: UNIT_PRICES[record.endpoint],
+        total_estimated_fee: 0,
+        reason_code_counts: {},
+      };
+
+      existing.count += 1;
+      existing.allowed_count += record.decision === 'allow' ? 1 : 0;
+      existing.denied_count += record.decision === 'deny' ? 1 : 0;
+      existing.reason_code_counts[record.reason_code] = (existing.reason_code_counts[record.reason_code] ?? 0) + 1;
+
+      if (existing.last_used_at === undefined || Date.parse(record.used_at) > Date.parse(existing.last_used_at)) {
+        existing.last_used_at = record.used_at;
+      }
+
+      existing.total_estimated_fee = Number((existing.count * existing.unit_price).toFixed(2));
+      byEndpoint.set(record.endpoint, existing);
+    }
+
+    return {
+      consumer_id: query.consumer_id,
+      from: query.from?.toISOString(),
+      to: query.to?.toISOString(),
+      endpoints: [...byEndpoint.values()].sort((a, b) => a.endpoint.localeCompare(b.endpoint)),
+    };
+  }
+}
+
+export { UNIT_PRICES };

--- a/runtime/usage/types.ts
+++ b/runtime/usage/types.ts
@@ -1,0 +1,42 @@
+import type { RuntimeEndpoint } from '../types/api-types';
+
+export type MeteredRuntimeEndpoint = '/data/access' | '/payout/execute' | '/trust/verify';
+
+export type UsageDecision = 'allow' | 'deny';
+
+export type UsageRecord = {
+  consumer_id: string;
+  endpoint: MeteredRuntimeEndpoint;
+  decision: UsageDecision;
+  reason_code: string;
+  used_at: string;
+};
+
+export type UsageSummaryQuery = {
+  consumer_id: string;
+  endpoint?: MeteredRuntimeEndpoint;
+  from?: Date;
+  to?: Date;
+};
+
+export type UsageSummaryItem = {
+  endpoint: MeteredRuntimeEndpoint;
+  count: number;
+  allowed_count: number;
+  denied_count: number;
+  last_used_at?: string;
+  unit_price: number;
+  total_estimated_fee: number;
+  reason_code_counts: Record<string, number>;
+};
+
+export type UsageSummaryResult = {
+  consumer_id: string;
+  from?: string;
+  to?: string;
+  endpoints: UsageSummaryItem[];
+};
+
+export function isMeteredEndpoint(endpoint: RuntimeEndpoint): endpoint is MeteredRuntimeEndpoint {
+  return endpoint === '/data/access' || endpoint === '/payout/execute' || endpoint === '/trust/verify';
+}


### PR DESCRIPTION
### Motivation

- Introduce per-endpoint usage metering and fee estimation to support billing and observability for hosted runtime endpoints.
- Provide stable server start/stop helpers for tests to avoid race conditions when binding/closing ephemeral ports.

### Description

- Add a new usage subsystem with types (`runtime/usage/types.ts`) and an in-memory service (`runtime/usage/service.ts`) exposing `recordUsage` and `getSummary`, plus `UNIT_PRICES` and `isMeteredEndpoint` utilities. 
- Wire a new `GET /usage/summary` route into `executeRoute` with validation, parsing, and delegation to `core.usageService.getSummary`, and include `/usage/summary` in `RuntimeEndpoint` and route lists. 
- In the server request flow, record usage asynchronously for metered endpoints via `core.usageService.recordUsage` using a new `maybeResolveUsageConsumerId` helper to extract `consumer_id` from payloads. 
- Extend SDK and public exports: add `getUsageSummary` to `HostedRuntimeClient`, export `InMemoryUsageService`, `UNIT_PRICES`, and related usage types from `runtime/index.ts` and `runtime/usage/index.ts`. 
- Add test infrastructure helpers `startServer` and `closeServer` (`runtime/__tests__/helpers/serverLifecycle.ts`) and update existing hosted tests to use them, plus add comprehensive usage metering tests in `runtime/__tests__/usageMeteringHosted.test.ts`.

### Testing

- Ran the Jest unit test suite for the runtime tests (updated hosted tests and the new usage metering tests) via `yarn test`; all tests passed. 
- Exercised the new `GET /usage/summary` endpoint and the SDK `getUsageSummary` flow in automated tests which validated counting, allowed/denied separation, fee calculations, endpoint/date filtering, market-maker separation, and that malformed requests are not metered. 
- Verified existing hosted endpoint tests were updated to use `startServer`/`closeServer` and continue to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc76f61cec83259e634d81a8b004c4)