### PR TITLE
Separate Launch App entry flow from public AOC landing

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1,8 +1,10 @@
 import { renderAocLandingPage } from './landing/AocLandingPage';
 import { renderEnterprisePage } from './landing/EnterprisePage';
+import { renderLaunchEntryPage } from './launch/LaunchEntryPage';
 
 function App() {
   if (window.location.pathname === '/enterprise') return renderEnterprisePage();
+  if (window.location.pathname === '/app') return renderLaunchEntryPage();
   return renderAocLandingPage();
 }
 

--- a/frontend/app/src/launch/LaunchEntryPage.tsx
+++ b/frontend/app/src/launch/LaunchEntryPage.tsx
@@ -1,0 +1,36 @@
+import { LogoRotating } from '../components/logo/LogoRotating';
+import { LaunchEntryExperience } from './components/LaunchEntryExperience';
+
+export const renderLaunchEntryPage = () => {
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white overflow-hidden font-sans">
+      <header>
+        <nav className="fixed top-0 left-0 right-0 z-50 bg-black/90 backdrop-blur-lg border-b border-white/10">
+          <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
+            <a href="/" className="flex items-center gap-3">
+              <div className="w-10 h-10 flex items-center justify-center">
+                <LogoRotating size={28} inverted />
+              </div>
+
+              <div className="flex items-baseline">
+                <span className="text-xl font-semibold tracking-tighter">AOC</span>
+                <span className="text-xs text-white uppercase tracking-[0.2em] ml-2">
+                  App Entry
+                </span>
+              </div>
+            </a>
+
+            <a
+              href="/enterprise"
+              className="px-6 py-2.5 border border-white/15 rounded-full text-sm font-semibold hover:border-white/30 transition"
+            >
+              Enterprise
+            </a>
+          </div>
+        </nav>
+      </header>
+
+      <LaunchEntryExperience />
+    </main>
+  );
+};

--- a/frontend/app/src/launch/components/LaunchEntryExperience.tsx
+++ b/frontend/app/src/launch/components/LaunchEntryExperience.tsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from 'react';
+
+type EntryMode = 'user' | 'company';
+
+export function LaunchEntryExperience() {
+  const [mode, setMode] = useState<EntryMode>('user');
+  const [showHowItWorks, setShowHowItWorks] = useState(false);
+
+  const content = useMemo(() => {
+    if (mode === 'company') {
+      return {
+        badge: 'Company entry',
+        title: 'Bring compliant access controls to your organization.',
+        description:
+          'Start a company workspace and configure explicit permissions, audit trails, and integration points for your team.',
+        primaryLabel: 'Launch company workspace',
+        secondaryLabel: 'Book enterprise onboarding',
+        secondaryHref: '/enterprise'
+      };
+    }
+
+    return {
+      badge: 'User entry',
+      title: 'Control your data access in real time.',
+      description:
+        'Enter AOC as a user to review permissions, approve scoped requests, and track every access interaction with full visibility.',
+      primaryLabel: 'Enter user control plane',
+      secondaryLabel: 'Learn about enterprise setup',
+      secondaryHref: '/enterprise'
+    };
+  }, [mode]);
+
+  return (
+    <section className="min-h-screen flex items-center py-24 px-4 sm:px-6">
+      <div className="w-full max-w-xl mx-auto rounded-3xl border border-white/10 bg-white/[0.03] p-5 sm:p-8 shadow-[0_0_0_1px_rgba(255,255,255,0.04),0_28px_100px_rgba(0,0,0,0.45)]">
+        <p className="inline-flex items-center rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-[11px] uppercase tracking-[0.2em] text-cyan-200">
+          Launch App
+        </p>
+
+        <p className="mt-4 text-xs uppercase tracking-[0.2em] text-white/50">{content.badge}</p>
+        <h1 className="mt-3 text-3xl sm:text-4xl font-semibold tracking-tight text-white leading-tight">
+          {content.title}
+        </h1>
+        <p className="mt-4 text-base text-white/70 leading-relaxed">{content.description}</p>
+
+        <div className="mt-6 grid grid-cols-2 rounded-2xl border border-white/10 p-1 bg-black/35">
+          <button
+            type="button"
+            className={`rounded-xl px-4 py-2.5 text-sm font-semibold transition ${
+              mode === 'user'
+                ? 'bg-cyan-300 text-black'
+                : 'text-white/70 hover:text-white hover:bg-white/5'
+            }`}
+            onClick={() => setMode('user')}
+          >
+            User
+          </button>
+          <button
+            type="button"
+            className={`rounded-xl px-4 py-2.5 text-sm font-semibold transition ${
+              mode === 'company'
+                ? 'bg-cyan-300 text-black'
+                : 'text-white/70 hover:text-white hover:bg-white/5'
+            }`}
+            onClick={() => setMode('company')}
+          >
+            Company
+          </button>
+        </div>
+
+        <div className="mt-6 grid gap-3">
+          <a
+            href="/"
+            className="w-full rounded-2xl bg-cyan-300 px-5 py-4 text-center text-base font-semibold text-black transition hover:bg-cyan-200 active:scale-[0.99]"
+          >
+            {content.primaryLabel}
+          </a>
+
+          <a
+            href={content.secondaryHref}
+            className="w-full rounded-2xl border border-white/15 px-5 py-4 text-center text-base font-semibold text-white transition hover:border-white/30 hover:bg-white/[0.03]"
+          >
+            {content.secondaryLabel}
+          </a>
+        </div>
+
+        <div className="mt-6 rounded-2xl border border-white/10 bg-black/30">
+          <button
+            type="button"
+            className="w-full px-4 py-3 text-left text-sm font-medium text-white/80 flex items-center justify-between"
+            onClick={() => setShowHowItWorks((current) => !current)}
+            aria-expanded={showHowItWorks}
+          >
+            <span>How it works</span>
+            <span className="text-cyan-200">{showHowItWorks ? '−' : '+'}</span>
+          </button>
+
+          {showHowItWorks && (
+            <div className="border-t border-white/10 px-4 py-4 text-sm text-white/70 leading-6 space-y-3">
+              <p>
+                1. Choose your entry mode (User or Company) based on who is initiating access.
+              </p>
+              <p>
+                2. Continue into the control plane to define permissions, verify requests, and audit outcomes.
+              </p>
+              <p>
+                3. Launch with explicit controls first, then integrate deeper workflows as needed.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- The public AOC landing hero was unintentionally replaced by an action-first onboarding surface; the public marketing narrative and hero must be restored and preserved as the marketing surface. 
- The action-first, mobile-friendly entry UI should live as a separate product entry (Launch App) screen focused on onboarding and direct system entry without altering the public landing.

### Description
- Restored separation of concerns by keeping the original landing hero and narrative in the public landing component and adding a dedicated page for the app entry flow. 
- Added a new page shell `renderLaunchEntryPage` at `frontend/app/src/launch/LaunchEntryPage.tsx` and a reusable component `LaunchEntryExperience` at `frontend/app/src/launch/components/LaunchEntryExperience.tsx` that implements the action-first mobile entry UI. 
- Wired routing in `frontend/app/src/App.tsx` so `'/app'` returns `renderLaunchEntryPage()` and `'/enterprise'` still returns `renderEnterprisePage()`, while `'/’` continues to render the marketing landing. 
- Kept CTAs and behavior intact by leaving the landing `Launch App` CTA pointing to `href="/app"` so it navigates to the new Launch App entry screen and avoided duplicating logic by extracting the entry experience into a reusable component.

### Testing
- Ran the frontend build via `cd frontend/app && npm run build`, which failed due to missing Vite-related type/module dependencies (`vite/client`, `vite`, `@vitejs/plugin-react`, etc.).
- Attempted `cd frontend/app && npm install`, which failed with an `ENOENT` error referencing `@tailwindcss/oxide-wasm32-wasi` in this environment.
- Files were staged and committed successfully; the code changes are present but full frontend build verification is blocked by missing environment/dependency setup (failures noted above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e565728a788325b6ff1cf6984515e7)