### PR TITLE
Fix mobile vertical card grid balance and sizing

### DIFF
--- a/frontend/app/src/landing/components/AocInfrastructureAnimated.tsx
+++ b/frontend/app/src/landing/components/AocInfrastructureAnimated.tsx
@@ -13,12 +13,17 @@ export function AocInfrastructureAnimated() {
           </p>
         </header>
 
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-5 md:gap-4">
           <VerticalCard title="HR" subtitle="References • Hiring • Reputation" />
           <VerticalCard title="Finance" subtitle="Consented Access • Risk Signals" />
           <VerticalCard title="Health" subtitle="Patient-Controlled Data" />
           <VerticalCard title="Events" subtitle="Tickets • Credentials • Rewards" />
-          <VerticalCard title="AI Agents" subtitle="Scoped Machine Access" active />
+          <VerticalCard
+            title="AI Agents"
+            subtitle="Scoped Machine Access"
+            active
+            className="col-span-2 md:col-span-1"
+          />
         </div>
 
         <div className="relative mt-10">
@@ -244,23 +249,26 @@ function VerticalCard({
   title,
   subtitle,
   active = false,
+  className,
 }: {
   title: string
   subtitle: string
   active?: boolean
+  className?: string
 }) {
   return (
     <div
       className={[
-        'rounded-[20px] border px-5 py-6 transition-all duration-500',
+        'min-h-[104px] rounded-[20px] border px-4 py-4 transition-all duration-500 md:min-h-[132px] md:px-5 md:py-6',
         'bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.015))]',
         active
           ? 'border-cyan-400/45 shadow-[0_0_32px_rgba(0,240,255,0.12)] animate-ai-card-pulse'
           : 'border-white/10',
+        className,
       ].join(' ')}
     >
-      <div className="text-xl font-semibold text-white">{title}</div>
-      <div className="mt-3 text-sm text-white/45">{subtitle}</div>
+      <div className="text-lg font-semibold text-white md:text-xl">{title}</div>
+      <div className="mt-2 text-xs text-white/45 md:mt-3 md:text-sm">{subtitle}</div>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Fix mobile layout where 5 vertical cards produced a broken last row by making the layout intentional on small screens.
- Keep the first four verticals (HR, Finance, Health, Events) in a 2-column grid while making the AI Agents card visually highlighted and full-width on mobile.
- Improve mobile density by reducing padding, min-height, font sizes, and tightening vertical spacing without changing the desktop layout.

### Description
- Adjusted the top grid container from `gap-4` to `gap-3` on mobile while preserving `md:gap-4` for desktop to tighten mobile spacing.
- Made the AI Agents card span both mobile columns by rendering it with `className="col-span-2 md:col-span-1"` so it remains single-column on desktop.
- Extended `VerticalCard` to accept a `className` prop and applied it to the AI Agents instance to control grid-span.
- Reduced mobile card density by changing the card wrapper to `min-h-[104px] px-4 py-4` with `md:` overrides for original sizes and lowered title/subtitle sizes via `text-lg/text-xs` with `md:` fallbacks.

### Testing
- Ran `npm --prefix frontend/app run lint -- --file src/landing/components/AocInfrastructureAnimated.tsx` which failed because the ESLint flat config in this repo does not support the `--file` flag.
- Ran `npm --prefix frontend/app run lint` which failed in this environment due to a missing local dependency (`@eslint/js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5699cc470832587f79a51edad6895)