### PR TITLE
Add Phase 2.4 visual capability runtime UI architecture scaffold

### DIFF
--- a/aoc/runtime-ui/README.md
+++ b/aoc/runtime-ui/README.md
@@ -1,0 +1,45 @@
+# Phase 2.4 Visual Capability Runtime UI
+
+This module provides a reusable, typed runtime UI architecture for the AOC capability delegation domain.
+
+## Included building blocks
+
+- **Live Capability Runtime Panel** data model via `CapabilityRuntimeCard`
+- **Capability Flow Visualizer** graph model via `GovernanceNode` / `GovernanceEdge`
+- **Capability Lifecycle Replay** controls via `replayLifecycle(...)`
+- **AI Agent Runtime Console** model via `RuntimeAgent`
+- **Relationship Governance Graph** mock topology via `mockGraph`
+- **Trust State Engine** via `deriveTrustPropagation(...)`
+- **Runtime Event Stream** model via `RuntimeEvent`
+
+## Integration approach (Next.js + shadcn/ui + Framer Motion)
+
+1. Keep `types.ts` as runtime contract between backend adapters and React components.
+2. Replace `mockRuntimeAdapter.ts` with websocket/SSE adapters while preserving stable interfaces.
+3. Bind motion primitives to fields:
+   - `activityLevel` -> card pulse speed
+   - `trustHealth` -> trust badge transition color
+   - `policyDriftAlerts` -> subtle warning shimmer
+4. Use virtualization for event stream and graph layers for enterprise scale.
+
+## Future scalability hooks
+
+- Event fanout: shard by `relationshipId` and `capabilityId`.
+- Graph layering: render static edges in canvas, interactive nodes in DOM.
+- Runtime policy interception: side-channel updates to prevent UI lockstep lag.
+
+## Suggested websocket architecture
+
+- `ws://runtime/capabilities`: capability card deltas
+- `ws://runtime/events`: append-only event stream
+- `ws://runtime/trust`: trust-state recalculations
+- `ws://runtime/graph`: graph mutation events
+- Use sequence IDs + optimistic interpolation to avoid out-of-order trust transitions.
+
+## Suggested marketplace runtime connectors
+
+- CRM connector (read-only relationship metadata import)
+- Support platform connector (ticket context capabilities)
+- Data warehouse connector (attestation + audit mirror)
+- AI provider connector (agent run attestations + policy traces)
+- Policy engine connector (OPA/Cedar decision traces)

--- a/aoc/runtime-ui/index.ts
+++ b/aoc/runtime-ui/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './runtimeEngines';
+export * from './mockRuntimeAdapter';

--- a/aoc/runtime-ui/mockRuntimeAdapter.ts
+++ b/aoc/runtime-ui/mockRuntimeAdapter.ts
@@ -1,0 +1,106 @@
+import {
+  CapabilityRuntimeCard,
+  GovernanceEdge,
+  GovernanceNode,
+  LifecycleEvent,
+  RuntimeAgent,
+  RuntimeEvent,
+} from './types';
+
+const now = Date.now();
+
+export const mockCapabilityCards: CapabilityRuntimeCard[] = [
+  {
+    capabilityId: 'cap_forecast_2_4_read_01',
+    delegatedBy: 'Maya Chen',
+    delegatedTo: 'Forecast Agent v2.4',
+    activeScopes: ['orders:read', 'inventory:trend:read'],
+    expiresAt: new Date(now + 1000 * 60 * 42).toISOString(),
+    runtimeVerification: 'passing',
+    trustHealth: 'verified',
+    revocationReadiness: 'ready',
+    activityLevel: 'active',
+    attestationState: 'attested',
+  },
+  {
+    capabilityId: 'cap_support_diag_01',
+    delegatedBy: 'Rafael Singh',
+    delegatedTo: 'Support Diagnostics Agent',
+    activeScopes: ['tickets:read', 'diagnostics:run:bounded'],
+    expiresAt: new Date(now + 1000 * 60 * 12).toISOString(),
+    runtimeVerification: 'warning',
+    trustHealth: 'degraded',
+    revocationReadiness: 'monitoring',
+    activityLevel: 'burst',
+    attestationState: 'pending',
+  },
+];
+
+export const mockRuntimeEvents: RuntimeEvent[] = [
+  {
+    id: 'evt_101',
+    timestamp: new Date(now - 1000 * 30).toISOString(),
+    type: 'scope_minimized',
+    capabilityId: 'cap_support_diag_01',
+    relationshipId: 'rel_customer_success_09',
+    trustState: 'attested',
+    summary: 'Policy runtime reduced diagnostic scope after anomaly.',
+  },
+  {
+    id: 'evt_102',
+    timestamp: new Date(now - 1000 * 12).toISOString(),
+    type: 'drift_detected',
+    capabilityId: 'cap_support_diag_01',
+    relationshipId: 'rel_customer_success_09',
+    trustState: 'degraded',
+    summary: 'Behavioral baseline drift detected for Support Diagnostics Agent.',
+  },
+];
+
+export const mockRuntimeAgents: RuntimeAgent[] = [
+  {
+    id: 'agt_forecast_24',
+    name: 'Forecast Agent v2.4',
+    delegatedCapabilities: ['cap_forecast_2_4_read_01'],
+    trustStatus: 'verified',
+    attestationProof: 'attest://proof/9f1',
+    policyDriftAlerts: 0,
+    autonomousRevocations: 1,
+    boundedScopes: ['orders:read', 'inventory:trend:read'],
+    minimizationEnforcement: 'strict',
+  },
+  {
+    id: 'agt_compliance_runtime',
+    name: 'Compliance Runtime',
+    delegatedCapabilities: ['cap_compliance_03'],
+    trustStatus: 'attested',
+    attestationProof: 'attest://proof/a33',
+    policyDriftAlerts: 1,
+    autonomousRevocations: 0,
+    boundedScopes: ['policy:validate', 'consent:lifecycle:read'],
+    minimizationEnforcement: 'adaptive',
+  },
+];
+
+export const mockGraph = {
+  nodes: [
+    { id: 'u1', label: 'User: Maya Chen', type: 'user', trustState: 'verified' },
+    { id: 'r1', label: 'Relationship: Retail Ops', type: 'relationship', trustState: 'attested' },
+    { id: 'c1', label: 'Capability: cap_forecast_2_4_read_01', type: 'capability', trustState: 'verified' },
+    { id: 'a1', label: 'AI: Forecast Agent v2.4', type: 'ai_agent', trustState: 'verified' },
+    { id: 'p1', label: 'Policy Runtime', type: 'policy_runtime', trustState: 'attested' },
+  ] as GovernanceNode[],
+  edges: [
+    { id: 'e1', from: 'u1', to: 'c1', relation: 'delegates', scope: ['orders:read'] },
+    { id: 'e2', from: 'c1', to: 'a1', relation: 'governs', scope: ['inventory:trend:read'] },
+    { id: 'e3', from: 'p1', to: 'a1', relation: 'enforces' },
+    { id: 'e4', from: 'r1', to: 'p1', relation: 'attests' },
+  ] as GovernanceEdge[],
+};
+
+export const mockLifecycle: LifecycleEvent[] = [
+  { id: 'l1', capabilityId: 'cap_forecast_2_4_read_01', type: 'issued', at: new Date(now - 1000 * 3600).toISOString(), trustSnapshot: 'verified', metadata: { issuer: 'Maya Chen' } },
+  { id: 'l2', capabilityId: 'cap_forecast_2_4_read_01', type: 'delegated', at: new Date(now - 1000 * 2400).toISOString(), trustSnapshot: 'attested', metadata: { to: 'Forecast Agent v2.4' } },
+  { id: 'l3', capabilityId: 'cap_forecast_2_4_read_01', type: 'consumed', at: new Date(now - 1000 * 1200).toISOString(), trustSnapshot: 'verified', metadata: { policyGate: 'allow' } },
+  { id: 'l4', capabilityId: 'cap_forecast_2_4_read_01', type: 'renewed', at: new Date(now - 1000 * 600).toISOString(), trustSnapshot: 'verified', metadata: { ttlMinutes: 60 } },
+];

--- a/aoc/runtime-ui/runtimeEngines.ts
+++ b/aoc/runtime-ui/runtimeEngines.ts
@@ -1,0 +1,33 @@
+import { LifecycleEvent, RuntimeEvent, TrustState } from './types';
+
+export const trustStateRank: Record<TrustState, number> = {
+  unverified: 0,
+  degraded: 1,
+  attested: 2,
+  verified: 3,
+};
+
+export function deriveTrustPropagation(events: RuntimeEvent[]): TrustState {
+  return events.reduce<TrustState>((state, event) => {
+    return trustStateRank[event.trustState] < trustStateRank[state] ? event.trustState : state;
+  }, 'verified');
+}
+
+export function replayLifecycle(
+  events: LifecycleEvent[],
+  progress: number,
+): { visibleEvents: LifecycleEvent[]; currentTrust: TrustState } {
+  const bounded = Math.max(0, Math.min(progress, 1));
+  const count = Math.max(1, Math.ceil(events.length * bounded));
+  const visibleEvents = events.slice(0, count);
+  const currentTrust = visibleEvents[visibleEvents.length - 1]?.trustSnapshot ?? 'unverified';
+  return { visibleEvents, currentTrust };
+}
+
+export function formatCountdown(expiresAtIso: string, nowMs = Date.now()): string {
+  const remainingMs = new Date(expiresAtIso).getTime() - nowMs;
+  if (remainingMs <= 0) return 'expired';
+  const minutes = Math.floor(remainingMs / 60000);
+  const seconds = Math.floor((remainingMs % 60000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}

--- a/aoc/runtime-ui/types.ts
+++ b/aoc/runtime-ui/types.ts
@@ -1,0 +1,76 @@
+export type TrustState = 'verified' | 'attested' | 'degraded' | 'unverified';
+
+export type LifecycleEventType =
+  | 'issued'
+  | 'delegated'
+  | 'consumed'
+  | 'renewed'
+  | 'restricted'
+  | 'expired'
+  | 'revoked';
+
+export interface CapabilityRuntimeCard {
+  capabilityId: string;
+  delegatedBy: string;
+  delegatedTo: string;
+  activeScopes: string[];
+  expiresAt: string;
+  runtimeVerification: 'passing' | 'warning' | 'failing';
+  trustHealth: TrustState;
+  revocationReadiness: 'ready' | 'monitoring' | 'blocked';
+  activityLevel: 'idle' | 'active' | 'burst';
+  attestationState: 'pending' | 'attested' | 'expired';
+}
+
+export interface RuntimeEvent {
+  id: string;
+  timestamp: string;
+  type:
+    | 'scope_minimized'
+    | 'runtime_attested'
+    | 'capability_consumed'
+    | 'drift_detected'
+    | 'revocation_triggered'
+    | 'access_denied'
+    | 'policy_updated';
+  capabilityId: string;
+  relationshipId: string;
+  trustState: TrustState;
+  summary: string;
+}
+
+export interface RuntimeAgent {
+  id: string;
+  name: string;
+  delegatedCapabilities: string[];
+  trustStatus: TrustState;
+  attestationProof: string;
+  policyDriftAlerts: number;
+  autonomousRevocations: number;
+  boundedScopes: string[];
+  minimizationEnforcement: 'strict' | 'adaptive';
+}
+
+export interface GovernanceNode {
+  id: string;
+  label: string;
+  type: 'user' | 'relationship' | 'capability' | 'organization' | 'ai_agent' | 'policy_runtime';
+  trustState: TrustState;
+}
+
+export interface GovernanceEdge {
+  id: string;
+  from: string;
+  to: string;
+  relation: 'governs' | 'delegates' | 'attests' | 'inherits' | 'enforces';
+  scope?: string[];
+}
+
+export interface LifecycleEvent {
+  id: string;
+  capabilityId: string;
+  type: LifecycleEventType;
+  at: string;
+  trustSnapshot: TrustState;
+  metadata: Record<string, string | number | boolean>;
+}


### PR DESCRIPTION
### Motivation
- Provide reusable, framework-agnostic runtime contracts and mock adapters to accelerate the Phase 2.4 Visual Capability Runtime UI implementation. 
- Surface basic trust/lifecycle primitives and runtime events so a Next.js + shadcn + Framer Motion UI can be built against stable, typed interfaces.

### Description
- Added `aoc/runtime-ui/types.ts` with typed contracts for capability cards, trust states, runtime events, agents, governance graph nodes/edges, and lifecycle events. 
- Added `aoc/runtime-ui/mockRuntimeAdapter.ts` that supplies representative capability cards, event stream entries, AI agent state, governance graph topology, and lifecycle snapshots for UI prototyping. 
- Added `aoc/runtime-ui/runtimeEngines.ts` with utility engines for trust propagation (`deriveTrustPropagation`), lifecycle replay (`replayLifecycle`), and expiration countdown formatting (`formatCountdown`). 
- Added `aoc/runtime-ui/README.md` with integration notes, websocket channel suggestions, and scalability guidance, and exported the module via `aoc/runtime-ui/index.ts`.

### Testing
- Ran `npm run test -- --runInBand`, which executed the repo test suites and reported most suites passing but one failing suite (`runtime/__tests__/helpers/serverLifecycle.ts`) due to an empty test file (summary: 46 suites, 45 passed, 1 failed). 
- Ran `npx tsc --noEmit`, which failed with pre-existing frontend/JSX and workspace TypeScript configuration errors unrelated to the new `aoc/runtime-ui` module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7d79745083258450d370516ceb5c)