### PR TITLE
Add foundational Relationship Engine primitives

### DIFF
--- a/protocol/relationships/README.md
+++ b/protocol/relationships/README.md
@@ -1,0 +1,59 @@
+# Relationship Core Primitive
+
+## Why relationships are infrastructure primitives
+
+Relationships are durable protocol objects that express *who can interact with whom, under what boundaries, and for how long*. This is infrastructure because policy, consent, capability checks, and auditing need a stable relationship anchor.
+
+## Relationship vs follows/subscriptions
+
+A follow/subscription is a product interaction signal. A relationship in AOC is a governance and authorization primitive:
+
+- explicit lifecycle state
+- policy binding surface
+- temporal validity window
+- audit references and transition trail
+- optional AI delegation boundaries
+
+## Lifecycle semantics
+
+Relationship states are:
+
+- proposed
+- pending
+- active
+- suspended
+- expired
+- revoked
+- disputed
+
+Core transition integrity in this phase:
+
+- revoked relationships cannot reactivate
+- expired relationships cannot transition to active
+- suspended relationships require an explicit restore path (not implemented yet)
+- every relationship must include at least one `subject` actor
+
+## Policy bindings
+
+Relationships can attach one or more PDP policy references. Attach/detach are local object transformations for now (no persistence layer).
+
+## Relationship vs consent vs capability
+
+- Relationship: the durable context and boundaries between actors.
+- Consent: a subject authorization artifact within that relationship context.
+- Capability: a scoped executable token derived from policy + consent + relationship validity.
+
+## Future MediaLab integration
+
+MediaLab can bind content and communication flows to relationship objects so distribution and monetization decisions evaluate against relationship scope and validity windows.
+
+## Future AI-agent integration
+
+Relationship scope includes optional AI delegation boundaries:
+
+- delegated AI actor IDs
+- allowed purposes
+- blocked categories
+- human review requirement
+
+This creates a governance envelope for future AI orchestration without introducing orchestration complexity in this phase.

--- a/protocol/relationships/relationship-audit.ts
+++ b/protocol/relationships/relationship-audit.ts
@@ -1,0 +1,109 @@
+export const RELATIONSHIP_AUDIT_EVENT_TYPES = [
+  'relationship_created',
+  'relationship_activated',
+  'relationship_suspended',
+  'relationship_revoked',
+  'relationship_expired',
+  'relationship_disputed',
+  'policy_attached',
+  'policy_detached',
+] as const;
+
+export type RelationshipAuditEventType = (typeof RELATIONSHIP_AUDIT_EVENT_TYPES)[number];
+
+export type RelationshipAuditEvent = {
+  eventId: string;
+  type: RelationshipAuditEventType;
+  relationshipId: string;
+  actorId?: string;
+  occurredAt: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+function buildEvent(
+  type: RelationshipAuditEventType,
+  input: {
+    relationshipId: string;
+    actorId?: string;
+    occurredAt?: string;
+    policyTraceId?: string;
+    metadata?: Record<string, unknown>;
+  },
+): RelationshipAuditEvent {
+  const occurredAt = input.occurredAt ?? new Date().toISOString();
+
+  return {
+    eventId: `${type}:${input.relationshipId}:${occurredAt}`,
+    type,
+    relationshipId: input.relationshipId,
+    actorId: input.actorId,
+    occurredAt,
+    policyTraceId: input.policyTraceId,
+    metadata: input.metadata,
+  };
+}
+
+export const emitRelationshipCreated = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('relationship_created', input);
+
+export const emitRelationshipActivated = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('relationship_activated', input);
+
+export const emitRelationshipSuspended = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('relationship_suspended', input);
+
+export const emitRelationshipRevoked = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('relationship_revoked', input);
+
+export const emitRelationshipExpired = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('relationship_expired', input);
+
+export const emitRelationshipDisputed = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('relationship_disputed', input);
+
+export const emitPolicyAttached = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('policy_attached', input);
+
+export const emitPolicyDetached = (input: {
+  relationshipId: string;
+  actorId?: string;
+  occurredAt?: string;
+  policyTraceId?: string;
+  metadata?: Record<string, unknown>;
+}): RelationshipAuditEvent => buildEvent('policy_detached', input);

--- a/protocol/relationships/relationship-lifecycle.ts
+++ b/protocol/relationships/relationship-lifecycle.ts
@@ -1,0 +1,115 @@
+import { Relationship, RelationshipActor, RelationshipState } from './types';
+
+type TransitionInput = {
+  actorId?: string;
+  at?: string;
+};
+
+function isoNow(at?: string): string {
+  return at ?? new Date().toISOString();
+}
+
+function assertHasSubjectActor(actors: RelationshipActor[]): void {
+  if (!actors.some((actor) => actor.role === 'subject')) {
+    throw new Error('Relationship must include at least one subject actor');
+  }
+}
+
+function applyState(
+  relationship: Relationship,
+  nextState: RelationshipState,
+  at?: string,
+): Relationship {
+  const transitionAt = isoNow(at);
+  return {
+    ...relationship,
+    state: nextState,
+    updatedAt: transitionAt,
+  };
+}
+
+export function createRelationship(input: {
+  id: string;
+  type: string;
+  actors: RelationshipActor[];
+  startsAt?: string;
+  expiresAt?: string;
+  scope?: Relationship['scope'];
+  state?: Extract<RelationshipState, 'proposed' | 'pending'>;
+}): Relationship {
+  assertHasSubjectActor(input.actors);
+
+  const now = new Date().toISOString();
+  return {
+    id: input.id,
+    type: input.type,
+    state: input.state ?? 'proposed',
+    actors: input.actors,
+    scope: input.scope,
+    policyBindings: [],
+    audit: { auditEventIds: [] },
+    createdAt: now,
+    updatedAt: now,
+    startsAt: input.startsAt,
+    expiresAt: input.expiresAt,
+  };
+}
+
+export function activateRelationship(
+  relationship: Relationship,
+  input: TransitionInput = {},
+): Relationship {
+  if (relationship.state === 'revoked') {
+    throw new Error('Revoked relationships cannot be reactivated');
+  }
+
+  if (relationship.state === 'expired') {
+    throw new Error('Expired relationships cannot transition to active');
+  }
+
+  if (relationship.state === 'suspended') {
+    throw new Error('Suspended relationships require an explicit restore path');
+  }
+
+  return applyState(relationship, 'active', input.at);
+}
+
+export function suspendRelationship(
+  relationship: Relationship,
+  input: TransitionInput = {},
+): Relationship {
+  const suspended = applyState(relationship, 'suspended', input.at);
+  return {
+    ...suspended,
+    suspendedAt: suspended.updatedAt,
+  };
+}
+
+export function revokeRelationship(
+  relationship: Relationship,
+  input: TransitionInput = {},
+): Relationship {
+  const revoked = applyState(relationship, 'revoked', input.at);
+  return {
+    ...revoked,
+    revokedAt: revoked.updatedAt,
+  };
+}
+
+export function expireRelationship(
+  relationship: Relationship,
+  input: TransitionInput = {},
+): Relationship {
+  const expired = applyState(relationship, 'expired', input.at);
+  return {
+    ...expired,
+    expiresAt: expired.updatedAt,
+  };
+}
+
+export function disputeRelationship(
+  relationship: Relationship,
+  input: TransitionInput = {},
+): Relationship {
+  return applyState(relationship, 'disputed', input.at);
+}

--- a/protocol/relationships/relationship-object.ts
+++ b/protocol/relationships/relationship-object.ts
@@ -1,0 +1,26 @@
+import { Relationship } from './types';
+
+export function isRelationshipCurrentlyValid(
+  relationship: Relationship,
+  now: Date = new Date(),
+): boolean {
+  if (relationship.state !== 'active') {
+    return false;
+  }
+
+  if (relationship.revokedAt) {
+    return false;
+  }
+
+  const nowMs = now.getTime();
+
+  if (relationship.startsAt && nowMs < new Date(relationship.startsAt).getTime()) {
+    return false;
+  }
+
+  if (relationship.expiresAt && nowMs >= new Date(relationship.expiresAt).getTime()) {
+    return false;
+  }
+
+  return true;
+}

--- a/protocol/relationships/relationship-policy-binding.ts
+++ b/protocol/relationships/relationship-policy-binding.ts
@@ -1,0 +1,50 @@
+import { Relationship, RelationshipPolicyBinding } from './types';
+
+export function attachPolicy(
+  relationship: Relationship,
+  input: { policyId: string; version?: string; at?: string },
+): Relationship {
+  const attachedAt = input.at ?? new Date().toISOString();
+  const currentBindings = relationship.policyBindings ?? [];
+
+  const nextBindings: RelationshipPolicyBinding[] = currentBindings.map((binding) =>
+    binding.policyId === input.policyId
+      ? { ...binding, active: true, version: input.version ?? binding.version, attachedAt }
+      : binding,
+  );
+
+  if (!nextBindings.some((binding) => binding.policyId === input.policyId)) {
+    nextBindings.push({
+      policyId: input.policyId,
+      version: input.version,
+      attachedAt,
+      active: true,
+    });
+  }
+
+  return {
+    ...relationship,
+    policyBindings: nextBindings,
+    updatedAt: attachedAt,
+  };
+}
+
+export function detachPolicy(
+  relationship: Relationship,
+  input: { policyId: string; at?: string },
+): Relationship {
+  const detachedAt = input.at ?? new Date().toISOString();
+  const nextBindings = (relationship.policyBindings ?? []).map((binding) =>
+    binding.policyId === input.policyId ? { ...binding, active: false } : binding,
+  );
+
+  return {
+    ...relationship,
+    policyBindings: nextBindings,
+    updatedAt: detachedAt,
+  };
+}
+
+export function listActivePolicies(relationship: Relationship): RelationshipPolicyBinding[] {
+  return (relationship.policyBindings ?? []).filter((binding) => binding.active);
+}

--- a/protocol/relationships/types.ts
+++ b/protocol/relationships/types.ts
@@ -1,0 +1,93 @@
+export const RELATIONSHIP_STATES = [
+  'proposed',
+  'pending',
+  'active',
+  'suspended',
+  'expired',
+  'revoked',
+  'disputed',
+] as const;
+
+export type RelationshipState = (typeof RELATIONSHIP_STATES)[number];
+
+export const RELATIONSHIP_ACTOR_ROLES = [
+  'subject',
+  'brand',
+  'organization',
+  'app',
+  'ai_agent',
+  'delegate',
+] as const;
+
+export type RelationshipActorRole = (typeof RELATIONSHIP_ACTOR_ROLES)[number];
+
+export type RelationshipActor = {
+  actorId: string;
+  actorType: string;
+  role: RelationshipActorRole;
+};
+
+export type RelationshipTemporalConstraints = {
+  startsAt?: string;
+  expiresAt?: string;
+  validDaysOfWeek?: number[];
+  validHoursUtc?: {
+    startHour: number;
+    endHour: number;
+  };
+};
+
+export type RelationshipCommunicationLimits = {
+  maxMessagesPerDay?: number;
+  quietHoursUtc?: {
+    startHour: number;
+    endHour: number;
+  };
+};
+
+export type AIDelegationBoundary = {
+  delegatedAiActorIds?: string[];
+  allowedPurposes?: string[];
+  blockedCategories?: string[];
+  requiresHumanReview?: boolean;
+};
+
+export type RelationshipScope = {
+  categories?: string[];
+  purposes?: string[];
+  allowedBrands?: string[];
+  allowedChannels?: string[];
+  allowedActions?: string[];
+  temporalConstraints?: RelationshipTemporalConstraints;
+  communicationLimits?: RelationshipCommunicationLimits;
+  aiDelegation?: AIDelegationBoundary;
+};
+
+export type RelationshipPolicyBinding = {
+  policyId: string;
+  attachedAt: string;
+  active: boolean;
+  version?: string;
+};
+
+export type RelationshipAuditReference = {
+  auditEventIds: string[];
+  lastEvaluatedAt?: string;
+  lastPolicyTraceId?: string;
+};
+
+export type Relationship = {
+  id: string;
+  type: string;
+  state: RelationshipState;
+  actors: RelationshipActor[];
+  scope?: RelationshipScope;
+  policyBindings?: RelationshipPolicyBinding[];
+  audit?: RelationshipAuditReference;
+  createdAt: string;
+  updatedAt: string;
+  startsAt?: string;
+  expiresAt?: string;
+  suspendedAt?: string;
+  revokedAt?: string;
+};


### PR DESCRIPTION
### Motivation

- Introduce a first-class Relationship primitive so policy, consent, capabilities and audit can evaluate against an explicit, durable relationship object rather than implicit grants.
- Provide a small, deterministic foundation (lifecycle, policy bindings, temporal validity, AI delegation hooks, and audit event shapes) that can be wired into existing PDP and audit layers in later phases.

### Description

- Added a new `protocol/relationships` module with `types.ts`, `relationship-object.ts`, `relationship-lifecycle.ts`, `relationship-policy-binding.ts`, `relationship-audit.ts`, and `README.md` that define the relationship primitive and its surface area.
- Defined canonical types in `types.ts` including `Relationship`, `RelationshipActor`, `RelationshipState`, `RelationshipScope`, `RelationshipPolicyBinding`, `RelationshipAuditReference`, and optional `AIDelegationBoundary` hooks.
- Implemented lifecycle functions in `relationship-lifecycle.ts`: `createRelationship()`, `activateRelationship()`, `suspendRelationship()`, `revokeRelationship()`, `expireRelationship()`, and `disputeRelationship()` with invariant checks (subject presence, no reactivation of `revoked`, no activation from `expired`, and explicit restore path required for `suspended`).
- Implemented policy binding helpers in `relationship-policy-binding.ts`: `attachPolicy()`, `detachPolicy()`, and `listActivePolicies()` as pure object transforms (no persistence).
- Implemented lightweight structured audit event emitters in `relationship-audit.ts` for lifecycle and policy events that include `relationshipId`, optional `actorId`, `occurredAt`, and `policyTraceId` fields.
- Implemented temporal validity evaluation in `relationship-object.ts` via `isRelationshipCurrentlyValid()` which evaluates `state`, `startsAt`, `expiresAt`, and `revokedAt`.
- Documented rationale, lifecycle semantics, policy binding surface, relationship vs consent/capability, and future AI/MediaLab integration in `README.md`.
- Design choices: purely in-memory / functional object transforms, no persistence or external infra, and intentionally no restore path for `suspended` in this phase (to be added as a minimal follow-up).

### Testing

- Ran the repository test suite with `npm test -- --runInBand` which executed all automated tests in the repo.
- Test summary: `47` test suites run with `46` passing and `1` failing; `581` tests passed overall and the single failing suite is `runtime/__tests__/helpers/serverLifecycle.ts` which fails with "Your test suite must contain at least one test" (pre-existing/repository hygiene issue and unrelated to the new relationship module).
- No new unit tests for the relationship module were added in this change; lifecycle and helpers are pure functions and ready for targeted unit tests in the next PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd2e6875c83259a903ef487338a56)