### PR TITLE
Add Phase 2.3 capability delegation layer domain scaffolding

### DIFF
--- a/docs/capability_delegation_layer_phase2_3.md
+++ b/docs/capability_delegation_layer_phase2_3.md
@@ -1,0 +1,46 @@
+# Phase 2.3 — Capability Delegation Layer (Infrastructure Spec)
+
+This module defines programmable relationship governance through delegated capabilities, built as trust infrastructure rather than CRM/IAM abstractions.
+
+## Module Surfaces
+
+1. **Capability Delegation Console**
+   - Projection source: `toDelegationConsoleRows`.
+   - Visual chain: `Entity -> Capability Token -> Organization/AI Agent -> Scoped Access`.
+   - Includes expiration window, revocability, trust state, and inherited scopes.
+
+2. **Active Capability Tokens Panel**
+   - Source: `capabilityTokens`.
+   - Required runtime statuses covered: `active`, `expiring`, `suspended`, `revoked`.
+   - Includes trust verification and signed runtime verification flags.
+
+3. **Scoped Access Visualization**
+   - Source: `CapabilityScope` fields.
+   - Captures `scope key`, `inheritedFrom`, `restrictions`, and `minimizationRule`.
+   - Supports policy-bounded access disclosure in UI.
+
+4. **AI Agent Governance Panel**
+   - Projection source: `toAgentGovernanceSignals`.
+   - Signals: delegated capabilities, trust state, autonomous revocation flags, policy drift detection, attestation result.
+
+5. **Capability Timeline**
+   - Source: `capabilityTimeline`.
+   - Lifecycle events modeled: issued, delegated, consumed, renewed, restricted, expired, revoked.
+
+6. **Relationship Governance Graph**
+   - Sources: `governanceGraphNodes`, `governanceGraphEdges`.
+   - Graph narrative: User ↔ Relationship ↔ Capability ↔ Organization ↔ AI Agent ↔ Policy Runtime.
+
+## Extensibility Hooks
+
+- Marketplace connector insertion point:
+  - capability recipient expansion (`delegatedTo`) to partner runtimes.
+  - graph edge relationship extension (e.g. `brokers`, `resells`, `subdelegates`).
+- Policy engines can attach attestation proofs to capability lifecycle events.
+- Delegation constraints can be bound to jurisdictional and model-risk policies.
+
+## Implementation Notes
+
+- Interfaces are typed for reuse in Next.js App Router UI components.
+- Runtime data is mock-safe for design and UX integration.
+- Projection functions isolate view-model shaping from backend state.

--- a/protocol/capability-delegation/__tests__/capabilityDelegationLayer.test.ts
+++ b/protocol/capability-delegation/__tests__/capabilityDelegationLayer.test.ts
@@ -1,0 +1,26 @@
+import { capabilityTokens } from '../mockRuntimeData';
+import { toAgentGovernanceSignals, toDelegationConsoleRows } from '../projections';
+
+describe('capability delegation layer projections', () => {
+  it('builds delegation console rows with scoped access', () => {
+    const rows = toDelegationConsoleRows(capabilityTokens);
+    expect(rows[0]).toMatchObject({
+      capabilityId: 'cap_01_fcast_runtime',
+      scopedAccess: ['ai.forecasting.runtime', 'read:behavioral_segments'],
+      revocable: true
+    });
+  });
+
+  it('builds AI governance signals by delegated agent', () => {
+    const signals = toAgentGovernanceSignals(capabilityTokens);
+    expect(signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agentId: 'agt_01',
+          delegatedCapabilities: 1,
+          runtimeAttestation: 'passed'
+        })
+      ])
+    );
+  });
+});

--- a/protocol/capability-delegation/index.ts
+++ b/protocol/capability-delegation/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './mockRuntimeData';
+export * from './projections';

--- a/protocol/capability-delegation/mockRuntimeData.ts
+++ b/protocol/capability-delegation/mockRuntimeData.ts
@@ -1,0 +1,65 @@
+import type { CapabilityTimelineEvent, CapabilityToken, GovernanceGraphEdge, GovernanceGraphNode, RelationshipEntity } from './types';
+
+export const entities: RelationshipEntity[] = [
+  { id: 'usr_01', displayName: 'Northstar Retail User Cohort', entityType: 'user' },
+  { id: 'org_01', displayName: 'Analytics Partner', entityType: 'organization' },
+  { id: 'agt_01', displayName: 'Forecast Agent v2.4', entityType: 'ai_agent' },
+  { id: 'agt_02', displayName: 'Support Diagnostics Agent', entityType: 'ai_agent' },
+  { id: 'rt_01', displayName: 'Compliance Runtime', entityType: 'runtime' }
+];
+
+export const capabilityTokens: CapabilityToken[] = [
+  {
+    capabilityId: 'cap_01_fcast_runtime',
+    delegatedBy: 'usr_01',
+    delegatedTo: 'agt_01',
+    runtimeStatus: 'active',
+    trustState: 'verified',
+    signedRuntimeVerification: true,
+    autonomousRevocationEnabled: true,
+    window: { issuedAt: '2026-05-01T09:00:00Z', effectiveAt: '2026-05-01T09:01:00Z', expiresAt: '2026-06-01T09:00:00Z' },
+    scopes: [
+      { id: 'scp_01', key: 'ai.forecasting.runtime', description: 'Forecasting signal execution', restrictions: ['no_export', 'region:us'], minimizationRule: 'aggregate_only' },
+      { id: 'scp_02', key: 'read:behavioral_segments', description: 'Segment reads only', inheritedFrom: 'scp_01', restrictions: ['mask_pii'], minimizationRule: 'minimum_columns' }
+    ]
+  },
+  {
+    capabilityId: 'cap_02_support_diag',
+    delegatedBy: 'usr_01',
+    delegatedTo: 'agt_02',
+    runtimeStatus: 'expiring',
+    trustState: 'attested',
+    signedRuntimeVerification: true,
+    autonomousRevocationEnabled: true,
+    window: { issuedAt: '2026-04-28T10:30:00Z', effectiveAt: '2026-04-28T10:31:00Z', expiresAt: '2026-05-08T10:30:00Z' },
+    scopes: [
+      { id: 'scp_03', key: 'support.diagnostics', description: 'Diagnostic decision traces', restrictions: ['case_scoped', '72h_retention'], minimizationRule: 'ticket_bound' }
+    ]
+  }
+];
+
+export const capabilityTimeline: CapabilityTimelineEvent[] = [
+  { id: 'evt_01', capabilityId: 'cap_01_fcast_runtime', eventType: 'issued', timestamp: '2026-05-01T09:00:00Z', actorId: 'rt_01', details: 'Capability issued from policy runtime.' },
+  { id: 'evt_02', capabilityId: 'cap_01_fcast_runtime', eventType: 'delegated', timestamp: '2026-05-01T09:01:00Z', actorId: 'usr_01', details: 'Delegated to Forecast Agent v2.4.' },
+  { id: 'evt_03', capabilityId: 'cap_01_fcast_runtime', eventType: 'consumed', timestamp: '2026-05-03T13:22:00Z', actorId: 'agt_01', details: 'Scope executed within regional boundary.' },
+  { id: 'evt_04', capabilityId: 'cap_02_support_diag', eventType: 'restricted', timestamp: '2026-05-05T08:10:00Z', actorId: 'rt_01', details: 'Diagnostics scope narrowed after drift signal.' },
+  { id: 'evt_05', capabilityId: 'cap_02_support_diag', eventType: 'renewed', timestamp: '2026-05-06T07:15:00Z', actorId: 'usr_01', details: 'Temporal extension approved with attestation.' }
+];
+
+export const governanceGraphNodes: GovernanceGraphNode[] = [
+  { id: 'usr_01', label: 'User', kind: 'user' },
+  { id: 'rel_01', label: 'Relationship', kind: 'relationship' },
+  { id: 'cap_01_fcast_runtime', label: 'Capability', kind: 'capability' },
+  { id: 'org_01', label: 'Organization', kind: 'organization' },
+  { id: 'agt_01', label: 'AI Agent', kind: 'ai_agent' },
+  { id: 'rt_01', label: 'Policy Runtime', kind: 'policy_runtime' }
+];
+
+export const governanceGraphEdges: GovernanceGraphEdge[] = [
+  { id: 'edge_1', from: 'usr_01', to: 'rel_01', relationship: 'governs' },
+  { id: 'edge_2', from: 'rel_01', to: 'cap_01_fcast_runtime', relationship: 'delegates' },
+  { id: 'edge_3', from: 'cap_01_fcast_runtime', to: 'org_01', relationship: 'inherits' },
+  { id: 'edge_4', from: 'org_01', to: 'agt_01', relationship: 'delegates' },
+  { id: 'edge_5', from: 'agt_01', to: 'rt_01', relationship: 'attests' },
+  { id: 'edge_6', from: 'rt_01', to: 'cap_01_fcast_runtime', relationship: 'enforces' }
+];

--- a/protocol/capability-delegation/projections.ts
+++ b/protocol/capability-delegation/projections.ts
@@ -1,0 +1,52 @@
+import type { CapabilityToken } from './types';
+
+export interface DelegationConsoleRow {
+  actor: string;
+  capabilityId: string;
+  receiver: string;
+  scopedAccess: string[];
+  expiresAt: string;
+  revocable: boolean;
+  runtimeTrust: string;
+}
+
+export interface AgentGovernanceSignal {
+  agentId: string;
+  delegatedCapabilities: number;
+  trustState: string;
+  signedRuntimeVerification: boolean;
+  autonomousRevocations: boolean;
+  policyDriftDetected: boolean;
+  runtimeAttestation: 'passed' | 'warning';
+}
+
+export const toDelegationConsoleRows = (tokens: CapabilityToken[]): DelegationConsoleRow[] =>
+  tokens.map((token) => ({
+    actor: token.delegatedBy,
+    capabilityId: token.capabilityId,
+    receiver: token.delegatedTo,
+    scopedAccess: token.scopes.map((scope) => scope.key),
+    expiresAt: token.window.expiresAt,
+    revocable: token.runtimeStatus !== 'revoked',
+    runtimeTrust: token.trustState
+  }));
+
+export const toAgentGovernanceSignals = (tokens: CapabilityToken[]): AgentGovernanceSignal[] => {
+  const byAgent = new Map<string, CapabilityToken[]>();
+
+  tokens.forEach((token) => {
+    const next = byAgent.get(token.delegatedTo) ?? [];
+    next.push(token);
+    byAgent.set(token.delegatedTo, next);
+  });
+
+  return Array.from(byAgent.entries()).map(([agentId, delegated]) => ({
+    agentId,
+    delegatedCapabilities: delegated.length,
+    trustState: delegated.some((capability) => capability.trustState === 'degraded') ? 'degraded' : 'trusted',
+    signedRuntimeVerification: delegated.every((capability) => capability.signedRuntimeVerification),
+    autonomousRevocations: delegated.some((capability) => capability.autonomousRevocationEnabled),
+    policyDriftDetected: delegated.some((capability) => capability.runtimeStatus === 'suspended'),
+    runtimeAttestation: delegated.every((capability) => capability.trustState === 'verified' || capability.trustState === 'attested') ? 'passed' : 'warning'
+  }));
+};

--- a/protocol/capability-delegation/types.ts
+++ b/protocol/capability-delegation/types.ts
@@ -1,0 +1,57 @@
+export type RuntimeStatus = 'active' | 'expiring' | 'suspended' | 'revoked';
+export type TrustState = 'verified' | 'attested' | 'degraded' | 'unverified';
+
+export interface RelationshipEntity {
+  id: string;
+  displayName: string;
+  entityType: 'user' | 'organization' | 'ai_agent' | 'runtime';
+}
+
+export interface CapabilityScope {
+  id: string;
+  key: string;
+  description: string;
+  inheritedFrom?: string;
+  restrictions: string[];
+  minimizationRule: string;
+}
+
+export interface DelegationWindow {
+  issuedAt: string;
+  effectiveAt: string;
+  expiresAt: string;
+}
+
+export interface CapabilityToken {
+  capabilityId: string;
+  delegatedBy: string;
+  delegatedTo: string;
+  runtimeStatus: RuntimeStatus;
+  trustState: TrustState;
+  signedRuntimeVerification: boolean;
+  autonomousRevocationEnabled: boolean;
+  window: DelegationWindow;
+  scopes: CapabilityScope[];
+}
+
+export interface CapabilityTimelineEvent {
+  id: string;
+  capabilityId: string;
+  eventType: 'issued' | 'delegated' | 'consumed' | 'renewed' | 'restricted' | 'expired' | 'revoked';
+  timestamp: string;
+  actorId: string;
+  details: string;
+}
+
+export interface GovernanceGraphNode {
+  id: string;
+  label: string;
+  kind: 'user' | 'relationship' | 'capability' | 'organization' | 'ai_agent' | 'policy_runtime';
+}
+
+export interface GovernanceGraphEdge {
+  id: string;
+  from: string;
+  to: string;
+  relationship: 'governs' | 'delegates' | 'inherits' | 'attests' | 'enforces';
+}


### PR DESCRIPTION
### Motivation

- Provide typed, backend-agnostic domain primitives to represent delegated capabilities, scopes, timelines, and governance graphs so the frontend can render programmable relationship governance without coupling to runtime services. 
- Create projection utilities and mock runtime fixtures to power a future Next.js/shadcn UI (console, tokens panel, scoped visualizations, agent governance, timeline, and graph) while keeping view-model shaping isolated from backend state.

### Description

- Added a new module at `protocol/capability-delegation` containing `types.ts` (domain interfaces), `mockRuntimeData.ts` (representative fixtures), `projections.ts` (view-model builders), and `index.ts` (exports). 
- Implemented two projection functions: `toDelegationConsoleRows` to shape delegation console rows and `toAgentGovernanceSignals` to aggregate per-agent governance signals. 
- Added unit tests in `protocol/capability-delegation/__tests__/capabilityDelegationLayer.test.ts` verifying projection behavior and created a spec doc at `docs/capability_delegation_layer_phase2_3.md` describing module surfaces and extensibility hooks. 
- Kept the change limited to domain/projection/model scaffolding so UI components, tenant normalization, and production attestation plumbing remain for follow-up work. 

### Testing

- Ran `npm test -- --runInBand` where the new `protocol/capability-delegation` tests passed and the overall repo test run reported `45 passed, 1 failed, 46 total`; the single failing suite is a pre-existing issue (`runtime/__tests__/helpers/serverLifecycle.ts`) that contains no tests. 
- Ran `npx tsc --noEmit` which failed due to pre-existing repository frontend/JSX and type dependency configuration issues unrelated to the new domain code. 
- Attempted `npm run build` which failed because no `build` script is defined in the repository `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7a6418a8832595f8da7b48073cc9)