### PR TITLE
Add foundational Identity Kernel primitives for AOC Core

### DIFF
--- a/protocol/identity/README.md
+++ b/protocol/identity/README.md
@@ -1,0 +1,31 @@
+# AOC Core Identity Kernel
+
+## Why identity is infrastructure
+Identity in AOC Core is protocol infrastructure, not application UX. The kernel defines *who can hold authority* and *how that authority is delegated and bounded* across policy decisions.
+
+## Actors are not users
+AOC actor identity models multiple authority-bearing entities:
+- humans
+- organizations
+- brands
+- applications
+- AI agents
+- delegates
+- system actors
+
+This avoids collapsing machine and organizational authority into user profile semantics.
+
+## Delegation philosophy
+Delegation is explicit and bounded. Every grant has a delegator, a delegate, allowed actions, allowed scopes, and validity windows. Revocation and expiration are first-class state.
+
+## Trust chains
+Trust chains are deterministic paths from a root authority to a delegated actor. Chain validation ensures links are contiguous and delegation depth can be bounded.
+
+## AI governance implications
+AI actors are first-class actors with explicit authority boundaries and optional human-review requirements. AI restrictions can block scopes, disallow autonomous redelegation, and require escalation for sensitive actions.
+
+## Identity vs authentication
+This module is not authentication. It does not implement login, OAuth, wallets, external IAM, or identity proofing UX. It provides typed identity semantics that authentication systems can bind to later.
+
+## Enterprise governance role
+The kernel provides protocol seams for future enterprise governance: adapter-backed registries, delegation-aware PDP normalization, and portable trust-chain evaluation across organizations and machine actors.

--- a/protocol/identity/actor-object.ts
+++ b/protocol/identity/actor-object.ts
@@ -1,0 +1,63 @@
+import { Actor, ActorAuthorityBoundary, ActorType, TrustLevel } from './types';
+
+const VALID_ACTOR_TYPES = new Set<ActorType>([
+  'human',
+  'organization',
+  'brand',
+  'app',
+  'ai_agent',
+  'delegate',
+  'system'
+]);
+
+export function defaultAuthorityBoundary(): ActorAuthorityBoundary {
+  return {
+    maxDelegationDepth: 2,
+    blockedActions: [],
+    restrictedScopes: [],
+    aiRestrictions: {
+      disallowAutonomousDelegation: true,
+      requireHumanEscalationForActions: [],
+      blockedScopes: []
+    },
+    requireHumanReview: false
+  };
+}
+
+export function createActor(input: {
+  actorId: string;
+  actorType: ActorType;
+  displayName: string;
+  trustLevel?: TrustLevel;
+  organizationId?: string;
+  parentActorId?: string;
+  authorityBoundary?: ActorAuthorityBoundary;
+  metadata?: Record<string, unknown>;
+  now?: Date;
+}): Actor {
+  if (!input.actorId || !input.actorId.trim()) {
+    throw new Error('actorId is required.');
+  }
+  if (!VALID_ACTOR_TYPES.has(input.actorType)) {
+    throw new Error(`Invalid actorType: ${input.actorType}.`);
+  }
+  if (!input.displayName || !input.displayName.trim()) {
+    throw new Error('displayName is required.');
+  }
+
+  const now = (input.now ?? new Date()).toISOString();
+
+  return {
+    actorId: input.actorId,
+    actorType: input.actorType,
+    displayName: input.displayName,
+    organizationId: input.organizationId,
+    parentActorId: input.parentActorId,
+    trustLevel: input.trustLevel ?? 'baseline',
+    active: true,
+    authorityBoundary: input.authorityBoundary ?? defaultAuthorityBoundary(),
+    metadata: input.metadata,
+    createdAt: now,
+    updatedAt: now
+  };
+}

--- a/protocol/identity/actor-registry.ts
+++ b/protocol/identity/actor-registry.ts
@@ -1,0 +1,81 @@
+import { Actor } from './types';
+
+export interface ActorRegistryAdapter {
+  get(actorId: string): Actor | undefined;
+  set(actor: Actor): void;
+  values(): Iterable<Actor>;
+}
+
+export class InMemoryActorRegistryAdapter implements ActorRegistryAdapter {
+  private readonly actors = new Map<string, Actor>();
+
+  get(actorId: string): Actor | undefined {
+    return this.actors.get(actorId);
+  }
+
+  set(actor: Actor): void {
+    this.actors.set(actor.actorId, actor);
+  }
+
+  values(): Iterable<Actor> {
+    return this.actors.values();
+  }
+}
+
+export class ActorRegistry {
+  constructor(private readonly adapter: ActorRegistryAdapter = new InMemoryActorRegistryAdapter()) {}
+
+  registerActor(actor: Actor): Actor {
+    if (this.adapter.get(actor.actorId)) {
+      throw new Error(`Actor already exists: ${actor.actorId}`);
+    }
+    this.adapter.set(actor);
+    return actor;
+  }
+
+  updateActor(actorId: string, patch: Partial<Actor>, now: Date = new Date()): Actor {
+    const current = this.resolveActor(actorId);
+    const updated: Actor = { ...current, ...patch, actorId: current.actorId, updatedAt: now.toISOString() };
+    this.adapter.set(updated);
+    return updated;
+  }
+
+  deactivateActor(actorId: string, now: Date = new Date()): Actor {
+    return this.updateActor(actorId, { active: false, deactivatedAt: now.toISOString() }, now);
+  }
+
+  resolveActor(actorId: string): Actor {
+    const actor = this.adapter.get(actorId);
+    if (!actor) {
+      throw new Error(`Actor not found: ${actorId}`);
+    }
+    return actor;
+  }
+}
+
+
+export function resolveRelationshipActors(
+  registry: ActorRegistry,
+  relationship: { subjectActorId: string; objectActorId: string }
+): { subject: Actor; object: Actor } {
+  return {
+    subject: registry.resolveActor(relationship.subjectActorId),
+    object: registry.resolveActor(relationship.objectActorId)
+  };
+}
+
+export function normalizeActorForPDP(actor: Actor): {
+  actorId: string;
+  actorType: string;
+  organizationId?: string;
+  trustLevel: string;
+  active: boolean;
+} {
+  return {
+    actorId: actor.actorId,
+    actorType: actor.actorType,
+    organizationId: actor.organizationId,
+    trustLevel: actor.trustLevel,
+    active: actor.active
+  };
+}

--- a/protocol/identity/delegation.ts
+++ b/protocol/identity/delegation.ts
@@ -1,0 +1,78 @@
+import { DelegationGrant, DelegationValidationResult } from './types';
+
+export function createDelegationGrant(input: {
+  grantId: string;
+  delegatorActorId: string;
+  delegateActorId: string;
+  allowedActions: string[];
+  allowedScopes: string[];
+  expiresAt?: string;
+  now?: Date;
+  metadata?: Record<string, unknown>;
+}): DelegationGrant {
+  const issuedAt = (input.now ?? new Date()).toISOString();
+  if (input.allowedActions.length === 0) throw new Error('allowedActions must be non-empty.');
+  if (input.allowedScopes.length === 0) throw new Error('allowedScopes must be non-empty.');
+
+  return {
+    grantId: input.grantId,
+    delegatorActorId: input.delegatorActorId,
+    delegateActorId: input.delegateActorId,
+    allowedActions: Array.from(new Set(input.allowedActions)),
+    allowedScopes: Array.from(new Set(input.allowedScopes)),
+    issuedAt,
+    expiresAt: input.expiresAt,
+    metadata: input.metadata
+  };
+}
+
+export function revokeDelegationGrant(grant: DelegationGrant, now: Date = new Date()): DelegationGrant {
+  return { ...grant, revokedAt: now.toISOString() };
+}
+
+export function validateDelegationGrant(
+  grant: DelegationGrant,
+  requestedAction: string,
+  requestedScopes: string[],
+  now: Date = new Date()
+): DelegationValidationResult {
+  const reasons: string[] = [];
+  const nowIso = now.toISOString();
+
+  if (grant.revokedAt && grant.revokedAt <= nowIso) reasons.push('GRANT_REVOKED');
+  if (grant.expiresAt && grant.expiresAt <= nowIso) reasons.push('GRANT_EXPIRED');
+  if (!grant.allowedActions.includes(requestedAction)) reasons.push('ACTION_NOT_ALLOWED');
+
+  const missingScopes = requestedScopes.filter((scope) => !grant.allowedScopes.includes(scope));
+  if (missingScopes.length > 0) reasons.push(`SCOPE_NOT_ALLOWED:${missingScopes.join(',')}`);
+
+  return { valid: reasons.length === 0, reasons };
+}
+
+export function listActiveDelegations(grants: DelegationGrant[], now: Date = new Date()): DelegationGrant[] {
+  const nowIso = now.toISOString();
+  return grants.filter((grant) => !grant.revokedAt && (!grant.expiresAt || grant.expiresAt > nowIso));
+}
+
+
+export function evaluateDelegationAwareAccess(input: {
+  grants: DelegationGrant[];
+  delegatorActorId: string;
+  delegateActorId: string;
+  action: string;
+  scopes: string[];
+  now?: Date;
+}): DelegationValidationResult {
+  const now = input.now ?? new Date();
+  const candidate = listActiveDelegations(input.grants, now).find(
+    (grant) =>
+      grant.delegatorActorId === input.delegatorActorId &&
+      grant.delegateActorId === input.delegateActorId
+  );
+
+  if (!candidate) {
+    return { valid: false, reasons: ['NO_ACTIVE_DELEGATION'] };
+  }
+
+  return validateDelegationGrant(candidate, input.action, input.scopes, now);
+}

--- a/protocol/identity/identity-reference.ts
+++ b/protocol/identity/identity-reference.ts
@@ -1,0 +1,31 @@
+import { IdentityReference, IdentityReferenceKind, VerificationStatus } from './types';
+
+export function createIdentityReference(input: {
+  referenceId: string;
+  actorId: string;
+  kind: IdentityReferenceKind;
+  value: string;
+  provider?: string;
+  verificationStatus?: VerificationStatus;
+  now?: Date;
+  metadata?: Record<string, unknown>;
+}): IdentityReference {
+  if (!input.referenceId || !input.actorId || !input.value) {
+    throw new Error('referenceId, actorId, and value are required.');
+  }
+
+  const nowIso = (input.now ?? new Date()).toISOString();
+
+  return {
+    referenceId: input.referenceId,
+    actorId: input.actorId,
+    kind: input.kind,
+    value: input.value,
+    provider: input.provider,
+    verificationStatus: input.verificationStatus ?? 'unverified',
+    verifiedAt: input.verificationStatus === 'verified' ? nowIso : undefined,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    metadata: input.metadata
+  };
+}

--- a/protocol/identity/trust-chain.ts
+++ b/protocol/identity/trust-chain.ts
@@ -1,0 +1,67 @@
+import { DelegationGrant, TrustChain } from './types';
+
+export function buildTrustChain(rootActorId: string, targetActorId: string, grants: DelegationGrant[], now: Date = new Date()): TrustChain {
+  const adjacency = new Map<string, DelegationGrant[]>();
+  for (const grant of grants) {
+    const existing = adjacency.get(grant.delegatorActorId) ?? [];
+    existing.push(grant);
+    adjacency.set(grant.delegatorActorId, existing);
+  }
+
+  const queue: Array<{ actorId: string; path: TrustChain['trustPath']; actors: string[] }> = [
+    { actorId: rootActorId, path: [], actors: [rootActorId] }
+  ];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) break;
+    if (current.actorId === targetActorId) {
+      return {
+        rootActorId,
+        delegatedActors: current.actors.slice(1),
+        trustPath: current.path,
+        chainValidity: 'valid',
+        evaluatedAt: now.toISOString(),
+        reasons: []
+      };
+    }
+
+    if (visited.has(current.actorId)) continue;
+    visited.add(current.actorId);
+
+    const outgoing = adjacency.get(current.actorId) ?? [];
+    for (const grant of outgoing) {
+      queue.push({
+        actorId: grant.delegateActorId,
+        path: [...current.path, { fromActorId: grant.delegatorActorId, toActorId: grant.delegateActorId, grantId: grant.grantId }],
+        actors: [...current.actors, grant.delegateActorId]
+      });
+    }
+  }
+
+  return {
+    rootActorId,
+    delegatedActors: [],
+    trustPath: [],
+    chainValidity: 'invalid',
+    evaluatedAt: now.toISOString(),
+    reasons: ['NO_TRUST_PATH']
+  };
+}
+
+export function validateTrustChain(chain: TrustChain, maxDepth: number): { valid: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+  if (chain.chainValidity !== 'valid') reasons.push('CHAIN_MARKED_INVALID');
+  if (chain.trustPath.length === 0) reasons.push('EMPTY_TRUST_PATH');
+  if (chain.trustPath.length > maxDepth) reasons.push('MAX_DELEGATION_DEPTH_EXCEEDED');
+
+  for (let i = 1; i < chain.trustPath.length; i++) {
+    if (chain.trustPath[i - 1].toActorId !== chain.trustPath[i].fromActorId) {
+      reasons.push('BROKEN_TRUST_LINK');
+      break;
+    }
+  }
+
+  return { valid: reasons.length === 0, reasons };
+}

--- a/protocol/identity/types.ts
+++ b/protocol/identity/types.ts
@@ -1,0 +1,82 @@
+export type ActorType =
+  | 'human'
+  | 'organization'
+  | 'brand'
+  | 'app'
+  | 'ai_agent'
+  | 'delegate'
+  | 'system';
+
+export type TrustLevel = 'untrusted' | 'baseline' | 'trusted' | 'high_assurance';
+
+export type VerificationStatus = 'unverified' | 'pending' | 'verified' | 'rejected';
+
+export type IdentityReferenceKind = 'internal' | 'did' | 'external_provider';
+
+export type IdentityReference = {
+  referenceId: string;
+  actorId: string;
+  kind: IdentityReferenceKind;
+  value: string;
+  provider?: string;
+  verificationStatus: VerificationStatus;
+  verifiedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type AIRestrictions = {
+  disallowAutonomousDelegation: boolean;
+  requireHumanEscalationForActions: string[];
+  blockedScopes: string[];
+};
+
+export type ActorAuthorityBoundary = {
+  maxDelegationDepth: number;
+  blockedActions: string[];
+  restrictedScopes: string[];
+  aiRestrictions: AIRestrictions;
+  requireHumanReview: boolean;
+};
+
+export type Actor = {
+  actorId: string;
+  actorType: ActorType;
+  displayName: string;
+  organizationId?: string;
+  parentActorId?: string;
+  trustLevel: TrustLevel;
+  active: boolean;
+  authorityBoundary: ActorAuthorityBoundary;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  deactivatedAt?: string;
+};
+
+export type DelegationGrant = {
+  grantId: string;
+  delegatorActorId: string;
+  delegateActorId: string;
+  allowedActions: string[];
+  allowedScopes: string[];
+  issuedAt: string;
+  expiresAt?: string;
+  revokedAt?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type TrustChain = {
+  rootActorId: string;
+  delegatedActors: string[];
+  trustPath: Array<{ fromActorId: string; toActorId: string; grantId: string }>;
+  chainValidity: 'valid' | 'invalid';
+  evaluatedAt: string;
+  reasons: string[];
+};
+
+export type DelegationValidationResult = {
+  valid: boolean;
+  reasons: string[];
+};


### PR DESCRIPTION
### Motivation
- Introduce a canonical, protocol-first actor identity model to replace weak/loose typing for actors and to support delegation, policy evaluation, and AI governance. 
- Provide deterministic, lightweight primitives for delegation and trust-chains so authority decisions can be proven and reasoned about without coupling to persistence or auth providers. 
- Add integration seams for PDP and relationship resolution while explicitly avoiding authentication, OAuth, wallets, UIs, and external IAM systems. 

### Description
- Adds a new `protocol/identity/` package with files: `types.ts`, `actor-object.ts`, `actor-registry.ts`, `identity-reference.ts`, `delegation.ts`, `trust-chain.ts`, and `README.md`. 
- Defines canonical types including `Actor`, `ActorType`, `ActorAuthorityBoundary`, `IdentityReference`, `DelegationGrant`, `TrustChain`, and `DelegationValidationResult` in `types.ts`. 
- Implements actor lifecycle primitives and defaults with `createActor` and `defaultAuthorityBoundary` in `actor-object.ts` and a lightweight adapter-backed registry (`InMemoryActorRegistryAdapter`) with `registerActor`, `updateActor`, `deactivateActor`, and `resolveActor` in `actor-registry.ts`. 
- Implements delegation lifecycle and validation (`createDelegationGrant`, `revokeDelegationGrant`, `validateDelegationGrant`, `listActiveDelegations`) and a delegation-aware helper `evaluateDelegationAwareAccess` in `delegation.ts`. 
- Implements deterministic trust-chain building and structural validation with `buildTrustChain` and `validateTrustChain` in `trust-chain.ts`. 
- Adds identity reference creation helper in `identity-reference.ts` and a focused `README.md` explaining design choices, delegation philosophy, and AI governance implications. 
- Adds small interoperability helpers (`resolveRelationshipActors`, `normalizeActorForPDP`) to ease future PDP/relationship integration without changing existing PDP logic. 

### Testing
- Ran a full-project type-check with `npx tsc --noEmit` which failed due to unrelated, pre-existing frontend and repo-level TypeScript configuration and dependency issues. 
- Successfully type-checked the new identity module files directly with `npx tsc --noEmit --target ES2020 --module commonjs protocol/identity/*.ts`, which completed without errors. 
- Created the new files and validated that the identity primitives compile in isolation, with no runtime or persistence dependencies introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd5f99cf083259dd819d88e7b5639)