### PR TITLE
Add minimal User & Enterprise control‑plane dashboards wired to HostedRuntimeClient

### DIFF
--- a/frontend/app/src/hooks/useAccessRequests.ts
+++ b/frontend/app/src/hooks/useAccessRequests.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { AccessRequest } from '../../../../runtime/controlPlane/types';
+import { runtimeClient } from '../lib/runtimeClient';
+
+type UseAccessRequestsInput = {
+  subjectId: string;
+  requesterId?: string;
+  status?: 'pending' | 'approved' | 'denied';
+};
+
+export function useAccessRequests(input: UseAccessRequestsInput) {
+  const [requests, setRequests] = useState<AccessRequest[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await runtimeClient.listAccessRequests({
+        subject_id: input.subjectId,
+        requester_id: input.requesterId,
+        status: input.status,
+      });
+
+      const filtered = input.requesterId === undefined ? data : data.filter((item) => item.requester_id === input.requesterId);
+      setRequests(filtered);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load requests.');
+      setRequests([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [input.requesterId, input.status, input.subjectId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { requests, loading, error, reload: load };
+}

--- a/frontend/app/src/hooks/useGrants.ts
+++ b/frontend/app/src/hooks/useGrants.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { GrantedAccess } from '../../../../runtime/controlPlane/types';
+import { runtimeClient } from '../lib/runtimeClient';
+
+type UseGrantsInput = {
+  subjectId?: string;
+  requesterId?: string;
+};
+
+export function useGrants(input: UseGrantsInput) {
+  const [grants, setGrants] = useState<GrantedAccess[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await runtimeClient.listActiveGrants({
+        subject_id: input.subjectId,
+        requester_id: input.requesterId,
+      });
+      setGrants(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load grants.');
+      setGrants([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [input.requesterId, input.subjectId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { grants, loading, error, reload: load };
+}

--- a/frontend/app/src/lib/runtimeClient.ts
+++ b/frontend/app/src/lib/runtimeClient.ts
@@ -1,0 +1,9 @@
+import { HostedRuntimeClient } from '../../../../runtime/sdk/client';
+
+export const MOCK_SUBJECT_ID = 'subject-1';
+export const MOCK_REQUESTER_ID = 'requester-1';
+
+export const runtimeClient = new HostedRuntimeClient({
+  baseUrl: 'http://localhost:8787',
+  apiKey: 'aoc_free_dev_key',
+});

--- a/frontend/app/src/pages/EnterpriseConsolePage.tsx
+++ b/frontend/app/src/pages/EnterpriseConsolePage.tsx
@@ -1,8 +1,89 @@
+import { useAccessRequests } from '../hooks/useAccessRequests';
+import { useGrants } from '../hooks/useGrants';
+import { MOCK_REQUESTER_ID, MOCK_SUBJECT_ID } from '../lib/runtimeClient';
+
 export function EnterpriseConsolePage() {
+  const { requests, loading: requestsLoading, error: requestsError } = useAccessRequests({
+    subjectId: MOCK_SUBJECT_ID,
+    requesterId: MOCK_REQUESTER_ID,
+  });
+  const { grants, loading: grantsLoading, error: grantsError } = useGrants({
+    requesterId: MOCK_REQUESTER_ID,
+  });
+
   return (
-    <section className="space-y-3">
-      <h1 className="text-2xl font-semibold">Market Maker Console Shell</h1>
-      <p className="text-white/70">P0 foundation route for future enterprise dashboard modules.</p>
+    <section className="space-y-8">
+      <h1 className="text-2xl font-semibold">Enterprise Dashboard</h1>
+
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Requests Sent</h2>
+        {requestsError !== null && <p className="text-red-300 text-sm">{requestsError}</p>}
+        <table className="w-full text-sm border border-white/10">
+          <thead className="text-left bg-white/5">
+            <tr>
+              <th className="p-2">Request</th>
+              <th className="p-2">Subject</th>
+              <th className="p-2">Dataset</th>
+              <th className="p-2">Purpose</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Scope</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!requestsLoading && requests.length === 0 && (
+              <tr>
+                <td className="p-2 text-white/60" colSpan={6}>
+                  No requests found.
+                </td>
+              </tr>
+            )}
+            {requests.map((request) => (
+              <tr key={request.request_id} className="border-t border-white/10">
+                <td className="p-2">{request.request_id}</td>
+                <td className="p-2">{request.subject_id}</td>
+                <td className="p-2">{request.dataset_id}</td>
+                <td className="p-2">{request.purpose}</td>
+                <td className="p-2">{request.status}</td>
+                <td className="p-2">{request.requested_scope.join(', ')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Active Access Inventory</h2>
+        {grantsError !== null && <p className="text-red-300 text-sm">{grantsError}</p>}
+        <table className="w-full text-sm border border-white/10">
+          <thead className="text-left bg-white/5">
+            <tr>
+              <th className="p-2">Grant</th>
+              <th className="p-2">Subject</th>
+              <th className="p-2">Dataset</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Scope</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!grantsLoading && grants.length === 0 && (
+              <tr>
+                <td className="p-2 text-white/60" colSpan={5}>
+                  No active grants found.
+                </td>
+              </tr>
+            )}
+            {grants.map((grant) => (
+              <tr key={grant.grant_id} className="border-t border-white/10">
+                <td className="p-2">{grant.grant_id}</td>
+                <td className="p-2">{grant.subject_id}</td>
+                <td className="p-2">{grant.dataset_id}</td>
+                <td className="p-2">{grant.status}</td>
+                <td className="p-2">{grant.scope.join(', ')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 }

--- a/frontend/app/src/pages/UserConsolePage.tsx
+++ b/frontend/app/src/pages/UserConsolePage.tsx
@@ -1,8 +1,156 @@
+import { useState } from 'react';
+import { useAccessRequests } from '../hooks/useAccessRequests';
+import { useGrants } from '../hooks/useGrants';
+import { MOCK_SUBJECT_ID, runtimeClient } from '../lib/runtimeClient';
+
 export function UserConsolePage() {
+  const { requests, loading: requestsLoading, error: requestsError, reload: reloadRequests } = useAccessRequests({
+    subjectId: MOCK_SUBJECT_ID,
+    status: 'pending',
+  });
+  const { grants, loading: grantsLoading, error: grantsError, reload: reloadGrants } = useGrants({
+    subjectId: MOCK_SUBJECT_ID,
+  });
+
+  const [decisionLoadingId, setDecisionLoadingId] = useState<string | null>(null);
+  const [revokeLoadingId, setRevokeLoadingId] = useState<string | null>(null);
+
+  const decide = async (requestId: string, decision: 'approve' | 'deny') => {
+    setDecisionLoadingId(requestId);
+    try {
+      await runtimeClient.decideAccessRequest({
+        request_id: requestId,
+        subject_id: MOCK_SUBJECT_ID,
+        decision,
+      });
+      await Promise.all([reloadRequests(), reloadGrants()]);
+    } finally {
+      setDecisionLoadingId(null);
+    }
+  };
+
+  const revoke = async (grantId: string) => {
+    setRevokeLoadingId(grantId);
+    try {
+      await runtimeClient.revokeGrant({
+        grant_id: grantId,
+        subject_id: MOCK_SUBJECT_ID,
+      });
+      await reloadGrants();
+    } finally {
+      setRevokeLoadingId(null);
+    }
+  };
+
   return (
-    <section className="space-y-3">
-      <h1 className="text-2xl font-semibold">User Console Shell</h1>
-      <p className="text-white/70">P0 foundation route for future user dashboard modules.</p>
+    <section className="space-y-8">
+      <h1 className="text-2xl font-semibold">User Dashboard</h1>
+
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Requests Inbox</h2>
+        {requestsError !== null && <p className="text-red-300 text-sm">{requestsError}</p>}
+        <table className="w-full text-sm border border-white/10">
+          <thead className="text-left bg-white/5">
+            <tr>
+              <th className="p-2">Request</th>
+              <th className="p-2">Requester</th>
+              <th className="p-2">Dataset</th>
+              <th className="p-2">Purpose</th>
+              <th className="p-2">Scope</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!requestsLoading && requests.length === 0 && (
+              <tr>
+                <td className="p-2 text-white/60" colSpan={6}>
+                  No pending requests.
+                </td>
+              </tr>
+            )}
+            {requests.map((request) => (
+              <tr key={request.request_id} className="border-t border-white/10">
+                <td className="p-2">{request.request_id}</td>
+                <td className="p-2">{request.requester_id}</td>
+                <td className="p-2">{request.dataset_id}</td>
+                <td className="p-2">{request.purpose}</td>
+                <td className="p-2">{request.requested_scope.join(', ')}</td>
+                <td className="p-2">
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      disabled={decisionLoadingId === request.request_id}
+                      className="px-2 py-1 border border-white/25 rounded"
+                      onClick={() => {
+                        void decide(request.request_id, 'approve');
+                      }}
+                    >
+                      Approve
+                    </button>
+                    <button
+                      type="button"
+                      disabled={decisionLoadingId === request.request_id}
+                      className="px-2 py-1 border border-white/25 rounded"
+                      onClick={() => {
+                        void decide(request.request_id, 'deny');
+                      }}
+                    >
+                      Deny
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Active Accesses</h2>
+        {grantsError !== null && <p className="text-red-300 text-sm">{grantsError}</p>}
+        <table className="w-full text-sm border border-white/10">
+          <thead className="text-left bg-white/5">
+            <tr>
+              <th className="p-2">Grant</th>
+              <th className="p-2">Requester</th>
+              <th className="p-2">Dataset</th>
+              <th className="p-2">Scope</th>
+              <th className="p-2">Granted At</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!grantsLoading && grants.length === 0 && (
+              <tr>
+                <td className="p-2 text-white/60" colSpan={6}>
+                  No active grants.
+                </td>
+              </tr>
+            )}
+            {grants.map((grant) => (
+              <tr key={grant.grant_id} className="border-t border-white/10">
+                <td className="p-2">{grant.grant_id}</td>
+                <td className="p-2">{grant.requester_id}</td>
+                <td className="p-2">{grant.dataset_id}</td>
+                <td className="p-2">{grant.scope.join(', ')}</td>
+                <td className="p-2">{grant.granted_at}</td>
+                <td className="p-2">
+                  <button
+                    type="button"
+                    disabled={revokeLoadingId === grant.grant_id}
+                    className="px-2 py-1 border border-white/25 rounded"
+                    onClick={() => {
+                      void revoke(grant.grant_id);
+                    }}
+                  >
+                    Revoke
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 }

--- a/runtime/sdk/client.ts
+++ b/runtime/sdk/client.ts
@@ -61,7 +61,11 @@ export interface HostedRuntimeSdk {
   listAuditEvents(input?: ListAuditEventsInput): Promise<RuntimeAuditEvent[]>;
   getUsageSummary(input: GetUsageSummaryInput): Promise<UsageSummaryResult>;
   createAccessRequest(input: CreateAccessRequestInput): Promise<AccessRequest>;
-  listAccessRequests(input: { subject_id: string; status?: 'pending' | 'approved' | 'denied' }): Promise<AccessRequest[]>;
+  listAccessRequests(input: {
+    subject_id: string;
+    requester_id?: string;
+    status?: 'pending' | 'approved' | 'denied';
+  }): Promise<AccessRequest[]>;
   decideAccessRequest(input: {
     request_id: string;
     subject_id: string;
@@ -211,7 +215,11 @@ export class HostedRuntimeClient implements HostedRuntimeSdk {
     return this.post('/access/request', input);
   }
 
-  async listAccessRequests(input: { subject_id: string; status?: 'pending' | 'approved' | 'denied' }): Promise<AccessRequest[]> {
+  async listAccessRequests(input: {
+    subject_id: string;
+    requester_id?: string;
+    status?: 'pending' | 'approved' | 'denied';
+  }): Promise<AccessRequest[]> {
     if (this.mode === 'local') {
       throw new Error('Control-plane access request endpoints are only available in hosted mode.');
     }


### PR DESCRIPTION
### Motivation
- Provide a first real UI layer for the AOC control plane using the existing P0 foundation without changing routing, auth, or backend structures.
- Wire simple user and enterprise console views to existing control-plane APIs so requests/grants can be inspected and acted on end-to-end.

### Description
- Implemented a minimal User dashboard in `frontend/app/src/pages/UserConsolePage.tsx` with a Requests Inbox (loads `listAccessRequests`, supports `Approve`/`Deny` via `decideAccessRequest`) and Active Accesses (loads `listActiveGrants`, supports `Revoke` via `revokeGrant`).
- Implemented a minimal Enterprise dashboard in `frontend/app/src/pages/EnterpriseConsolePage.tsx` showing Requests Sent (via `listAccessRequests`) and Active Access Inventory (via `listActiveGrants`).
- Added lightweight hooks `useAccessRequests` and `useGrants` in `frontend/app/src/hooks/` to encapsulate loading/error state and `reload` behavior for both dashboards.
- Added `frontend/app/src/lib/runtimeClient.ts` that instantiates the existing `HostedRuntimeClient` and exports hardcoded mock IDs (`subject-1`, `requester-1`) for the UI; also extended `HostedRuntimeClient.listAccessRequests` typing to accept an optional `requester_id` to support frontend filtering without backend changes.

### Testing
- Ran the project test runner with `npm test -- --runInBand`, which produced mostly green results but the run failed overall because `runtime/__tests__/helpers/serverLifecycle.ts` contains no tests and caused a suite error (44 suites passed, 1 failed). 
- Executed the focused control-plane lifecycle test with `npx jest runtime/__tests__/controlPlaneHosted.test.ts --runInBand`, and it passed, validating create→approve→list grants→revoke flows against the hosted runtime.
- Attempted to verify the frontend build with `npm run build` inside `frontend/app`, but dependency installation failed in this environment (`@tailwindcss/oxide-wasm32-wasi` missing), so the UI build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6454a5fa8832580cd69cc15938af3)