### PR TITLE
Add runtime monetization layer to generate billable events from usage

### DIFF
--- a/runtime/__tests__/monetization.test.ts
+++ b/runtime/__tests__/monetization.test.ts
@@ -1,0 +1,224 @@
+import { createRuntimeServer } from '../api/server';
+import { DEFAULT_RUNTIME_CORE } from '../api/routes';
+import { DataAccessService } from '../access/service';
+import { RuntimeAuditService } from '../audit/service';
+import { InMemoryMonetizationService, InMemoryPricingRegistry, type PricingRule } from '../monetization';
+import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
+import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
+import { closeServer, startServer } from './helpers/serverLifecycle';
+import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
+import { InMemoryUsageService } from '../usage';
+
+const PRICING_RULES: PricingRule[] = [
+  { resource: '/data/access', action: 'execute', unit_price: 0.05, currency: 'AOC' },
+  { resource: '/payout/execute', action: 'execute', unit_price: 0.25, currency: 'AOC' },
+];
+
+describe('in-memory monetization service', () => {
+  it('calculates price and total_price correctly with deterministic timestamps', () => {
+    const service = new InMemoryMonetizationService(new InMemoryPricingRegistry(PRICING_RULES));
+
+    const event = service.recordUsageAsBillable({
+      consumer_id: 'mm-1',
+      resource: '/data/access',
+      action: 'execute',
+      quantity: 3,
+      occurred_at: '2026-03-01T12:00:00.000Z',
+      audit_event_id: 'audit-1',
+    });
+
+    expect(event).toBeDefined();
+    expect(event).toMatchObject({
+      consumer_id: 'mm-1',
+      resource: '/data/access',
+      action: 'execute',
+      unit_price: 0.05,
+      quantity: 3,
+      total_price: 0.15,
+      currency: 'AOC',
+      occurred_at: '2026-03-01T12:00:00.000Z',
+      audit_event_id: 'audit-1',
+    });
+  });
+
+  it('does not generate billable event when pricing rule is missing', () => {
+    const service = new InMemoryMonetizationService(new InMemoryPricingRegistry(PRICING_RULES));
+
+    const event = service.recordUsageAsBillable({
+      consumer_id: 'mm-2',
+      resource: '/trust/verify',
+      action: 'execute',
+      quantity: 1,
+      occurred_at: '2026-03-01T12:00:00.000Z',
+    });
+
+    expect(event).toBeUndefined();
+    expect(service.listBillableEvents()).toHaveLength(0);
+  });
+
+  it('aggregates totals per consumer across multiple usage events', () => {
+    const service = new InMemoryMonetizationService(new InMemoryPricingRegistry(PRICING_RULES));
+
+    service.recordUsageAsBillable({
+      consumer_id: 'mm-3',
+      resource: '/data/access',
+      action: 'execute',
+      quantity: 2,
+      occurred_at: '2026-03-01T10:00:00.000Z',
+    });
+    service.recordUsageAsBillable({
+      consumer_id: 'mm-3',
+      resource: '/payout/execute',
+      action: 'execute',
+      quantity: 1,
+      occurred_at: '2026-03-01T11:00:00.000Z',
+    });
+    service.recordUsageAsBillable({
+      consumer_id: 'mm-other',
+      resource: '/data/access',
+      action: 'execute',
+      quantity: 100,
+      occurred_at: '2026-03-01T12:00:00.000Z',
+    });
+
+    const summary = service.getConsumerSummary('mm-3');
+    expect(summary).toEqual({
+      consumer_id: 'mm-3',
+      currency: 'AOC',
+      total_quantity: 3,
+      total_price: 0.35,
+      total_events: 2,
+      by_resource_action: [
+        {
+          resource: '/data/access',
+          action: 'execute',
+          quantity: 2,
+          total_price: 0.1,
+          event_count: 1,
+        },
+        {
+          resource: '/payout/execute',
+          action: 'execute',
+          quantity: 1,
+          total_price: 0.25,
+          event_count: 1,
+        },
+      ],
+    });
+  });
+
+  it('prevents mutation leaks from listed events', () => {
+    const service = new InMemoryMonetizationService(new InMemoryPricingRegistry(PRICING_RULES));
+    service.recordUsageAsBillable({
+      consumer_id: 'mm-4',
+      resource: '/data/access',
+      action: 'execute',
+      quantity: 1,
+      occurred_at: '2026-03-01T12:00:00.000Z',
+    });
+
+    const listed = service.listBillableEvents({ consumer_id: 'mm-4' });
+    listed[0].total_price = 999;
+
+    const listedAgain = service.listBillableEvents({ consumer_id: 'mm-4' });
+    expect(listedAgain[0].total_price).toBe(0.05);
+  });
+});
+
+describe('usage integration with monetization', () => {
+  function buildCore() {
+    const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
+    const payoutExecutor = new RlusdPayoutExecutorService(trustService, new RlusdPayoutAdapter());
+    const dataAccessService = new DataAccessService(trustService);
+    const usageService = new InMemoryUsageService();
+    const auditService = new RuntimeAuditService(trustService, payoutExecutor, dataAccessService);
+    const monetizationService = new InMemoryMonetizationService(new InMemoryPricingRegistry(PRICING_RULES));
+
+    return {
+      ...DEFAULT_RUNTIME_CORE,
+      trustService,
+      payoutExecutor,
+      dataAccessService,
+      usageService,
+      auditService,
+      monetizationService,
+    };
+  }
+
+  it('creates billable events from metered endpoint executions without blocking', async () => {
+    const core = buildCore();
+    const server = createRuntimeServer({ core });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as { port: number };
+      const base = `http://127.0.0.1:${port}`;
+      const headers = { 'x-api-key': 'aoc_free_dev_key', 'content-type': 'application/json' };
+
+      const response = await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          subject_hash: '0xsubject_monetized',
+          consumer_id: 'mm-integrated',
+          dataset_id: 'dataset-z',
+          purpose: 'analytics',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const events = core.monetizationService.listBillableEvents({ consumer_id: 'mm-integrated' });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        consumer_id: 'mm-integrated',
+        resource: '/data/access',
+        action: 'execute',
+        unit_price: 0.05,
+        quantity: 1,
+        total_price: 0.05,
+        currency: 'AOC',
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('skips billable events when pricing rule does not exist', async () => {
+    const core = buildCore();
+    const unpricedCore = {
+      ...core,
+      monetizationService: new InMemoryMonetizationService(new InMemoryPricingRegistry([])),
+    };
+
+    const server = createRuntimeServer({ core: unpricedCore });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as { port: number };
+      const base = `http://127.0.0.1:${port}`;
+
+      const response = await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers: { 'x-api-key': 'aoc_free_dev_key', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          subject_hash: '0xsubject_unpriced',
+          consumer_id: 'mm-unpriced',
+          dataset_id: 'dataset-no-price',
+          purpose: 'analytics',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const events = unpricedCore.monetizationService.listBillableEvents({ consumer_id: 'mm-unpriced' });
+      expect(events).toHaveLength(0);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/runtime/__tests__/usageMeteringHosted.test.ts
+++ b/runtime/__tests__/usageMeteringHosted.test.ts
@@ -8,7 +8,14 @@ import { HostedRuntimeClient } from '../sdk/client';
 import { DEFAULT_TRUST_ISSUERS, InMemoryTrustService } from '../trust/service';
 import { InMemoryUsageService } from '../usage';
 import { RuntimeAuditService } from '../audit/service';
+import { InMemoryMonetizationService, InMemoryPricingRegistry, type PricingRule } from '../monetization';
 import { closeServer, startServer } from './helpers/serverLifecycle';
+
+const TEST_PRICING_RULES: PricingRule[] = [
+  { resource: '/data/access', action: 'execute', unit_price: 0.05, currency: 'AOC' },
+  { resource: '/payout/execute', action: 'execute', unit_price: 0.25, currency: 'AOC' },
+  { resource: '/trust/verify', action: 'execute', unit_price: 0, currency: 'AOC' },
+];
 
 function buildCore() {
   const trustService = new InMemoryTrustService(DEFAULT_TRUST_ISSUERS);
@@ -16,6 +23,7 @@ function buildCore() {
   const dataAccessService = new DataAccessService(trustService);
   const usageService = new InMemoryUsageService();
   const auditService = new RuntimeAuditService(trustService, payoutExecutor, dataAccessService);
+  const monetizationService = new InMemoryMonetizationService(new InMemoryPricingRegistry(TEST_PRICING_RULES));
 
   return {
     ...DEFAULT_RUNTIME_CORE,
@@ -24,6 +32,7 @@ function buildCore() {
     dataAccessService,
     auditService,
     usageService,
+    monetizationService,
   };
 }
 

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -16,6 +16,7 @@ import type {
 } from '../trust/types';
 import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
 import { InMemoryUsageService, isMeteredEndpoint } from '../usage';
+import { InMemoryMonetizationService, InMemoryPricingRegistry, type PricingRule } from '../monetization';
 import type { MeteredRuntimeEndpoint, UsageSummaryResult } from '../usage';
 
 export type RuntimeCore = {
@@ -27,13 +28,21 @@ export type RuntimeCore = {
   dataAccessService: DataAccessService;
   auditService: RuntimeAuditService;
   usageService: InMemoryUsageService;
+  monetizationService: InMemoryMonetizationService;
 };
+
+const DEFAULT_PRICING_RULES: PricingRule[] = [
+  { resource: '/data/access', action: 'execute', unit_price: 0.05, currency: 'AOC' },
+  { resource: '/payout/execute', action: 'execute', unit_price: 0.25, currency: 'AOC' },
+  { resource: '/trust/verify', action: 'execute', unit_price: 0, currency: 'AOC' },
+];
 
 const defaultTrustService = new InMemoryTrustService();
 const defaultPayoutExecutor = new RlusdPayoutExecutorService(defaultTrustService, new RlusdPayoutAdapter());
 const defaultDataAccessService = new DataAccessService(defaultTrustService);
 const defaultAuditService = new RuntimeAuditService(defaultTrustService, defaultPayoutExecutor, defaultDataAccessService);
 const defaultUsageService = new InMemoryUsageService();
+const defaultMonetizationService = new InMemoryMonetizationService(new InMemoryPricingRegistry(DEFAULT_PRICING_RULES));
 
 const ROUTE_ERRORS = {
   invalidRequest: 'INVALID_REQUEST',
@@ -51,6 +60,7 @@ export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
   dataAccessService: defaultDataAccessService,
   auditService: defaultAuditService,
   usageService: defaultUsageService,
+  monetizationService: defaultMonetizationService,
 };
 
 function reviveNow<T extends Record<string, unknown>>(payload: T): T {

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -137,6 +137,7 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
     if (isMeteredEndpoint(pathname)) {
       const consumerId = maybeResolveUsageConsumerId(pathname, payload);
       if (consumerId !== undefined) {
+        const occurredAt = new Date().toISOString();
         Promise.resolve()
           .then(() => {
             core.usageService.recordUsage({
@@ -144,6 +145,15 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
               endpoint: pathname,
               decision: decisionInfo.decision,
               reason_code: decisionInfo.reasonCode,
+              usedAt: new Date(occurredAt),
+            });
+
+            core.monetizationService.recordUsageAsBillable({
+              consumer_id: consumerId,
+              resource: pathname,
+              action: 'execute',
+              quantity: 1,
+              occurred_at: occurredAt,
             });
           })
           .catch(() => {

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -20,6 +20,15 @@ export type { PayoutCallbackInput, PayoutExecuteResult, PayoutAuditEvent } from 
 export type { DataAccessAuditEvent, DataAccessDecision, DataAccessRequestInput, AccessTokenRecord } from './access/types';
 export type { GetUsageSummaryInput, ListAuditEventsInput } from './sdk/client';
 export { InMemoryUsageService, UNIT_PRICES } from './usage';
+export { InMemoryMonetizationService, InMemoryPricingRegistry } from './monetization';
+export type {
+  PricingRule,
+  BillableEvent,
+  BillableEventQuery,
+  ConsumerBillingSummary,
+  MonetizationUsageEvent,
+} from './monetization';
+
 export type {
   MeteredRuntimeEndpoint,
   UsageDecision,

--- a/runtime/monetization/index.ts
+++ b/runtime/monetization/index.ts
@@ -1,0 +1,9 @@
+export { InMemoryPricingRegistry } from './pricing';
+export { InMemoryMonetizationService } from './service';
+export type {
+  PricingRule,
+  BillableEvent,
+  BillableEventQuery,
+  ConsumerBillingSummary,
+  MonetizationUsageEvent,
+} from './types';

--- a/runtime/monetization/pricing.ts
+++ b/runtime/monetization/pricing.ts
@@ -1,0 +1,30 @@
+import type { PricingRule } from './types';
+
+function toPricingKey(resource: string, action: string): string {
+  return `${resource}::${action}`;
+}
+
+export class InMemoryPricingRegistry {
+  private readonly rules = new Map<string, PricingRule>();
+
+  constructor(initialRules: PricingRule[] = []) {
+    for (const rule of initialRules) {
+      this.setRule(rule);
+    }
+  }
+
+  setRule(rule: PricingRule): void {
+    this.rules.set(toPricingKey(rule.resource, rule.action), { ...rule });
+  }
+
+  getRule(resource: string, action: string): PricingRule | undefined {
+    const rule = this.rules.get(toPricingKey(resource, action));
+    return rule === undefined ? undefined : { ...rule };
+  }
+
+  listRules(): PricingRule[] {
+    return [...this.rules.values()]
+      .map((rule) => ({ ...rule }))
+      .sort((a, b) => `${a.resource}:${a.action}`.localeCompare(`${b.resource}:${b.action}`));
+  }
+}

--- a/runtime/monetization/service.ts
+++ b/runtime/monetization/service.ts
@@ -1,0 +1,116 @@
+import { InMemoryPricingRegistry } from './pricing';
+import type {
+  BillableEvent,
+  BillableEventQuery,
+  ConsumerBillingSummary,
+  MonetizationUsageEvent,
+  PricingRule,
+} from './types';
+
+function roundMoney(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function cloneEvent(event: BillableEvent): BillableEvent {
+  return { ...event };
+}
+
+export class InMemoryMonetizationService {
+  private readonly pricingRegistry: InMemoryPricingRegistry;
+  private readonly billableEvents: BillableEvent[] = [];
+  private idSequence = 0;
+
+  constructor(pricingRegistry: InMemoryPricingRegistry = new InMemoryPricingRegistry()) {
+    this.pricingRegistry = pricingRegistry;
+  }
+
+  getPricingRegistry(): InMemoryPricingRegistry {
+    return this.pricingRegistry;
+  }
+
+  recordUsageAsBillable(usageEvent: MonetizationUsageEvent, pricingRule?: PricingRule): BillableEvent | undefined {
+    const rule = pricingRule ?? this.pricingRegistry.getRule(usageEvent.resource, usageEvent.action);
+    if (rule === undefined) {
+      return undefined;
+    }
+
+    this.idSequence += 1;
+    const billableEvent: BillableEvent = {
+      event_id: `billable_${String(this.idSequence).padStart(8, '0')}`,
+      consumer_id: usageEvent.consumer_id,
+      resource: usageEvent.resource,
+      action: usageEvent.action,
+      unit_price: rule.unit_price,
+      quantity: usageEvent.quantity,
+      total_price: roundMoney(rule.unit_price * usageEvent.quantity),
+      currency: rule.currency,
+      occurred_at: usageEvent.occurred_at,
+      audit_event_id: usageEvent.audit_event_id,
+    };
+
+    this.billableEvents.push(billableEvent);
+    return cloneEvent(billableEvent);
+  }
+
+  listBillableEvents(query: BillableEventQuery = {}): BillableEvent[] {
+    return this.billableEvents
+      .filter((event) => {
+        if (query.consumer_id !== undefined && event.consumer_id !== query.consumer_id) {
+          return false;
+        }
+        if (query.resource !== undefined && event.resource !== query.resource) {
+          return false;
+        }
+        if (query.action !== undefined && event.action !== query.action) {
+          return false;
+        }
+
+        const occurredAtTime = Date.parse(event.occurred_at);
+        if (query.from !== undefined && occurredAtTime < query.from.getTime()) {
+          return false;
+        }
+        if (query.to !== undefined && occurredAtTime > query.to.getTime()) {
+          return false;
+        }
+
+        return true;
+      })
+      .slice()
+      .sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at))
+      .map(cloneEvent);
+  }
+
+  getConsumerSummary(consumer_id: string): ConsumerBillingSummary {
+    const events = this.listBillableEvents({ consumer_id });
+
+    const grouped = new Map<string, ConsumerBillingSummary['by_resource_action'][number]>();
+    for (const event of events) {
+      const key = `${event.resource}::${event.action}`;
+      const existing = grouped.get(key) ?? {
+        resource: event.resource,
+        action: event.action,
+        quantity: 0,
+        total_price: 0,
+        event_count: 0,
+      };
+
+      existing.quantity += event.quantity;
+      existing.total_price = roundMoney(existing.total_price + event.total_price);
+      existing.event_count += 1;
+      grouped.set(key, existing);
+    }
+
+    const byResourceAction = [...grouped.values()]
+      .map((item) => ({ ...item }))
+      .sort((a, b) => `${a.resource}:${a.action}`.localeCompare(`${b.resource}:${b.action}`));
+
+    return {
+      consumer_id,
+      currency: 'AOC',
+      total_quantity: byResourceAction.reduce((acc, item) => acc + item.quantity, 0),
+      total_price: roundMoney(byResourceAction.reduce((acc, item) => acc + item.total_price, 0)),
+      total_events: events.length,
+      by_resource_action: byResourceAction,
+    };
+  }
+}

--- a/runtime/monetization/types.ts
+++ b/runtime/monetization/types.ts
@@ -1,0 +1,51 @@
+export type PricingRule = {
+  resource: string;
+  action: string;
+  unit_price: number;
+  currency: 'AOC';
+};
+
+export type BillableEvent = {
+  event_id: string;
+  consumer_id: string;
+  resource: string;
+  action: string;
+  unit_price: number;
+  quantity: number;
+  total_price: number;
+  currency: 'AOC';
+  occurred_at: string;
+  audit_event_id?: string;
+};
+
+export type MonetizationUsageEvent = {
+  consumer_id: string;
+  resource: string;
+  action: string;
+  quantity: number;
+  occurred_at: string;
+  audit_event_id?: string;
+};
+
+export type BillableEventQuery = {
+  consumer_id?: string;
+  resource?: string;
+  action?: string;
+  from?: Date;
+  to?: Date;
+};
+
+export type ConsumerBillingSummary = {
+  consumer_id: string;
+  currency: 'AOC';
+  total_quantity: number;
+  total_price: number;
+  total_events: number;
+  by_resource_action: Array<{
+    resource: string;
+    action: string;
+    quantity: number;
+    total_price: number;
+    event_count: number;
+  }>;
+};


### PR DESCRIPTION
### Motivation
- Introduce a deterministic, testable monetization foundation in the runtime that converts metered usage into billable economic events without adding blockchain or token logic.
- Keep separation of concerns so protocol layers (`protocol/consent`, `protocol/capability`) are unchanged and request lifecycles are non-blocking.

### Description
- Add monetization domain types in `runtime/monetization/types.ts` (`PricingRule`, `BillableEvent`, `MonetizationUsageEvent`, query and summary types). 
- Implement an in-memory pricing registry `InMemoryPricingRegistry` in `runtime/monetization/pricing.ts` supporting `setRule`, `getRule`, and `listRules` with defensive copies. 
- Implement `InMemoryMonetizationService` in `runtime/monetization/service.ts` with `recordUsageAsBillable(usageEvent, pricingRule?)`, `listBillableEvents(query)`, and `getConsumerSummary(consumer_id)`, deterministic event IDs, safe skip when pricing is missing, and precise total price calculation. 
- Wire monetization into runtime: export services from `runtime/index.ts`, add a default in-memory pricing set and service in `runtime/api/routes.ts`, and generate billable events asynchronously after usage is recorded in `runtime/api/server.ts` without blocking the request. 
- Add `runtime/__tests__/monetization.test.ts` and update `runtime/__tests__/usageMeteringHosted.test.ts` to exercise price calculation, missing-rule behavior, consumer aggregation, multiple events, deterministic timestamps, mutation-safety, and usage->billing integration.

### Testing
- Ran the added and updated suites with `jest runtime/__tests__/monetization.test.ts runtime/__tests__/usageMeteringHosted.test.ts` which executed the new `runtime/__tests__/monetization.test.ts` and the hosted usage metering tests. 
- All targeted tests passed (`12` tests across the two suites) and validate pricing, aggregation, non-blocking integration, deterministic timestamps, and no mutation leaks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd490720608325bcbe517a6bfdbcd8)