### PR TITLE
feat(frontend): add AOC Runtime OS interactive enterprise experience

### DIFF
--- a/frontend/app/src/landing/EnterprisePage.tsx
+++ b/frontend/app/src/landing/EnterprisePage.tsx
@@ -1,225 +1,37 @@
-import { AocInfrastructureAnimated } from "./components/AocInfrastructureAnimated";
 import { LogoRotating } from '../components/logo/LogoRotating';
+import { AocRuntimeOS } from './components/AocRuntimeOS';
 
 export const renderEnterprisePage = () => {
   return (
-    <main className="min-h-screen bg-[#0a0a0a] text-white overflow-hidden font-sans">
-      <header>
-        <nav className="fixed top-0 left-0 right-0 z-50 bg-black/90 backdrop-blur-lg border-b border-white/10">
-          <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <a href="/" className="flex items-center gap-3">
-              <div className="w-10 h-10 flex items-center justify-center">
-                <LogoRotating size={28} inverted />
-              </div>
-              <div className="flex items-baseline">
-                <span className="text-xl font-semibold tracking-tighter">AOC</span>
-                <span className="text-xs text-white uppercase tracking-[0.2em] ml-2">
-                  Enterprise
-                </span>
-              </div>
-            </a>
-
-            <div className="hidden md:flex items-center gap-10 text-sm font-medium">
-              <a href="#problem" className="hover:text-white transition">Problem</a>
-              <a href="#solution" className="hover:text-white transition">Solution</a>
-              <a href="#integration" className="hover:text-white transition">Integration</a>
-            </div>
-
-            <a
-              href="mailto:hello@aocprotocol.xyz?subject=AOC%20Enterprise%20Inquiry"
-              className="px-6 py-2.5 bg-[#00f0ff] text-black rounded-full text-sm font-semibold hover:bg-[#00d4e0] transition"
-            >
-              Talk to us
-            </a>
-          </div>
-        </nav>
-      </header>
-
-      <section className="min-h-screen flex items-center pt-16">
-        <div className="max-w-6xl mx-auto px-6 text-center">
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-cyan-400/20 bg-cyan-400/5 text-cyan-300 text-xs tracking-[0.22em] uppercase mb-8">
-            Compliance infrastructure for modern data systems
-          </div>
-
-          <h1 className="text-[56px] md:text-[78px] leading-[1.04] font-semibold tracking-[-3px] mb-6">
-            Make data access
-            <br />
-            provably compliant.
-          </h1>
-
-          <p className="max-w-3xl mx-auto text-lg md:text-2xl text-white/70 leading-relaxed mb-10">
-            AOC gives enterprises a control layer for consent, permissions, and auditability —
-            so every data interaction is explicit, enforceable, and verifiable.
-          </p>
-
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href="mailto:hello@aocprotocol.xyz?subject=Request%20AOC%20Enterprise%20Demo"
-              className="px-10 py-4 bg-[#00f0ff] hover:bg-[#00d4e0] text-black font-semibold rounded-2xl transition"
-            >
-              Request a demo
-            </a>
-            <a
-              href="#solution"
-              className="px-10 py-4 border border-white/15 hover:border-white/30 text-white rounded-2xl transition"
-            >
-              See how it works
-            </a>
-          </div>
+    <main className="min-h-screen bg-[#090b11] text-white font-sans">
+      <nav className="sticky top-0 z-30 backdrop-blur bg-black/70 border-b border-white/10">
+        <div className="max-w-7xl mx-auto h-16 px-6 flex items-center justify-between">
+          <a href="/" className="flex items-center gap-3"><LogoRotating size={28} inverted /><span className="font-semibold tracking-tight">AOC Runtime OS</span></a>
+          <a className="px-4 py-2 rounded-xl bg-cyan-300 text-black text-sm font-semibold" href="mailto:hello@aocprotocol.xyz?subject=AOC%20Runtime%20OS">Book runtime walkthrough</a>
         </div>
+      </nav>
+
+      <section className="max-w-7xl mx-auto px-6 pt-16 pb-10">
+        <p className="text-cyan-300 text-xs uppercase tracking-[0.23em] mb-5">Phase 2.5 — Interactive Runtime Experience</p>
+        <h1 className="text-4xl md:text-6xl font-semibold tracking-tight max-w-5xl">Relationship Infrastructure for the AI and Zero-Party Data Era.</h1>
+        <p className="mt-6 text-white/70 text-lg max-w-4xl">AOC operates as runtime trust infrastructure: programmable capabilities, live consent enforcement, bounded AI execution, policy intervention, and append-only auditability across machine-governed relationships.</p>
       </section>
 
-      <section id="problem" className="py-32 border-t border-white/10">
-        <div className="max-w-6xl mx-auto px-6">
-          <header className="text-center mb-16">
-            <h2 className="text-4xl md:text-6xl font-semibold tracking-tight mb-4">
-              The current enterprise model is fragile.
-            </h2>
-            <p className="max-w-3xl mx-auto text-white/60 text-lg">
-              Most companies still rely on implied consent, fragmented permissions, and weak audit trails.
-            </p>
-          </header>
-
-          <div className="grid md:grid-cols-3 gap-8">
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Risk</div>
-              <h3 className="text-2xl font-semibold mb-3">Privacy compliance is reactive</h3>
-              <p className="text-white/60 leading-relaxed">
-                Policies say one thing, but systems often cannot prove who accessed what, when, or under which permission state.
-              </p>
-            </article>
-
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Trust</div>
-              <h3 className="text-2xl font-semibold mb-3">Users are asked to trust blindly</h3>
-              <p className="text-white/60 leading-relaxed">
-                Access is usually inherited, bundled, or hidden inside terms nobody can realistically monitor in real time.
-              </p>
-            </article>
-
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Auditability</div>
-              <h3 className="text-2xl font-semibold mb-3">Evidence is incomplete</h3>
-              <p className="text-white/60 leading-relaxed">
-                Without enforced permissions and verifiable logs, enterprises carry regulatory exposure and operational ambiguity.
-              </p>
-            </article>
-          </div>
-        </div>
+      <section className="max-w-7xl mx-auto px-6 pb-10">
+        <AocRuntimeOS />
       </section>
 
-      <section id="solution" className="py-32 border-t border-white/10">
-        <div className="max-w-6xl mx-auto px-6">
-          <header className="text-center mb-16">
-            <h2 className="text-4xl md:text-6xl font-semibold tracking-tight mb-4">
-              AOC turns compliance into infrastructure.
-            </h2>
-            <p className="max-w-3xl mx-auto text-white/60 text-lg">
-              Instead of treating privacy as policy alone, AOC enforces access at the system level.
-            </p>
-          </header>
-
-          <div className="grid md:grid-cols-2 gap-8">
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Explicit consent</div>
-              <h3 className="text-2xl font-semibold mb-3">Access is granted, not assumed</h3>
-              <p className="text-white/60 leading-relaxed">
-                Requests become visible actions. Permissions are explicit, time-bound, and tied to user intent.
-              </p>
-            </article>
-
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Modular permissions</div>
-              <h3 className="text-2xl font-semibold mb-3">Granularity replaces all-or-nothing access</h3>
-              <p className="text-white/60 leading-relaxed">
-                Enterprises can request exactly what is needed, while users retain control over the scope of access.
-              </p>
-            </article>
-
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Verifiable interactions</div>
-              <h3 className="text-2xl font-semibold mb-3">Every interaction leaves evidence</h3>
-              <p className="text-white/60 leading-relaxed">
-                Access events can be logged, verified, and audited — giving compliance teams a stronger operational foundation.
-              </p>
-            </article>
-
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Competitive advantage</div>
-              <h3 className="text-2xl font-semibold mb-3">Trust becomes a product feature</h3>
-              <p className="text-white/60 leading-relaxed">
-                The first companies to give users visible control over their data can differentiate on trust, compliance, and transparency.
-              </p>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section id="integration" className="py-32 border-t border-white/10">
-        <div className="max-w-6xl mx-auto px-6">
-          <header className="text-center mb-16">
-            <h2 className="text-4xl md:text-6xl font-semibold tracking-tight mb-4">
-      <section className="py-24">
-        <div className="w-full">
-          <div className="mb-10 max-w-3xl mx-auto text-center">
-            <p className="text-sm uppercase tracking-[0.25em] text-white/50 mb-4">Shared Infrastructure</p>
-            <h2 className="text-4xl md:text-5xl font-semibold text-white mb-4">
-              A single control plane for governed enterprise access
-            </h2>
-            <p className="text-white/70 text-lg leading-relaxed">
-              AOC provides a unified layer for consent, policy enforcement, capability restrictions,
-              identity-aware access, and full auditability across enterprise systems.
-            </p>
-          </div>
-          <AocInfrastructureAnimated />
-        </div>
-      </section>
-              How enterprises can use AOC
-            </h2>
-            <p className="max-w-3xl mx-auto text-white/60 text-lg">
-              AOC can serve as a control and verification layer across data-heavy products and workflows.
-            </p>
-          </header>
-
-          <div className="grid md:grid-cols-3 gap-8">
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <h3 className="text-xl font-semibold mb-3">Data brokers & lookup platforms</h3>
-              <p className="text-white/60 leading-relaxed">
-                Replace implicit access with enforceable permission states and user-visible evidence.
-              </p>
-            </article>
-
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <h3 className="text-xl font-semibold mb-3">Fintech, HR, health & identity</h3>
-              <p className="text-white/60 leading-relaxed">
-                Introduce modular permissions in sensitive workflows where consent and traceability matter most.
-              </p>
-            </article>
-
-            <article className="bg-white/[0.03] border border-white/10 rounded-3xl p-8">
-              <h3 className="text-xl font-semibold mb-3">Compliance-forward product teams</h3>
-              <p className="text-white/60 leading-relaxed">
-                Build trust-centered experiences without leaving consent logic buried in policy documents.
-              </p>
-            </article>
-          </div>
-
-          <div className="mt-16 bg-white/[0.03] border border-white/10 rounded-3xl p-10 text-center">
-            <div className="text-cyan-300 text-xs uppercase tracking-[0.2em] mb-4">Next step</div>
-            <h3 className="text-3xl md:text-4xl font-semibold mb-4">
-              Want to make your system compliant by design?
-            </h3>
-            <p className="max-w-2xl mx-auto text-white/60 leading-relaxed mb-8">
-              Talk to us about enterprise use cases, pilot integrations, and how AOC can become your permission and auditability layer.
-            </p>
-            <a
-              href="mailto:hello@aocprotocol.xyz?subject=AOC%20Enterprise%20Pilot"
-              className="px-10 py-4 bg-[#00f0ff] hover:bg-[#00d4e0] text-black font-semibold rounded-2xl transition inline-block"
-            >
-              Start the conversation
-            </a>
-          </div>
-        </div>
+      <section className="max-w-7xl mx-auto px-6 pb-24 grid md:grid-cols-3 gap-6">
+        {[
+          ['Trust Propagation', 'Verified and attested paths propagate safely. Degraded states are isolated and recovered through runtime attestations.'],
+          ['Capability Orchestration', 'Capabilities activate, minimize scope, expire, renew, and revoke in bounded execution paths.'],
+          ['AI Governance Boundaries', 'Agents execute only in delegated scopes with policy-gated interventions and audit-backed evidence.'],
+        ].map(([title, body]) => (
+          <article key={title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+            <h3 className="text-xl font-semibold mb-2">{title}</h3>
+            <p className="text-white/65 text-sm leading-relaxed">{body}</p>
+          </article>
+        ))}
       </section>
     </main>
   );

--- a/frontend/app/src/landing/components/AocRuntimeOS.tsx
+++ b/frontend/app/src/landing/components/AocRuntimeOS.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from 'react';
+
+type TrustState = 'verified' | 'attested' | 'degraded' | 'unverified';
+
+type RuntimeNode = {
+  id: string;
+  label: string;
+  kind: 'user' | 'relationship' | 'capability' | 'organization' | 'agent' | 'policy' | 'audit';
+  x: number;
+  y: number;
+  trust: TrustState;
+  health: number;
+  scope: string;
+};
+
+type RuntimeEvent = {
+  id: number;
+  at: string;
+  message: string;
+  trust: TrustState;
+};
+
+const trustClass: Record<TrustState, string> = {
+  verified: 'text-emerald-300 border-emerald-400/40 bg-emerald-400/10',
+  attested: 'text-cyan-300 border-cyan-400/40 bg-cyan-400/10',
+  degraded: 'text-amber-300 border-amber-400/40 bg-amber-400/10',
+  unverified: 'text-rose-300 border-rose-400/40 bg-rose-400/10',
+};
+
+const seeds: RuntimeNode[] = [
+  { id: 'u1', label: 'User Identity', kind: 'user', x: 12, y: 42, trust: 'verified', health: 95, scope: 'personal.profile' },
+  { id: 'r1', label: 'Relationship Contract', kind: 'relationship', x: 31, y: 25, trust: 'attested', health: 93, scope: 'relationship.v1' },
+  { id: 'c1', label: 'Capability Runtime', kind: 'capability', x: 49, y: 48, trust: 'attested', health: 90, scope: 'cap.read:minimized' },
+  { id: 'o1', label: 'Enterprise Org', kind: 'organization', x: 70, y: 28, trust: 'verified', health: 96, scope: 'org.hr.workflow' },
+  { id: 'a1', label: 'AI Agent', kind: 'agent', x: 71, y: 66, trust: 'degraded', health: 75, scope: 'agent.exec:bounded' },
+  { id: 'p1', label: 'Policy Runtime', kind: 'policy', x: 89, y: 46, trust: 'attested', health: 91, scope: 'policy.guardrails' },
+  { id: 'au1', label: 'Audit Layer', kind: 'audit', x: 50, y: 80, trust: 'verified', health: 98, scope: 'audit.append-only' },
+];
+
+const links: Array<[string, string]> = [['u1','r1'],['r1','c1'],['c1','o1'],['c1','a1'],['a1','p1'],['p1','au1'],['r1','au1']];
+
+const eventTemplates = [
+  'Capability issued with minimized scope',
+  'Runtime attestation renewed',
+  'Policy drift detected and contained',
+  'Autonomous revocation triggered',
+  'Access denied by policy gate',
+  'Trust chain recovered after attestation',
+  'AI agent execution bounded in zone',
+  'Relationship contract renewed',
+];
+
+export function AocRuntimeOS() {
+  const [nodes, setNodes] = useState(seeds);
+  const [activeNodeId, setActiveNodeId] = useState('c1');
+  const [events, setEvents] = useState<RuntimeEvent[]>([]);
+  const [tick, setTick] = useState(0);
+  const [replay, setReplay] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setTick((t) => t + 1);
+      setNodes((prev) => prev.map((n) => {
+        const drift = (Math.random() - 0.5) * 6;
+        const health = Math.max(52, Math.min(99, Math.round(n.health + drift)));
+        const trust: TrustState = health < 68 ? 'degraded' : health < 80 ? 'attested' : n.trust === 'unverified' ? 'attested' : n.trust;
+        return { ...n, health, trust };
+      }));
+
+      const template = eventTemplates[Math.floor(Math.random() * eventTemplates.length)];
+      const trustPool: TrustState[] = ['verified', 'attested', 'degraded', 'unverified'];
+      const trust = trustPool[Math.floor(Math.random() * trustPool.length)];
+      setEvents((prev) => [{ id: Date.now(), at: new Date().toLocaleTimeString(), message: template, trust }, ...prev].slice(0, 12));
+    }, replay ? 1200 : 1800);
+
+    return () => window.clearInterval(timer);
+  }, [replay]);
+
+  const active = useMemo(() => nodes.find((n) => n.id === activeNodeId) ?? nodes[0], [nodes, activeNodeId]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-6 md:p-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <p className="text-cyan-300 text-xs tracking-[0.2em] uppercase">AOC Runtime OS</p>
+          <h3 className="text-2xl md:text-3xl font-semibold">Live Relationship Runtime Canvas</h3>
+        </div>
+        <button onClick={() => setReplay((r) => !r)} className="px-4 py-2 rounded-xl border border-white/15 hover:border-white/30 text-sm">
+          {replay ? 'Replay: ON' : 'Replay: OFF'}
+        </button>
+      </div>
+      <div className="grid lg:grid-cols-[2fr_1fr] gap-6">
+        <div className="relative rounded-2xl border border-white/10 h-[460px] bg-[#090d14] overflow-hidden">
+          {links.map(([from, to], idx) => {
+            const a = nodes.find((n) => n.id === from)!;
+            const b = nodes.find((n) => n.id === to)!;
+            return <svg key={`${from}-${to}`} className="absolute inset-0 w-full h-full pointer-events-none"><line x1={`${a.x}%`} y1={`${a.y}%`} x2={`${b.x}%`} y2={`${b.y}%`} stroke="rgba(130,173,255,0.25)" strokeWidth="1.5" strokeDasharray={idx % 2 === 0 ? '4 4' : '0'} /></svg>;
+          })}
+          {nodes.map((node) => (
+            <button key={node.id} onMouseEnter={() => setActiveNodeId(node.id)} onClick={() => setActiveNodeId(node.id)} className={`absolute -translate-x-1/2 -translate-y-1/2 px-3 py-2 rounded-xl border text-left transition-all ${trustClass[node.trust]} ${activeNodeId === node.id ? 'scale-105 shadow-[0_0_24px_rgba(0,240,255,0.22)]' : ''}`} style={{ left: `${node.x}%`, top: `${node.y}%` }}>
+              <div className="text-[11px] uppercase tracking-[0.18em] opacity-80">{node.kind}</div>
+              <div className="text-sm font-medium">{node.label}</div>
+              <div className="text-xs opacity-80">Health {node.health}%</div>
+            </button>
+          ))}
+          <div className="absolute bottom-3 right-3 text-xs text-white/50">Pulse tick: {tick}</div>
+        </div>
+        <div className="space-y-4">
+          <article className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-white/50">Node inspection</p>
+            <h4 className="text-lg font-semibold mt-2">{active.label}</h4>
+            <p className="text-sm text-white/65">Scope: {active.scope}</p>
+            <p className="text-sm text-white/65">Trust: {active.trust}</p>
+            <p className="text-sm text-white/65">Relationship health: {active.health}%</p>
+          </article>
+          <article className="rounded-2xl border border-white/10 bg-white/[0.02] p-4 max-h-[280px] overflow-auto">
+            <p className="text-xs uppercase tracking-[0.2em] text-white/50 mb-3">Operational telemetry stream</p>
+            <div className="space-y-2">
+              {events.map((event) => (
+                <div key={event.id} className={`rounded-xl border px-3 py-2 ${trustClass[event.trust]}`}>
+                  <p className="text-xs opacity-75">{event.at}</p>
+                  <p className="text-sm">{event.message}</p>
+                </div>
+              ))}
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Surface a runtime-first, operational view of AOC to demonstrate programmable relationship infrastructure and AI governance in an immediately compelling way. 
- Replace a broad enterprise landing with a focused interactive Runtime OS that highlights trust propagation, capability orchestration, AI boundaries, and telemetry. 

### Description
- Replace the enterprise landing with a runtime-focused page and hero that embeds the new `AocRuntimeOS` component. 
- Add `src/landing/components/AocRuntimeOS.tsx`, an interactive runtime canvas that simulates nodes (user, relationship, capability, org, agent, policy, audit), directed links, trust-state styling (`verified|attested|degraded|unverified`), health drift, hover/click inspection, and a pulse tick. 
- Implement an append-only operational telemetry stream driven by randomized event templates and a `Replay` cadence toggle to accelerate updates for demo/replay mode. 
- Keep the runtime canvas component client-side and intentionally componentized for future integration with websockets, streaming graph updates, and multi-tenant adapters. 

### Testing
- Ran `npm run build` inside `frontend/app`, which failed due to missing Vite/Tailwind type/module dependencies (errors: `Cannot find type definition file for 'vite/client'` and missing modules/types for `vite`, `@vitejs/plugin-react`, `@tailwindcss/vite`). 
- Ran `npm install` inside `frontend/app`, which failed with an `ENOENT` during package resolution for `@tailwindcss/oxide-wasm32-wasi`, preventing dependency restoration. 
- No additional automated unit tests were run for the new UI component in this environment due to dependency/install issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb80b6c5b88325b4cb84db25dbbb12)