### PR TITLE
PR27: Enforce capability-based access control in runtime endpoints

### DIFF
--- a/runtime/__tests__/enforcement.test.ts
+++ b/runtime/__tests__/enforcement.test.ts
@@ -1,0 +1,260 @@
+import type { AddressInfo } from 'net';
+import { issueCapabilityToken, type ConsentDecision, type ConsentRecord, type ConsentRequest } from '../../protocol/consent';
+import { DEFAULT_RUNTIME_CORE, type RuntimeCore } from '../api/routes';
+import { createRuntimeServer } from '../api/server';
+import { closeServer, startServer } from './helpers/serverLifecycle';
+
+const CAPABILITY_SECRET = 'runtime-enforcement-secret';
+
+function buildConsent(overrides: Partial<ConsentRecord> = {}): ConsentRecord {
+  return {
+    consent_id: 'consent-runtime-1',
+    subject_id: 'subject-1',
+    requester_id: 'requester-1',
+    resource: '/data/access',
+    actions: ['execute'],
+    granted: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+    expires_at: '2026-12-31T00:00:00.000Z',
+    revoked_at: null,
+    consent_hash: 'consent-hash-runtime-1',
+    ...overrides,
+  };
+}
+
+function buildRequest(overrides: Partial<ConsentRequest> = {}): ConsentRequest {
+  return {
+    subject_id: 'subject-1',
+    requester_id: 'requester-1',
+    resource: '/data/access',
+    action: 'execute',
+    requested_at: '2026-02-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildDecision(overrides: Partial<ConsentDecision> = {}): ConsentDecision {
+  return {
+    allowed: true,
+    reason_code: 'ALLOW',
+    evaluated_at: '2026-02-01T00:00:00.000Z',
+    consent_id: 'consent-runtime-1',
+    ...overrides,
+  };
+}
+
+function makeCapability(resource: '/data/access' | '/payout/execute', requester = 'requester-1') {
+  return issueCapabilityToken(
+    {
+      consent: buildConsent({ resource, requester_id: requester }),
+      request: buildRequest({ resource, requester_id: requester }),
+      decision: buildDecision(),
+    },
+    CAPABILITY_SECRET
+  );
+}
+
+function makeCore(overrides: Partial<RuntimeCore> = {}): RuntimeCore {
+  return {
+    ...DEFAULT_RUNTIME_CORE,
+    ...overrides,
+  };
+}
+
+describe('runtime capability enforcement', () => {
+  it('allows access with valid capability', async () => {
+    const dataAccessService = {
+      requestAccess: jest.fn().mockReturnValue({
+        allowed: true,
+        reason_code: 'ACCESS_ALLOWED',
+        evaluated_at: '2026-03-01T00:00:00.000Z',
+        access_token: 'aoc_access_valid',
+        expires_at: '2026-03-01T01:00:00.000Z',
+        audit_ref: 'audit-1',
+      }),
+      getAuditEvents: jest.fn().mockReturnValue([]),
+    } as unknown as RuntimeCore['dataAccessService'];
+
+    const core = makeCore({ dataAccessService });
+    const server = createRuntimeServer({ core, capabilitySecret: CAPABILITY_SECRET, enforcementMode: 'strict' });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/data/access`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+          'x-aoc-capability': JSON.stringify(makeCapability('/data/access')),
+        },
+        body: JSON.stringify({
+          subject_hash: 'subject-1',
+          consumer_id: 'requester-1',
+          dataset_id: 'dataset-1',
+          purpose: 'risk',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(dataAccessService.requestAccess).toHaveBeenCalledTimes(1);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('denies access with invalid capability', async () => {
+    const dataAccessService = {
+      requestAccess: jest.fn(),
+      getAuditEvents: jest.fn().mockReturnValue([]),
+    } as unknown as RuntimeCore['dataAccessService'];
+
+    const core = makeCore({ dataAccessService });
+    const server = createRuntimeServer({ core, capabilitySecret: CAPABILITY_SECRET, enforcementMode: 'strict' });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/data/access`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+          'x-aoc-capability': JSON.stringify({ bad: true }),
+        },
+        body: JSON.stringify({
+          subject_hash: 'subject-1',
+          consumer_id: 'requester-1',
+          dataset_id: 'dataset-1',
+          purpose: 'risk',
+        }),
+      });
+
+      expect(response.status).toBe(403);
+      expect(dataAccessService.requestAccess).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('allows access in soft mode without token', async () => {
+    const dataAccessService = {
+      requestAccess: jest.fn().mockReturnValue({
+        allowed: true,
+        reason_code: 'ACCESS_ALLOWED',
+        evaluated_at: '2026-03-01T00:00:00.000Z',
+        access_token: 'aoc_access_valid',
+        expires_at: '2026-03-01T01:00:00.000Z',
+        audit_ref: 'audit-2',
+      }),
+      getAuditEvents: jest.fn().mockReturnValue([]),
+    } as unknown as RuntimeCore['dataAccessService'];
+
+    const core = makeCore({ dataAccessService });
+    const server = createRuntimeServer({ core, capabilitySecret: CAPABILITY_SECRET, enforcementMode: 'soft' });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/data/access`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+        },
+        body: JSON.stringify({
+          subject_hash: 'subject-1',
+          consumer_id: 'requester-1',
+          dataset_id: 'dataset-1',
+          purpose: 'risk',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(dataAccessService.requestAccess).toHaveBeenCalledTimes(1);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('denies access in strict mode without token', async () => {
+    const payoutExecutor = {
+      execute: jest.fn(),
+      callback: jest.fn(),
+      getAuditEvents: jest.fn().mockReturnValue([]),
+    } as unknown as RuntimeCore['payoutExecutor'];
+
+    const core = makeCore({ payoutExecutor });
+    const server = createRuntimeServer({ core, capabilitySecret: CAPABILITY_SECRET, enforcementMode: 'strict' });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${port}/payout/execute`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+        },
+        body: JSON.stringify({
+          withdrawal_id: 'wd-1',
+          subject_hash: 'subject-1',
+          consumer_id: 'requester-1',
+          amount: '10',
+        }),
+      });
+
+      expect(response.status).toBe(403);
+      expect(payoutExecutor.execute).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('records capability audit events for authorized and denied requests', async () => {
+    const core = makeCore();
+    const server = createRuntimeServer({ core, capabilitySecret: CAPABILITY_SECRET, enforcementMode: 'strict' });
+    await startServer(server);
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const base = `http://127.0.0.1:${port}`;
+
+      await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+          'x-aoc-capability': JSON.stringify(makeCapability('/data/access')),
+        },
+        body: JSON.stringify({
+          subject_hash: 'subject-1',
+          consumer_id: 'requester-1',
+          dataset_id: 'dataset-1',
+          purpose: 'risk',
+        }),
+      });
+
+      await fetch(`${base}/data/access`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': 'aoc_free_dev_key',
+          'x-aoc-capability': JSON.stringify(makeCapability('/data/access', 'other-requester')),
+        },
+        body: JSON.stringify({
+          subject_hash: 'subject-1',
+          consumer_id: 'requester-1',
+          dataset_id: 'dataset-1',
+          purpose: 'risk',
+        }),
+      });
+
+      const events = core.capabilityAuditService.listEvents();
+      expect(events.some((event) => event.event_type === 'CAPABILITY_AUTHORIZED')).toBe(true);
+      expect(events.some((event) => event.event_type === 'CAPABILITY_DENIED')).toBe(true);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -4,6 +4,7 @@ import { mintCapability, type ProtocolCapability } from '../../protocol/capabili
 import { DataAccessService } from '../access/service';
 import type { DataAccessDecision, DataAccessRequestInput } from '../access/types';
 import { RuntimeAuditService, type ListAuditEventsInput, type RuntimeAuditEvent } from '../audit/service';
+import { InMemoryAuditService } from '../audit/service';
 import { RlusdPayoutAdapter } from '../payout/payoutAdapters/rlusd.adapter';
 import { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.service';
 import type { PayoutCallbackInput, PayoutExecuteResult } from '../payout/types';
@@ -29,6 +30,7 @@ export type RuntimeCore = {
   auditService: RuntimeAuditService;
   usageService: InMemoryUsageService;
   monetizationService: InMemoryMonetizationService;
+  capabilityAuditService: InMemoryAuditService;
 };
 
 const DEFAULT_PRICING_RULES: PricingRule[] = [
@@ -43,6 +45,7 @@ const defaultDataAccessService = new DataAccessService(defaultTrustService);
 const defaultAuditService = new RuntimeAuditService(defaultTrustService, defaultPayoutExecutor, defaultDataAccessService);
 const defaultUsageService = new InMemoryUsageService();
 const defaultMonetizationService = new InMemoryMonetizationService(new InMemoryPricingRegistry(DEFAULT_PRICING_RULES));
+const defaultCapabilityAuditService = new InMemoryAuditService();
 
 const ROUTE_ERRORS = {
   invalidRequest: 'INVALID_REQUEST',
@@ -61,6 +64,7 @@ export const DEFAULT_RUNTIME_CORE: RuntimeCore = {
   auditService: defaultAuditService,
   usageService: defaultUsageService,
   monetizationService: defaultMonetizationService,
+  capabilityAuditService: defaultCapabilityAuditService,
 };
 
 function reviveNow<T extends Record<string, unknown>>(payload: T): T {

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -7,6 +7,7 @@ import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
 import { authAndLimit } from './middleware';
 import { DEFAULT_RUNTIME_CORE, deriveDecision, executeRoute, maybeResolveUsageConsumerId, type RuntimeCore } from './routes';
 import { isMeteredEndpoint } from '../usage';
+import { enforceCapabilityAccess, type EnforcementMode } from '../enforcement';
 
 const POST_ENDPOINTS: RuntimeEndpoint[] = [
   '/enforcement/evaluate',
@@ -27,6 +28,8 @@ export type RuntimeServerDeps = {
   rateLimiter?: InMemoryRateLimiter;
   logger?: RuntimeLogger;
   core?: RuntimeCore;
+  capabilitySecret?: string;
+  enforcementMode?: EnforcementMode;
 };
 
 function sendJson(response: ServerResponse, statusCode: number, body: ApiResponse<unknown>): void {
@@ -62,6 +65,8 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
   const rateLimiter = deps.rateLimiter ?? new InMemoryRateLimiter();
   const logger = deps.logger ?? new RuntimeLogger();
   const core = deps.core ?? DEFAULT_RUNTIME_CORE;
+  const capabilitySecret = deps.capabilitySecret ?? process.env.AOC_CAPABILITY_SECRET ?? 'aoc_runtime_capability_secret';
+  const enforcementMode = deps.enforcementMode ?? (process.env.ENFORCEMENT_MODE === 'strict' ? 'strict' : 'soft');
 
   return createServer(async (request, response) => {
     if (request.url === undefined) {
@@ -112,6 +117,49 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
             message: error instanceof Error ? error.message : 'Invalid JSON payload.',
           },
         });
+      }
+    }
+
+    if (
+      method === 'POST' &&
+      (pathname === '/data/access' || pathname === '/payout/execute') &&
+      payload !== null &&
+      typeof payload === 'object'
+    ) {
+      const requestPayload = payload as { subject_hash?: unknown; consumer_id?: unknown };
+      const subjectId = typeof requestPayload.subject_hash === 'string' ? requestPayload.subject_hash : undefined;
+      const requesterId = typeof requestPayload.consumer_id === 'string' ? requestPayload.consumer_id : undefined;
+
+      if (subjectId !== undefined && requesterId !== undefined) {
+        const capabilityResult = enforceCapabilityAccess({
+          endpoint: pathname,
+          headers: request.headers,
+          payload,
+          subject_id: subjectId,
+          requester_id: requesterId,
+          mode: enforcementMode,
+          capabilitySecret,
+        });
+
+        if (capabilityResult.auditEvent !== undefined) {
+          core.capabilityAuditService.recordEvent(capabilityResult.auditEvent);
+        }
+
+        if (!capabilityResult.allowed) {
+          logger.log({
+            requestId,
+            endpoint: pathname,
+            decision: 'deny',
+            reason_code: capabilityResult.authorization?.reason_code ?? capabilityResult.reason_code,
+          });
+          return sendJson(response, 403, {
+            success: false,
+            error: {
+              code: 'CAPABILITY_ACCESS_DENIED',
+              message: `Capability enforcement denied access (${capabilityResult.reason_code}).`,
+            },
+          });
+        }
       }
     }
 

--- a/runtime/enforcement/enforceCapability.ts
+++ b/runtime/enforcement/enforceCapability.ts
@@ -1,0 +1,147 @@
+import { buildCapabilityAuthorizedEvent, buildCapabilityDeniedEvent } from '../../protocol/audit/builders';
+import { authorizeWithCapability, type CapabilityAuthorizationResult, type CapabilityToken } from '../../protocol/consent';
+import type { AuditEvent } from '../../protocol/audit';
+
+export type EnforcementMode = 'soft' | 'strict';
+
+export type CapabilityRequestContext = {
+  endpoint: string;
+  headers: Record<string, string | string[] | undefined>;
+  payload: unknown;
+  subject_id: string;
+  requester_id: string;
+  mode: EnforcementMode;
+  capabilitySecret: string;
+};
+
+export type CapabilityEnforcementResult = {
+  allowed: boolean;
+  reason_code: string;
+  status_code: number;
+  token_present: boolean;
+  authorization?: CapabilityAuthorizationResult;
+  auditEvent?: AuditEvent;
+};
+
+function normalizeHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function maybeParseCapabilityHeader(value: string | undefined): unknown {
+  if (value === undefined || value.trim() === '') {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function getCapabilityFromPayload(payload: unknown): unknown {
+  if (payload === null || typeof payload !== 'object') {
+    return undefined;
+  }
+
+  const candidate = payload as { capability?: unknown; capability_token?: unknown; token?: unknown };
+  if (candidate.capability !== undefined) {
+    return candidate.capability;
+  }
+  if (candidate.capability_token !== undefined) {
+    return candidate.capability_token;
+  }
+  if (candidate.token !== undefined) {
+    return candidate.token;
+  }
+
+  return undefined;
+}
+
+function extractCapabilityToken(context: CapabilityRequestContext): unknown {
+  const headerToken = maybeParseCapabilityHeader(normalizeHeaderValue(context.headers['x-aoc-capability']));
+  if (headerToken !== undefined) {
+    return headerToken;
+  }
+
+  return getCapabilityFromPayload(context.payload);
+}
+
+function buildAudit(result: CapabilityAuthorizationResult, context: CapabilityRequestContext): AuditEvent {
+  const builderInput = {
+    allowed: result.allowed,
+    reason_code: result.reason_code,
+    subject_id: context.subject_id,
+    requester_id: context.requester_id,
+    resource: context.endpoint,
+    action: 'execute',
+    capability_id: result.capability_id,
+    metadata: {
+      enforcement_mode: context.mode,
+    },
+  };
+
+  return result.allowed ? buildCapabilityAuthorizedEvent(builderInput) : buildCapabilityDeniedEvent(builderInput);
+}
+
+export function enforceCapabilityAccess(context: CapabilityRequestContext): CapabilityEnforcementResult {
+  const token = extractCapabilityToken(context);
+  const tokenPresent = token !== undefined;
+
+  if (!tokenPresent && context.mode === 'soft') {
+    return {
+      allowed: true,
+      reason_code: 'CAPABILITY_SOFT_ALLOW_MISSING',
+      status_code: 200,
+      token_present: false,
+    };
+  }
+
+  if (!tokenPresent) {
+    const authorization: CapabilityAuthorizationResult = {
+      allowed: false,
+      reason_code: 'DENY_INVALID_CAPABILITY',
+      evaluated_at: new Date().toISOString(),
+      capability_id: null,
+    };
+
+    return {
+      allowed: false,
+      reason_code: 'CAPABILITY_MISSING',
+      status_code: 403,
+      token_present: false,
+      authorization,
+      auditEvent: buildAudit(authorization, context),
+    };
+  }
+
+  const authorization = authorizeWithCapability(
+    {
+      subject_id: context.subject_id,
+      requester_id: context.requester_id,
+      resource: context.endpoint,
+      action: 'execute',
+    },
+    token,
+    context.capabilitySecret
+  );
+
+  return {
+    allowed: authorization.allowed,
+    reason_code: authorization.allowed ? 'CAPABILITY_AUTHORIZED' : 'CAPABILITY_DENIED',
+    status_code: authorization.allowed ? 200 : 403,
+    token_present: true,
+    authorization,
+    auditEvent: buildAudit(authorization, context),
+  };
+}
+
+export function asCapabilityToken(token: unknown): CapabilityToken | undefined {
+  if (!token || typeof token !== 'object') {
+    return undefined;
+  }
+  return token as CapabilityToken;
+}

--- a/runtime/enforcement/index.ts
+++ b/runtime/enforcement/index.ts
@@ -1,0 +1,1 @@
+export { enforceCapabilityAccess, type CapabilityEnforcementResult, type CapabilityRequestContext, type EnforcementMode } from './enforceCapability';


### PR DESCRIPTION
### Motivation
- Introduce active runtime enforcement of capability tokens so sensitive endpoints require valid capability authorization before executing business logic.
- Keep protocol logic pure and unchanged by performing enforcement only in the runtime layer and using existing capability token validation/authorization primitives.
- Support a safe rollout with a configurable soft/strict enforcement mode so missing tokens can be allowed during migration.

### Description
- Add a runtime enforcement helper at `runtime/enforcement/enforceCapability.ts` that extracts a capability token from the `x-aoc-capability` header (JSON or raw) or from payload fields, maps request context to `{ subject_id, requester_id, resource, action: 'execute' }`, calls `authorizeWithCapability(...)`, and builds audit events via existing builders (`CAPABILITY_AUTHORIZED` / `CAPABILITY_DENIED`).
- Integrate enforcement into the hosted server in `runtime/api/server.ts` for sensitive POST endpoints `/data/access` and `/payout/execute` so enforcement runs before route business logic and returns HTTP 403 on deny.
- Wire capability audit persistence into runtime core by adding `capabilityAuditService: InMemoryAuditService` to `DEFAULT_RUNTIME_CORE` and recording enforcement audit events there.
- Add configuration for `ENFORCEMENT_MODE` (`soft` | `strict`, default `soft`) and injectable capability secret (`AOC_CAPABILITY_SECRET` env or `capabilitySecret` server dependency).
- Export enforcement helpers from `runtime/enforcement/index.ts` and include tests in `runtime/__tests__/enforcement.test.ts` covering allowed/denied flows, soft/strict behavior, non-execution of endpoint logic on deny, and audit event recording.

### Testing
- Ran the enforcement unit tests with `npm test -- runtime/__tests__/enforcement.test.ts`, which passed (5 tests).
- Ran existing hosted tests with `npm test -- runtime/__tests__/dataAccessHosted.test.ts runtime/__tests__/payoutHosted.test.ts`, which passed.
- All automated tests executed for these changes succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4c224870832593b9c36a7ff19e0e)