### PR TITLE
Add initial PDP foundation under protocol/policy

### DIFF
--- a/protocol/policy/README.md
+++ b/protocol/policy/README.md
@@ -1,0 +1,60 @@
+# Policy Decision Point (PDP) Foundation
+
+## Why this module exists
+
+Authorization in AOC is currently distributed across enforcement engines, capability checks, adapter policies, and runtime request guards. This module introduces a **single policy evaluation entry point** so future access decisions can converge into one pathway.
+
+Current objective:
+- centralize decision evaluation contract (`PolicyEvaluationInput`)
+- return normalized decisions (`PolicyDecision`)
+- produce traceable outcomes (`PolicyDecisionTrace`)
+- avoid breaking existing modules while migration is staged
+
+## Current scope (phase-1 foundation)
+
+The PDP currently performs lightweight baseline checks:
+- permission expiration
+- allowed action matching
+- category matching
+- basic brand alignment
+- basic actor/resource ownership alignment
+
+This is intentionally minimal and not yet a full policy engine.
+
+## Current limitations
+
+- No persistence for traces (in-memory only).
+- No distributed policy storage.
+- No external policy language/DSL.
+- No native rate-limit/frequency counters (returned as obligations).
+- Existing enforcement paths are **not yet routed** through PDP.
+
+## Future architecture direction
+
+Expected migration path:
+1. Keep existing enforcement behavior stable.
+2. Add adapter wrappers that call `evaluateAccess(...)` before legacy checks.
+3. Gradually move duplicated authorization logic into PDP policy evaluators.
+4. Standardize reason codes and obligations across protocol/runtime.
+5. Attach PDP trace IDs to audit logs.
+
+## Where integrations should happen next
+
+Candidate modules to adopt PDP entrypoints:
+- `protocol/enforcement/*`
+- `runtime/enforcement/*`
+- `runtime/access/*` (if present in runtime topology)
+- capability authorization paths
+- adapter-level authorization checks
+- API request validation gates
+
+## Role boundaries
+
+- **PDP (Policy Decision Point):** evaluates policy input and returns allow/deny + reason + trace metadata.
+- **PEP (Policy Enforcement Point):** intercepts requests and enforces PDP decisions at runtime boundaries.
+- **Consent:** records subject intent/permissions over time.
+- **Capability:** cryptographically portable authorization artifact.
+- **Relationship:** trust/business context between actors.
+- **Audit:** immutable event trail and compliance evidence.
+
+PDP should evaluate policy using these inputs, but should not replace domain ownership of consent, capability, relationship, or audit.

--- a/protocol/policy/decision-trace.ts
+++ b/protocol/policy/decision-trace.ts
@@ -1,0 +1,18 @@
+export type PolicyDecisionTrace = {
+  traceId: string;
+  evaluatedAt: string;
+  evaluatedPolicies: string[];
+  decisionReason: string;
+  actorId: string;
+  resourceId: string;
+};
+
+const traceStore = new Map<string, PolicyDecisionTrace>();
+
+export function recordDecisionTrace(trace: PolicyDecisionTrace): void {
+  traceStore.set(trace.traceId, trace);
+}
+
+export function getDecisionTrace(traceId: string): PolicyDecisionTrace | undefined {
+  return traceStore.get(traceId);
+}

--- a/protocol/policy/pdp.ts
+++ b/protocol/policy/pdp.ts
@@ -1,0 +1,111 @@
+import { recordDecisionTrace } from './decision-trace';
+import type { PolicyDecisionTrace } from './decision-trace';
+import type { PolicyDecision, PolicyEvaluationInput } from './types';
+
+const POLICY_IDS = {
+  EXPIRATION: 'policy.permission.expiration',
+  ACTION_MATCH: 'policy.permission.action_match',
+  CATEGORY_MATCH: 'policy.permission.category_match',
+  BRAND_ALIGNMENT: 'policy.permission.brand_alignment',
+  ACTOR_RESOURCE_ALIGNMENT: 'policy.actor_resource.alignment',
+} as const;
+
+function createTraceId(): string {
+  return `pdp_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function deny(
+  traceId: string,
+  evaluatedPolicies: string[],
+  reason: string,
+  input: PolicyEvaluationInput,
+  obligations?: string[]
+): PolicyDecision {
+  const trace: PolicyDecisionTrace = {
+    traceId,
+    evaluatedAt: new Date().toISOString(),
+    evaluatedPolicies,
+    decisionReason: reason,
+    actorId: input.actor.id,
+    resourceId: input.resource.id,
+  };
+  recordDecisionTrace(trace);
+
+  return {
+    allow: false,
+    reason,
+    obligations,
+    traceId,
+    evaluatedPolicies,
+  };
+}
+
+export function evaluateAccess(input: PolicyEvaluationInput): PolicyDecision {
+  const traceId = createTraceId();
+  const evaluatedPolicies: string[] = [];
+
+  const now = input.context?.temporal?.now ? new Date(input.context.temporal.now) : new Date();
+
+  if (input.permission.expiresAt) {
+    evaluatedPolicies.push(POLICY_IDS.EXPIRATION);
+    const expiresAt = new Date(input.permission.expiresAt);
+    if (!Number.isNaN(expiresAt.getTime()) && now > expiresAt) {
+      return deny(traceId, evaluatedPolicies, 'DENY_PERMISSION_EXPIRED', input);
+    }
+  }
+
+  evaluatedPolicies.push(POLICY_IDS.ACTION_MATCH);
+  const allowedActions = input.permission.allowedActions ?? [input.permission.action];
+  if (!allowedActions.includes(input.action)) {
+    return deny(traceId, evaluatedPolicies, 'DENY_ACTION_NOT_ALLOWED', input);
+  }
+
+  if (input.permission.category) {
+    evaluatedPolicies.push(POLICY_IDS.CATEGORY_MATCH);
+    if (input.resource.category !== input.permission.category) {
+      return deny(traceId, evaluatedPolicies, 'DENY_CATEGORY_MISMATCH', input);
+    }
+  }
+
+  if (input.permission.allowedBrands && input.permission.allowedBrands.length > 0) {
+    evaluatedPolicies.push(POLICY_IDS.BRAND_ALIGNMENT);
+    const brand = input.resource.brandId ?? input.actor.brandId;
+    if (!brand || !input.permission.allowedBrands.includes(brand)) {
+      return deny(traceId, evaluatedPolicies, 'DENY_BRAND_NOT_ALLOWED', input);
+    }
+  }
+
+  evaluatedPolicies.push(POLICY_IDS.ACTOR_RESOURCE_ALIGNMENT);
+  if (input.resource.ownerActorId && input.resource.ownerActorId !== input.actor.id) {
+    return deny(traceId, evaluatedPolicies, 'DENY_ACTOR_RESOURCE_MISMATCH', input);
+  }
+
+  const reason = 'ALLOW_BASELINE_POLICY_CHECKS_PASSED';
+  const obligations: string[] = [];
+
+  if (input.permission.frequency) {
+    obligations.push('OBLIGATION_ENFORCE_FREQUENCY_OUTSIDE_PDP');
+  }
+
+  if (input.permission.purpose) {
+    obligations.push('OBLIGATION_ASSERT_PURPOSE_AT_PEP');
+  }
+
+  const trace: PolicyDecisionTrace = {
+    traceId,
+    evaluatedAt: new Date().toISOString(),
+    evaluatedPolicies,
+    decisionReason: reason,
+    actorId: input.actor.id,
+    resourceId: input.resource.id,
+  };
+  recordDecisionTrace(trace);
+
+  return {
+    allow: true,
+    reason,
+    obligations: obligations.length > 0 ? obligations : undefined,
+    traceId,
+    evaluatedPolicies,
+  };
+}

--- a/protocol/policy/policy-object.ts
+++ b/protocol/policy/policy-object.ts
@@ -1,0 +1,9 @@
+import type { ScopedPermission } from './types';
+
+export type PolicyObject = {
+  id: string;
+  name: string;
+  description?: string;
+  permission: ScopedPermission;
+  active: boolean;
+};

--- a/protocol/policy/types.ts
+++ b/protocol/policy/types.ts
@@ -1,0 +1,76 @@
+export type ActorType = 'human' | 'organization' | 'brand' | 'app' | 'ai_agent';
+
+export type Actor = {
+  id: string;
+  type: ActorType;
+  organizationId?: string;
+  brandId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type Resource = {
+  id: string;
+  type: string;
+  ownerActorId?: string;
+  ownerOrganizationId?: string;
+  brandId?: string;
+  category?: string;
+  dataClassification?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ScopedPermission = {
+  action: string;
+  category?: string;
+  purpose?: string;
+  allowedBrands?: string[];
+  allowedActions?: string[];
+  frequency?: {
+    maxCount: number;
+    windowSeconds: number;
+  };
+  expiresAt?: string;
+  dataClassification?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type AccessContext = {
+  runtime?: {
+    module?: string;
+    path?: string;
+    method?: string;
+    transport?: string;
+  };
+  request?: {
+    requestId?: string;
+    ip?: string;
+    userAgent?: string;
+    headers?: Record<string, string | string[] | undefined>;
+  };
+  environment?: {
+    environmentName?: string;
+    region?: string;
+    adapterId?: string;
+  };
+  temporal?: {
+    now?: string;
+    timezone?: string;
+  };
+  metadata?: Record<string, unknown>;
+};
+
+export type PolicyDecision = {
+  allow: boolean;
+  reason: string;
+  obligations?: string[];
+  traceId: string;
+  evaluatedPolicies: string[];
+};
+
+export type PolicyEvaluationInput = {
+  actor: Actor;
+  resource: Resource;
+  action: string;
+  permission: ScopedPermission;
+  context?: AccessContext;
+};


### PR DESCRIPTION
### Motivation
- Introduce a single, lightweight Policy Decision Point (PDP) entrypoint to centralize future access decisions and reduce policy drift across enforcement, capability, and adapter layers.
- Provide a minimally opinionated, protocol-first foundation that is migration-friendly and does not rewrite or break existing enforcement logic.

### Description
- Added a new `protocol/policy/` module with files `types.ts`, `pdp.ts`, `decision-trace.ts`, `policy-object.ts`, and `README.md` that define the PDP foundation and documentation.
- Introduced canonical types including `Actor`, `Resource`, `ScopedPermission`, `AccessContext`, `PolicyEvaluationInput`, and `PolicyDecision` in `types.ts` to standardize evaluation inputs and outputs.
- Implemented `evaluateAccess(input: PolicyEvaluationInput): PolicyDecision` in `pdp.ts` that performs baseline checks for permission expiration, action matching, category matching, brand alignment, and simple actor/resource ownership alignment, and returns obligations for frequency/purpose enforcement.
- Added explainability support via `PolicyDecisionTrace` and in-memory trace recording/get helpers in `decision-trace.ts`, and a lightweight `PolicyObject` shape in `policy-object.ts` for future policy records.

### Testing
- Ran `npm test -- --runInBand` to validate repository behavior and integration with the new module.
- Test result summary: 47 test suites were collected, with 46 suites passing and 1 suite failing due to a pre-existing empty test file (`runtime/__tests__/helpers/serverLifecycle.ts`), and a total of 581 tests passed.
- No new unit tests were added for the PDP in this phase because the change is an initial infrastructure addition and backward-compatible by design.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd012cd74832584c63dd50211c31e)