### PR TITLE
Add protocol audit types/builders and in-memory runtime audit service with tests

### DIFF
--- a/protocol/audit/builders.ts
+++ b/protocol/audit/builders.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'crypto';
+import type { AuditEvent, AuditEventType } from './types';
+
+type AuditEventBuilderInput = Omit<AuditEvent, 'event_type' | 'event_id' | 'occurred_at'> & {
+  event_id?: string;
+  occurred_at?: Date | string;
+};
+
+function normalizeOccurredAt(input?: Date | string): string {
+  if (input === undefined) {
+    return new Date().toISOString();
+  }
+
+  if (input instanceof Date) {
+    return input.toISOString();
+  }
+
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date().toISOString();
+  }
+
+  return parsed.toISOString();
+}
+
+function normalizeMetadata(metadata?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  return { ...metadata };
+}
+
+function buildAuditEvent(eventType: AuditEventType, input: AuditEventBuilderInput): AuditEvent {
+  return {
+    ...input,
+    event_id: input.event_id ?? randomUUID(),
+    event_type: eventType,
+    occurred_at: normalizeOccurredAt(input.occurred_at),
+    metadata: normalizeMetadata(input.metadata),
+  };
+}
+
+export function buildConsentEvaluatedEvent(input: AuditEventBuilderInput): AuditEvent {
+  return buildAuditEvent('CONSENT_EVALUATED', input);
+}
+
+export function buildCapabilityIssuedEvent(input: AuditEventBuilderInput): AuditEvent {
+  return buildAuditEvent('CAPABILITY_ISSUED', input);
+}
+
+export function buildCapabilityValidatedEvent(input: AuditEventBuilderInput): AuditEvent {
+  return buildAuditEvent('CAPABILITY_VALIDATED', input);
+}
+
+export function buildCapabilityAuthorizedEvent(input: AuditEventBuilderInput): AuditEvent {
+  return buildAuditEvent('CAPABILITY_AUTHORIZED', input);
+}
+
+export function buildCapabilityDeniedEvent(input: AuditEventBuilderInput): AuditEvent {
+  return buildAuditEvent('CAPABILITY_DENIED', input);
+}

--- a/protocol/audit/index.ts
+++ b/protocol/audit/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './builders';

--- a/protocol/audit/types.ts
+++ b/protocol/audit/types.ts
@@ -1,0 +1,34 @@
+export const AUDIT_EVENT_TYPES = [
+  'CONSENT_EVALUATED',
+  'CAPABILITY_ISSUED',
+  'CAPABILITY_VALIDATED',
+  'CAPABILITY_AUTHORIZED',
+  'CAPABILITY_DENIED',
+] as const;
+
+export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number];
+
+export type AuditEvent = {
+  event_id: string;
+  event_type: AuditEventType;
+  occurred_at: string;
+  allowed?: boolean;
+  reason_code?: string;
+  subject_id?: string;
+  requester_id?: string;
+  resource?: string;
+  action?: string;
+  consent_id?: string | null;
+  capability_id?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export type AuditEventQuery = {
+  event_type?: AuditEventType;
+  subject_id?: string;
+  requester_id?: string;
+  consent_id?: string;
+  capability_id?: string;
+  from?: Date;
+  to?: Date;
+};

--- a/runtime/__tests__/auditTrail.test.ts
+++ b/runtime/__tests__/auditTrail.test.ts
@@ -1,0 +1,299 @@
+import { InMemoryAuditService } from '../audit';
+import {
+  buildCapabilityAuthorizedEvent,
+  buildCapabilityDeniedEvent,
+  buildCapabilityIssuedEvent,
+  buildCapabilityValidatedEvent,
+  buildConsentEvaluatedEvent,
+  type AuditEvent,
+} from '../../protocol/audit';
+
+const SUBJECT_A = 'did:aoc:subject:a';
+const SUBJECT_B = 'did:aoc:subject:b';
+const REQUESTER_A = 'did:aoc:requester:a';
+const REQUESTER_B = 'did:aoc:requester:b';
+
+describe('InMemoryAuditService', () => {
+  function createEvent(event: Partial<AuditEvent> & Pick<AuditEvent, 'event_type'>): AuditEvent {
+    const now = event.occurred_at ?? '2026-01-01T00:00:00.000Z';
+
+    if (event.event_type === 'CONSENT_EVALUATED') {
+      return buildConsentEvaluatedEvent({
+        event_id: event.event_id ?? 'evt-consent',
+        occurred_at: now,
+        allowed: event.allowed,
+        reason_code: event.reason_code,
+        subject_id: event.subject_id,
+        requester_id: event.requester_id,
+        consent_id: event.consent_id,
+        metadata: event.metadata,
+      });
+    }
+
+    if (event.event_type === 'CAPABILITY_ISSUED') {
+      return buildCapabilityIssuedEvent({
+        event_id: event.event_id ?? 'evt-issued',
+        occurred_at: now,
+        subject_id: event.subject_id,
+        requester_id: event.requester_id,
+        capability_id: event.capability_id,
+        reason_code: event.reason_code,
+        metadata: event.metadata,
+      });
+    }
+
+    if (event.event_type === 'CAPABILITY_AUTHORIZED') {
+      return buildCapabilityAuthorizedEvent({
+        event_id: event.event_id ?? 'evt-authorized',
+        occurred_at: now,
+        allowed: event.allowed,
+        subject_id: event.subject_id,
+        requester_id: event.requester_id,
+        capability_id: event.capability_id,
+        reason_code: event.reason_code,
+        metadata: event.metadata,
+      });
+    }
+
+    if (event.event_type === 'CAPABILITY_VALIDATED') {
+      return buildCapabilityValidatedEvent({
+        event_id: event.event_id ?? 'evt-validated',
+        occurred_at: now,
+        allowed: event.allowed,
+        subject_id: event.subject_id,
+        requester_id: event.requester_id,
+        capability_id: event.capability_id,
+        reason_code: event.reason_code,
+        metadata: event.metadata,
+      });
+    }
+
+    return buildCapabilityDeniedEvent({
+      event_id: event.event_id ?? 'evt-denied',
+      occurred_at: now,
+      allowed: event.allowed,
+      subject_id: event.subject_id,
+      requester_id: event.requester_id,
+      capability_id: event.capability_id,
+      reason_code: event.reason_code,
+      metadata: event.metadata,
+    });
+  }
+
+  it('records and lists a consent evaluation allow event', () => {
+    const service = new InMemoryAuditService();
+    const event = createEvent({
+      event_type: 'CONSENT_EVALUATED',
+      event_id: 'evt-1',
+      occurred_at: '2026-01-01T00:00:00.000Z',
+      allowed: true,
+      reason_code: 'CONSENT_ALLOW',
+      subject_id: SUBJECT_A,
+      requester_id: REQUESTER_A,
+      consent_id: 'consent-1',
+    });
+
+    service.recordEvent(event);
+
+    expect(service.listEvents()).toEqual([event]);
+  });
+
+  it('records and lists a consent evaluation deny event', () => {
+    const service = new InMemoryAuditService();
+    const event = createEvent({
+      event_type: 'CONSENT_EVALUATED',
+      event_id: 'evt-2',
+      occurred_at: '2026-01-01T01:00:00.000Z',
+      allowed: false,
+      reason_code: 'CONSENT_DENY',
+      subject_id: SUBJECT_A,
+      requester_id: REQUESTER_B,
+      consent_id: 'consent-2',
+    });
+
+    service.recordEvent(event);
+
+    expect(service.listEvents()).toEqual([event]);
+  });
+
+  it('records capability issued event', () => {
+    const service = new InMemoryAuditService();
+    const event = createEvent({
+      event_type: 'CAPABILITY_ISSUED',
+      event_id: 'evt-3',
+      occurred_at: '2026-01-01T02:00:00.000Z',
+      subject_id: SUBJECT_A,
+      requester_id: REQUESTER_A,
+      capability_id: 'cap-1',
+      reason_code: 'CAPABILITY_ISSUED_OK',
+    });
+
+    service.recordEvent(event);
+
+    expect(service.listEvents()).toEqual([event]);
+  });
+
+  it('records capability authorized event', () => {
+    const service = new InMemoryAuditService();
+    const event = createEvent({
+      event_type: 'CAPABILITY_AUTHORIZED',
+      event_id: 'evt-4',
+      occurred_at: '2026-01-01T03:00:00.000Z',
+      allowed: true,
+      subject_id: SUBJECT_B,
+      requester_id: REQUESTER_A,
+      capability_id: 'cap-2',
+      reason_code: 'CAPABILITY_AUTHORIZED',
+    });
+
+    service.recordEvent(event);
+
+    expect(service.listEvents()).toEqual([event]);
+  });
+
+  it('records capability denied event', () => {
+    const service = new InMemoryAuditService();
+    const event = createEvent({
+      event_type: 'CAPABILITY_DENIED',
+      event_id: 'evt-5',
+      occurred_at: '2026-01-01T04:00:00.000Z',
+      allowed: false,
+      subject_id: SUBJECT_B,
+      requester_id: REQUESTER_B,
+      capability_id: 'cap-3',
+      reason_code: 'CAPABILITY_NOT_ALLOWED',
+    });
+
+    service.recordEvent(event);
+
+    expect(service.listEvents()).toEqual([event]);
+  });
+
+  it('filters by event_type', () => {
+    const service = new InMemoryAuditService();
+    const issued = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-6', capability_id: 'cap-6' });
+    const denied = createEvent({ event_type: 'CAPABILITY_DENIED', event_id: 'evt-7', capability_id: 'cap-7' });
+
+    service.recordEvent(issued);
+    service.recordEvent(denied);
+
+    expect(service.listEvents({ event_type: 'CAPABILITY_DENIED' })).toEqual([denied]);
+  });
+
+  it('filters by subject_id', () => {
+    const service = new InMemoryAuditService();
+    const a = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-8', subject_id: SUBJECT_A });
+    const b = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-9', subject_id: SUBJECT_B });
+
+    service.recordEvent(a);
+    service.recordEvent(b);
+
+    expect(service.listEvents({ subject_id: SUBJECT_A })).toEqual([a]);
+  });
+
+  it('filters by requester_id', () => {
+    const service = new InMemoryAuditService();
+    const a = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-10', requester_id: REQUESTER_A });
+    const b = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-11', requester_id: REQUESTER_B });
+
+    service.recordEvent(a);
+    service.recordEvent(b);
+
+    expect(service.listEvents({ requester_id: REQUESTER_B })).toEqual([b]);
+  });
+
+  it('filters by consent_id', () => {
+    const service = new InMemoryAuditService();
+    const a = createEvent({ event_type: 'CONSENT_EVALUATED', event_id: 'evt-12', consent_id: 'consent-a' });
+    const b = createEvent({ event_type: 'CONSENT_EVALUATED', event_id: 'evt-13', consent_id: 'consent-b' });
+
+    service.recordEvent(a);
+    service.recordEvent(b);
+
+    expect(service.listEvents({ consent_id: 'consent-a' })).toEqual([a]);
+  });
+
+  it('filters by capability_id', () => {
+    const service = new InMemoryAuditService();
+    const a = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-14', capability_id: 'cap-a' });
+    const b = createEvent({ event_type: 'CAPABILITY_DENIED', event_id: 'evt-15', capability_id: 'cap-b' });
+
+    service.recordEvent(a);
+    service.recordEvent(b);
+
+    expect(service.listEvents({ capability_id: 'cap-b' })).toEqual([b]);
+  });
+
+  it('filters by inclusive date range', () => {
+    const service = new InMemoryAuditService();
+    const start = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-16', occurred_at: '2026-01-02T00:00:00.000Z' });
+    const middle = createEvent({ event_type: 'CAPABILITY_AUTHORIZED', event_id: 'evt-17', occurred_at: '2026-01-02T12:00:00.000Z' });
+    const end = createEvent({ event_type: 'CAPABILITY_DENIED', event_id: 'evt-18', occurred_at: '2026-01-03T00:00:00.000Z' });
+
+    service.recordEvent(start);
+    service.recordEvent(middle);
+    service.recordEvent(end);
+
+    expect(
+      service.listEvents({
+        from: new Date('2026-01-02T00:00:00.000Z'),
+        to: new Date('2026-01-03T00:00:00.000Z'),
+      })
+    ).toEqual([start, middle, end]);
+  });
+
+  it('returns empty when nothing matches', () => {
+    const service = new InMemoryAuditService();
+    service.recordEvent(createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-19', subject_id: SUBJECT_A }));
+
+    expect(service.listEvents({ subject_id: 'did:aoc:subject:missing' })).toEqual([]);
+  });
+
+  it('handles metadata safely', () => {
+    const service = new InMemoryAuditService();
+    const metadata = { channel: 'api', cost: 10 };
+    const event = createEvent({
+      event_type: 'CAPABILITY_AUTHORIZED',
+      event_id: 'evt-20',
+      metadata,
+    });
+
+    service.recordEvent(event);
+    metadata.channel = 'mutated';
+
+    const listed = service.listEvents();
+    expect(listed[0]?.metadata).toEqual({ channel: 'api', cost: 10 });
+
+    const copy = listed[0]?.metadata as { channel: string };
+    copy.channel = 'changed-again';
+
+    expect(service.listEvents()[0]?.metadata).toEqual({ channel: 'api', cost: 10 });
+  });
+
+  it('preserves deterministic ordering', () => {
+    const service = new InMemoryAuditService();
+    const first = createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-21', occurred_at: '2026-01-04T03:00:00.000Z' });
+    const second = createEvent({
+      event_type: 'CAPABILITY_VALIDATED',
+      event_id: 'evt-22',
+      occurred_at: '2026-01-04T01:00:00.000Z',
+    });
+    const third = createEvent({ event_type: 'CAPABILITY_DENIED', event_id: 'evt-23', occurred_at: '2026-01-04T02:00:00.000Z' });
+
+    service.recordEvent(first);
+    service.recordEvent(second);
+    service.recordEvent(third);
+
+    expect(service.listEvents().map((event) => event.event_id)).toEqual(['evt-22', 'evt-23', 'evt-21']);
+  });
+
+  it('drops oldest events when max size is exceeded', () => {
+    const service = new InMemoryAuditService(2);
+
+    service.recordEvent(createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-24', occurred_at: '2026-01-05T01:00:00.000Z' }));
+    service.recordEvent(createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-25', occurred_at: '2026-01-05T02:00:00.000Z' }));
+    service.recordEvent(createEvent({ event_type: 'CAPABILITY_ISSUED', event_id: 'evt-26', occurred_at: '2026-01-05T03:00:00.000Z' }));
+
+    expect(service.listEvents().map((event) => event.event_id)).toEqual(['evt-25', 'evt-26']);
+  });
+});

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -3,7 +3,7 @@ import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/en
 import { mintCapability, type ProtocolCapability } from '../../protocol/capability';
 import { DataAccessService } from '../access/service';
 import type { DataAccessDecision, DataAccessRequestInput } from '../access/types';
-import { RuntimeAuditService, type AuditEvent, type ListAuditEventsInput } from '../audit/service';
+import { RuntimeAuditService, type ListAuditEventsInput, type RuntimeAuditEvent } from '../audit/service';
 import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
 import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
 import type { PayoutCallbackInput, PayoutExecuteResult } from '../payout/types';
@@ -191,7 +191,7 @@ export function executeRoute(
   | PayoutExecuteResult
   | DataAccessDecision
   | { received: true; reason_code: string }
-  | { events: AuditEvent[] }
+  | { events: RuntimeAuditEvent[] }
   | UsageSummaryResult
 > {
   try {

--- a/runtime/audit/index.ts
+++ b/runtime/audit/index.ts
@@ -1,0 +1,3 @@
+export { InMemoryAuditService, RuntimeAuditService } from './service';
+export type { ListAuditEventsInput, RuntimeAuditEvent } from './service';
+export type { AuditEvent as ProtocolAuditEvent, AuditEventQuery, AuditEventType } from '../../protocol/audit';

--- a/runtime/audit/service.ts
+++ b/runtime/audit/service.ts
@@ -1,3 +1,4 @@
+import type { AuditEventQuery, AuditEvent as ProtocolAuditEvent } from '../../protocol/audit';
 import type { DataAccessService } from '../access/service';
 import type { DataAccessAuditEvent } from '../access/types';
 import type { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
@@ -5,7 +6,9 @@ import type { PayoutAuditEvent } from '../payout/types';
 import type { InMemoryTrustService } from '../trust/service';
 import type { TrustAuditEvent } from '../trust/types';
 
-export type AuditEvent = TrustAuditEvent | PayoutAuditEvent | DataAccessAuditEvent;
+const DEFAULT_MAX_AUDIT_EVENTS = 10_000;
+
+export type RuntimeAuditEvent = TrustAuditEvent | PayoutAuditEvent | DataAccessAuditEvent;
 
 export type ListAuditEventsInput = {
   subject_hash?: string;
@@ -15,6 +18,70 @@ export type ListAuditEventsInput = {
   to?: Date;
 };
 
+export class InMemoryAuditService {
+  private readonly events: ProtocolAuditEvent[] = [];
+  private readonly maxEvents: number;
+
+  constructor(maxEvents: number = DEFAULT_MAX_AUDIT_EVENTS) {
+    this.maxEvents = Number.isFinite(maxEvents) && maxEvents > 0 ? Math.floor(maxEvents) : DEFAULT_MAX_AUDIT_EVENTS;
+  }
+
+  recordEvent(event: ProtocolAuditEvent): void {
+    this.events.push({
+      ...event,
+      metadata: event.metadata === undefined ? undefined : { ...event.metadata },
+    });
+
+    while (this.events.length > this.maxEvents) {
+      this.events.shift();
+    }
+  }
+
+  listEvents(query: AuditEventQuery = {}): ProtocolAuditEvent[] {
+    return this.events
+      .filter((event) => this.matchesQuery(event, query))
+      .slice()
+      .sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at))
+      .map((event) => ({
+        ...event,
+        metadata: event.metadata === undefined ? undefined : { ...event.metadata },
+      }));
+  }
+
+  private matchesQuery(event: ProtocolAuditEvent, query: AuditEventQuery): boolean {
+    if (query.event_type !== undefined && event.event_type !== query.event_type) {
+      return false;
+    }
+
+    if (query.subject_id !== undefined && event.subject_id !== query.subject_id) {
+      return false;
+    }
+
+    if (query.requester_id !== undefined && event.requester_id !== query.requester_id) {
+      return false;
+    }
+
+    if (query.consent_id !== undefined && event.consent_id !== query.consent_id) {
+      return false;
+    }
+
+    if (query.capability_id !== undefined && event.capability_id !== query.capability_id) {
+      return false;
+    }
+
+    const occurredAt = Date.parse(event.occurred_at);
+    if (query.from !== undefined && occurredAt < query.from.getTime()) {
+      return false;
+    }
+
+    if (query.to !== undefined && occurredAt > query.to.getTime()) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
 export class RuntimeAuditService {
   constructor(
     private readonly trustService: InMemoryTrustService,
@@ -22,8 +89,8 @@ export class RuntimeAuditService {
     private readonly dataAccessService: DataAccessService
   ) {}
 
-  listEvents(input: ListAuditEventsInput): AuditEvent[] {
-    const all = [
+  listEvents(input: ListAuditEventsInput): RuntimeAuditEvent[] {
+    const all: RuntimeAuditEvent[] = [
       ...this.trustService.getAuditEvents(),
       ...this.payoutExecutor.getAuditEvents(),
       ...this.dataAccessService.getAuditEvents(),
@@ -31,10 +98,10 @@ export class RuntimeAuditService {
 
     return all
       .filter((event) => this.matchesFilters(event, input))
-      .sort((a, b) => Date.parse(b.at) - Date.parse(a.at));
+      .sort((a, b) => Date.parse(a.at) - Date.parse(b.at));
   }
 
-  private matchesFilters(event: AuditEvent, input: ListAuditEventsInput): boolean {
+  private matchesFilters(event: RuntimeAuditEvent, input: ListAuditEventsInput): boolean {
     if (input.subject_hash !== undefined) {
       if (!('subject_hash' in event) || event.subject_hash !== input.subject_hash) {
         return false;

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -18,7 +18,6 @@ export type { ApiRequest, ApiResponse, ErrorResponse, RuntimeEndpoint } from './
 export type { PayoutCallbackInput, PayoutExecuteResult, PayoutAuditEvent } from './payout/types';
 
 export type { DataAccessAuditEvent, DataAccessDecision, DataAccessRequestInput, AccessTokenRecord } from './access/types';
-export type { AuditEvent } from './audit/service';
 export type { GetUsageSummaryInput, ListAuditEventsInput } from './sdk/client';
 export { InMemoryUsageService, UNIT_PRICES } from './usage';
 export type {
@@ -29,3 +28,5 @@ export type {
   UsageSummaryQuery,
   UsageSummaryResult,
 } from './usage';
+
+export * from './audit';

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -2,7 +2,7 @@ import { authorizeExecution, type ExecutionAuthorizationResult } from '../../pro
 import { evaluateEnforcement, type EnforcementDecision } from '../../protocol/enforcement';
 import { mintCapability, type MintCapabilityInput, type ProtocolCapability } from '../../protocol/capability';
 import type { DataAccessDecision, DataAccessRequestInput } from '../access/types';
-import type { AuditEvent } from '../audit/service';
+import type { RuntimeAuditEvent } from '../audit/service';
 import type { GrantConsentInput, RegisterCredentialInput, VerifyIdentityInput } from '../trust/service';
 import type {
   AocIdentityConsentRecord,
@@ -57,7 +57,7 @@ export interface HostedRuntimeSdk {
   executePayout(input: RlusdWithdrawalRequest): Promise<PayoutExecuteResult>;
   callbackPayout(input: PayoutCallbackInput): Promise<PayoutCallbackResult>;
   requestDataAccess(input: DataAccessRequestInput): Promise<DataAccessDecision>;
-  listAuditEvents(input?: ListAuditEventsInput): Promise<AuditEvent[]>;
+  listAuditEvents(input?: ListAuditEventsInput): Promise<RuntimeAuditEvent[]>;
   getUsageSummary(input: GetUsageSummaryInput): Promise<UsageSummaryResult>;
 }
 
@@ -178,11 +178,11 @@ export class HostedRuntimeClient implements HostedRuntimeSdk {
     return this.post('/data/access', input);
   }
 
-  async listAuditEvents(input: ListAuditEventsInput = {}): Promise<AuditEvent[]> {
+  async listAuditEvents(input: ListAuditEventsInput = {}): Promise<RuntimeAuditEvent[]> {
     if (this.mode === 'local') {
       throw new Error('Audit event listing is only available in hosted mode.');
     }
-    const result = await this.get<{ events: AuditEvent[] }>('/audit/events', input);
+    const result = await this.get<{ events: RuntimeAuditEvent[] }>('/audit/events', input);
     return result.events;
   }
 


### PR DESCRIPTION
### Motivation

- Introduce a first-class audit protocol and runtime audit support to record and query authorization, payout and data-access events.
- Provide builders to create well-formed protocol audit events and an in-memory runtime audit store for local usage and testing.

### Description

- Add protocol audit definitions and helpers in `protocol/audit` including `types.ts`, `builders.ts`, and an index export, and expose event builders like `buildConsentEvaluatedEvent` and related helpers.
- Implement an `InMemoryAuditService` in `runtime/audit/service.ts` that stores `ProtocolAuditEvent` instances with safe metadata copies, deterministic ordering, and a configurable `maxEvents` eviction policy, and refine `RuntimeAuditService` to return `RuntimeAuditEvent[]` and sort events in ascending time order.
- Wire runtime exports and public SDK/route types to use the new `RuntimeAuditEvent` and `ListAuditEventsInput` types by updating `runtime/index.ts`, `runtime/audit/index.ts`, `runtime/api/routes.ts`, and `runtime/sdk/client.ts`.
- Add comprehensive unit tests in `runtime/__tests__/auditTrail.test.ts` that exercise recording, listing, filtering, ordering, metadata immutability, and max-size eviction behavior.

### Testing

- Ran the new unit test file `runtime/__tests__/auditTrail.test.ts`, which covers recording/listing/filters/ordering/metadata/max-size behavior, and it passed.
- Existing TypeScript compilation and type checks were exercised implicitly by the updated types and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3751cba483258b8023998bf54dcc)