### PR TITLE
Add durable in-memory audit plane with normalization, correlation, and hooks

### DIFF
--- a/protocol/audit/README.md
+++ b/protocol/audit/README.md
@@ -1,0 +1,27 @@
+# Durable Audit Plane (AOC Core)
+
+This module defines protocol-grade **audit infrastructure** for governance decisions. Audit is not operator logging: it is canonical evidence for why governance allowed, denied, escalated, or revoked an action.
+
+## Why this exists
+- PDP, identity, relationships, delegation, and AI governance each emit decision signals.
+- Without normalization, explainability and traceability are fragmented.
+- The audit plane creates one canonical event model for future replay, compliance export, and cross-module reasoning.
+
+## Logging vs. Audit
+- Logging is implementation diagnostics.
+- Audit is governance evidence with stable semantics (`decision`, `reasons`, `obligations`, trace references, and relationship/delegation links).
+
+## System relationship
+- PDP contributes policy traces and decisions.
+- Identity-policy contributes denial reasons, delegation IDs, trust-chain references, and AI restrictions.
+- Relationship lifecycle contributes state transitions.
+- Delegation contributes grant create/revoke and validation outcomes.
+- AI governance contributes blocked scopes + escalation obligations.
+
+## Explainability goals
+- Deterministically reconstruct why access was denied/allowed.
+- Rebuild relationship and delegation timelines.
+- Surface AI escalation and human-review obligations.
+
+## Future compliance and forensic replay
+This phase is intentionally in-memory only. Canonical schemas and correlations are the foundation for future durable storage, retention policy enforcement, and forensic replay pipelines without changing event semantics.

--- a/protocol/audit/__tests__/audit-plane.test.ts
+++ b/protocol/audit/__tests__/audit-plane.test.ts
@@ -1,0 +1,63 @@
+import { createDelegationGrant, revokeDelegationGrant } from '../../identity/delegation';
+import { evaluateAccessWithIdentity, registerIdentityDecisionAuditHook } from '../../identity-policy/identity-pdp-adapter';
+import { type Actor, type DelegationGrant } from '../../identity/types';
+import { evaluateAccess, registerPolicyDecisionAuditHook } from '../../policy/pdp';
+import { createRelationship, activateRelationship, revokeRelationship } from '../../relationships/relationship-lifecycle';
+import { InMemoryAuditPlane } from '../audit-plane';
+import { createCorrelation, attachRelatedEvent } from '../audit-correlation';
+import { normalizeAuditEvent } from '../audit-normalization';
+
+const baseActor: Actor = {
+  actorId: 'actor-1', actorType: 'human', displayName: 'Actor', trustLevel: 'trusted', active: true, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), authorityBoundary: { maxDelegationDepth: 2, blockedActions: [], restrictedScopes: [], requireHumanReview: false, aiRestrictions: { blockedScopes: [], disallowAutonomousDelegation: false, requireHumanEscalationForActions: [] } }
+};
+
+describe('durable audit plane', () => {
+  it('normalizes heterogeneous events', () => {
+    const event = normalizeAuditEvent({ event_id: 'e1', allow: false, reason: 'DENY_ACTION', subject_id: 'a1', traceId: 't1' });
+    expect(event.eventId).toBe('e1');
+    expect(event.decision).toBe('deny');
+    expect(event.policyTraceId).toBe('t1');
+  });
+
+  it('creates and attaches correlated events', () => {
+    const plane = new InMemoryAuditPlane();
+    const root = plane.emitAuditEvent({ eventType: 'policy_decision', actorId: 'a1', allow: true, traceId: 'tr-1' });
+    const corr = createCorrelation(root);
+    const child = plane.emitAuditEvent({ eventType: 'delegation_created', actorId: 'a1' });
+    const updated = attachRelatedEvent(corr, child);
+    expect(updated.relatedEventIds).toContain(root.eventId);
+    expect(updated.relatedEventIds).toContain(child.eventId);
+  });
+
+  it('emits PDP decision audit hooks', () => {
+    const plane = new InMemoryAuditPlane();
+    registerPolicyDecisionAuditHook((event) => plane.emitAuditEvent(event));
+    evaluateAccess({ actor: { id: 'a1', type: 'human' }, action: 'write', permission: { action: 'read' }, resource: { id: 'r1', type: 'record' } });
+    expect(plane.listAuditEvents().some((e) => e.eventType === 'policy_decision')).toBe(true);
+  });
+
+  it('emits identity denied and AI escalation events', () => {
+    const plane = new InMemoryAuditPlane();
+    registerIdentityDecisionAuditHook((event) => plane.emitAuditEvent(event));
+    const grant: DelegationGrant = createDelegationGrant({ grantId: 'g1', delegatorActorId: 'root', delegateActorId: 'ai1', allowedActions: ['read'], allowedScopes: ['scope:ok'] });
+    const aiActor: Actor = { ...baseActor, actorId: 'ai1', actorType: 'ai_agent', authorityBoundary: { ...baseActor.authorityBoundary, aiRestrictions: { blockedScopes: ['scope:blocked'], disallowAutonomousDelegation: false, requireHumanEscalationForActions: ['delete'] } } };
+    evaluateAccessWithIdentity({ identity: { actor: aiActor, rootActor: { ...baseActor, actorId: 'root' }, delegateActor: aiActor, delegationGrants: [grant], requestedAction: 'delete', requestedScopes: ['scope:blocked'] }, policyInput: { permission: { action: 'delete' }, resource: { id: 'r1', type: 'record' } } });
+    const events = plane.listAuditEvents();
+    expect(events.some((e) => e.eventType === 'ai_scope_blocked' || e.eventType === 'identity_denied')).toBe(true);
+  });
+
+  it('emits relationship lifecycle and delegation grant changes', () => {
+    const plane = new InMemoryAuditPlane();
+    const relationship = createRelationship({ id: 'rel-1', type: 'employment', actors: [{ actorId: 'a', role: 'subject', actorType: 'human' }, { actorId: 'b', role: 'organization', actorType: 'organization' }] });
+    plane.emitAuditEvent({ eventType: 'relationship_created', relationshipId: relationship.id, actorId: 'a' });
+    const active = activateRelationship(relationship);
+    plane.emitAuditEvent({ eventType: 'relationship_activated', relationshipId: active.id, actorId: 'a' });
+    const revoked = revokeRelationship(active);
+    plane.emitAuditEvent({ eventType: 'relationship_revoked', relationshipId: revoked.id, actorId: 'a' });
+    const grant = createDelegationGrant({ grantId: 'g-1', delegatorActorId: 'a', delegateActorId: 'b', allowedActions: ['read'], allowedScopes: ['s1'] });
+    plane.emitAuditEvent({ eventType: 'delegation_created', actorId: 'a', targetActorId: 'b', delegationGrantIds: [grant.grantId] });
+    const revokedGrant = revokeDelegationGrant(grant);
+    plane.emitAuditEvent({ eventType: 'delegation_revoked', actorId: 'a', targetActorId: 'b', delegationGrantIds: [revokedGrant.grantId] });
+    expect(plane.getEventsForRelationship('rel-1')).toHaveLength(3);
+  });
+});

--- a/protocol/audit/audit-correlation.ts
+++ b/protocol/audit/audit-correlation.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from 'crypto';
+import type { AuditCorrelation, AuditEvent } from './types';
+
+export function createCorrelation(rootEvent: AuditEvent): AuditCorrelation {
+  return {
+    correlationId: randomUUID(),
+    rootEventId: rootEvent.eventId,
+    relatedEventIds: [rootEvent.eventId],
+    traceIds: rootEvent.policyTraceId ? [rootEvent.policyTraceId] : [],
+    actorRefs: [rootEvent.actorId, rootEvent.targetActorId].filter((v): v is string => Boolean(v)),
+  };
+}
+
+export function attachRelatedEvent(correlation: AuditCorrelation, event: AuditEvent): AuditCorrelation {
+  return {
+    ...correlation,
+    relatedEventIds: Array.from(new Set([...correlation.relatedEventIds, event.eventId])),
+    traceIds: event.policyTraceId ? Array.from(new Set([...correlation.traceIds, event.policyTraceId])) : correlation.traceIds,
+    actorRefs: Array.from(new Set([...correlation.actorRefs, event.actorId, event.targetActorId].filter((v): v is string => Boolean(v)))),
+  };
+}
+
+export function resolveCorrelation(correlation: AuditCorrelation, events: AuditEvent[]): AuditEvent[] {
+  const ids = new Set(correlation.relatedEventIds);
+  return events.filter((event) => ids.has(event.eventId)).sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+}

--- a/protocol/audit/audit-event.ts
+++ b/protocol/audit/audit-event.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from 'crypto';
+import type { AuditDecision, AuditEvent, AuditEventInput, AuditEventType } from './types';
+
+export function createAuditEvent(input: AuditEventInput): AuditEvent {
+  return {
+    eventId: input.eventId ?? randomUUID(),
+    eventType: input.eventType,
+    timestamp: normalizeTimestamp(input.timestamp),
+    actorId: input.actorId,
+    targetActorId: input.targetActorId,
+    relationshipId: input.relationshipId,
+    policyTraceId: input.policyTraceId,
+    delegationGrantIds: input.delegationGrantIds ?? [],
+    trustChainRef: input.trustChainRef,
+    resourceId: input.resourceId,
+    action: input.action,
+    decision: input.decision,
+    reasons: input.reasons ?? [],
+    obligations: input.obligations ?? [],
+    metadata: input.metadata ?? {},
+  };
+}
+
+export function inferEventTypeFromDecision(decision: AuditDecision, aiEscalation = false, aiScopeBlocked = false): AuditEventType {
+  if (aiScopeBlocked) return 'ai_scope_blocked';
+  if (aiEscalation) return 'ai_escalation_required';
+  return 'policy_decision';
+}
+
+function normalizeTimestamp(value?: Date | string): string {
+  if (!value) return new Date().toISOString();
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+}

--- a/protocol/audit/audit-normalization.ts
+++ b/protocol/audit/audit-normalization.ts
@@ -1,0 +1,44 @@
+import { createAuditEvent, inferEventTypeFromDecision } from './audit-event';
+import type { AuditEvent, AuditEventInput } from './types';
+
+export function normalizeAuditEvent(input: Record<string, unknown>): AuditEvent {
+  const explicitType = typeof input.eventType === 'string' ? input.eventType : undefined;
+  const reasons = asStringArray(input.reasons ?? input.identityReasons ?? input.reason);
+  const obligations = asStringArray(input.obligations);
+  const aiEscalation = obligations.includes('OBLIGATION_AI_ESCALATION_REQUIRED');
+  const aiScopeBlocked = reasons.includes('DENY_AI_SCOPE_BLOCKED');
+  const decision = inferDecision(input);
+  const eventType = (explicitType as AuditEventInput['eventType'] | undefined) ?? inferEventTypeFromDecision(decision, aiEscalation, aiScopeBlocked);
+
+  return createAuditEvent({
+    eventId: asString(input.eventId ?? input.event_id),
+    eventType,
+    timestamp: asDateish(input.timestamp ?? input.occurred_at),
+    actorId: asString(input.actorId ?? input.actor_id ?? input.subject_id),
+    targetActorId: asString(input.targetActorId ?? input.requester_id),
+    relationshipId: asString(input.relationshipId),
+    policyTraceId: asString(input.policyTraceId ?? input.traceId),
+    delegationGrantIds: asStringArray(input.delegationGrantIds ?? input.delegation_grant_ids),
+    trustChainRef: asString(input.trustChainRef),
+    resourceId: asString(input.resourceId ?? input.resource),
+    action: asString(input.action),
+    decision,
+    reasons,
+    obligations,
+    metadata: (input.metadata as Record<string, unknown> | undefined) ?? {},
+  });
+}
+
+function inferDecision(input: Record<string, unknown>) {
+  if (typeof input.decision === 'string') return input.decision as any;
+  if (typeof input.allow === 'boolean') return input.allow ? 'allow' : 'deny';
+  if (typeof input.allowed === 'boolean') return input.allowed ? 'allow' : 'deny';
+  return 'unknown' as const;
+}
+const asString = (value: unknown) => (typeof value === 'string' && value.length > 0 ? value : undefined);
+const asDateish = (value: unknown) => (value instanceof Date || typeof value === 'string' ? value : undefined);
+function asStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+  if (typeof value === 'string') return [value];
+  return [];
+}

--- a/protocol/audit/audit-plane.ts
+++ b/protocol/audit/audit-plane.ts
@@ -1,0 +1,57 @@
+import { attachRelatedEvent, createCorrelation } from './audit-correlation';
+import { normalizeAuditEvent } from './audit-normalization';
+import { getAIEscalationEvents, getDeniedActions, getEventsForActor, getEventsForRelationship, getEventsForTrace } from './audit-query';
+import type { AuditCorrelation, AuditEvent, AuditQueryFilter } from './types';
+
+export class InMemoryAuditPlane {
+  private readonly events: AuditEvent[] = [];
+  private readonly correlations = new Map<string, AuditCorrelation>();
+
+  emitAuditEvent(input: Record<string, unknown>): AuditEvent {
+    const event = normalizeAuditEvent(input);
+    this.events.push(event);
+    return event;
+  }
+
+  emitCorrelatedAuditEvent(correlationId: string, input: Record<string, unknown>): AuditEvent {
+    const event = this.emitAuditEvent(input);
+    const correlation = this.correlations.get(correlationId);
+    if (!correlation) throw new Error(`Unknown correlation: ${correlationId}`);
+    this.correlations.set(correlationId, attachRelatedEvent(correlation, event));
+    return event;
+  }
+
+  listAuditEvents(): AuditEvent[] { return [...this.events]; }
+
+  queryAuditEvents(filter: AuditQueryFilter): AuditEvent[] {
+    return this.events.filter((event) => {
+      if (filter.actorId && event.actorId !== filter.actorId && event.targetActorId !== filter.actorId) return false;
+      if (filter.relationshipId && event.relationshipId !== filter.relationshipId) return false;
+      if (filter.eventType && event.eventType !== filter.eventType) return false;
+      if (filter.decision && event.decision !== filter.decision) return false;
+      if (filter.traceId && event.policyTraceId !== filter.traceId) return false;
+      const ts = Date.parse(event.timestamp);
+      if (filter.from && ts < filter.from.getTime()) return false;
+      if (filter.to && ts > filter.to.getTime()) return false;
+      return true;
+    });
+  }
+
+  createCorrelationFromEvent(event: AuditEvent): AuditCorrelation {
+    const correlation = createCorrelation(event);
+    this.correlations.set(correlation.correlationId, correlation);
+    return correlation;
+  }
+
+  resolveCorrelation(correlationId: string): AuditEvent[] {
+    const correlation = this.correlations.get(correlationId);
+    if (!correlation) return [];
+    return this.events.filter((event) => correlation.relatedEventIds.includes(event.eventId));
+  }
+
+  getEventsForActor = (actorId: string) => getEventsForActor(this.events, actorId);
+  getEventsForRelationship = (relationshipId: string) => getEventsForRelationship(this.events, relationshipId);
+  getEventsForTrace = (traceId: string) => getEventsForTrace(this.events, traceId);
+  getDeniedActions = () => getDeniedActions(this.events);
+  getAIEscalationEvents = () => getAIEscalationEvents(this.events);
+}

--- a/protocol/audit/audit-query.ts
+++ b/protocol/audit/audit-query.ts
@@ -1,0 +1,17 @@
+import type { AuditEvent } from './types';
+
+export function getEventsForActor(events: AuditEvent[], actorId: string): AuditEvent[] {
+  return events.filter((event) => event.actorId === actorId || event.targetActorId === actorId);
+}
+export function getEventsForRelationship(events: AuditEvent[], relationshipId: string): AuditEvent[] {
+  return events.filter((event) => event.relationshipId === relationshipId);
+}
+export function getEventsForTrace(events: AuditEvent[], traceId: string): AuditEvent[] {
+  return events.filter((event) => event.policyTraceId === traceId);
+}
+export function getDeniedActions(events: AuditEvent[]): AuditEvent[] {
+  return events.filter((event) => event.decision === 'deny');
+}
+export function getAIEscalationEvents(events: AuditEvent[]): AuditEvent[] {
+  return events.filter((event) => event.eventType === 'ai_escalation_required' || event.obligations.includes('OBLIGATION_AI_ESCALATION_REQUIRED'));
+}

--- a/protocol/audit/index.ts
+++ b/protocol/audit/index.ts
@@ -1,2 +1,10 @@
 export * from './types';
 export * from './builders';
+export * from './audit-event';
+export * from './audit-plane';
+export * from './audit-correlation';
+export * from './audit-query';
+export * from './audit-normalization';
+
+export { LEGACY_AUDIT_EVENT_TYPES as AUDIT_EVENT_TYPES } from './types';
+export type { LegacyAuditEvent as AuditEventLegacy, LegacyAuditEventQuery as AuditEventQuery, LegacyAuditEventType as AuditEventTypeLegacy } from './types';

--- a/protocol/audit/types.ts
+++ b/protocol/audit/types.ts
@@ -1,34 +1,77 @@
-export const AUDIT_EVENT_TYPES = [
+export type AuditDecision = 'allow' | 'deny' | 'conditional' | 'unknown';
+
+export type AuditEventType =
+  | 'policy_decision'
+  | 'relationship_created'
+  | 'relationship_activated'
+  | 'relationship_revoked'
+  | 'delegation_created'
+  | 'delegation_revoked'
+  | 'identity_denied'
+  | 'ai_escalation_required'
+  | 'ai_scope_blocked'
+  | 'intent_activated'
+  | 'audience_access_evaluated';
+
+export type AuditEvent = {
+  eventId: string;
+  eventType: AuditEventType;
+  timestamp: string;
+  actorId?: string;
+  targetActorId?: string;
+  relationshipId?: string;
+  policyTraceId?: string;
+  delegationGrantIds: string[];
+  trustChainRef?: string;
+  resourceId?: string;
+  action?: string;
+  decision?: AuditDecision;
+  reasons: string[];
+  obligations: string[];
+  metadata: Record<string, unknown>;
+};
+
+export type AuditEventInput = Omit<AuditEvent, 'eventId' | 'timestamp' | 'delegationGrantIds' | 'reasons' | 'obligations' | 'metadata'> & {
+  eventId?: string;
+  timestamp?: Date | string;
+  delegationGrantIds?: string[];
+  reasons?: string[];
+  obligations?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+export type AuditCorrelation = {
+  correlationId: string;
+  rootEventId: string;
+  relatedEventIds: string[];
+  traceIds: string[];
+  actorRefs: string[];
+};
+
+export type AuditQueryFilter = {
+  actorId?: string;
+  relationshipId?: string;
+  eventType?: AuditEventType;
+  decision?: AuditDecision;
+  from?: Date;
+  to?: Date;
+  traceId?: string;
+};
+
+// legacy runtime audit contract retained for compatibility
+export const LEGACY_AUDIT_EVENT_TYPES = [
   'CONSENT_EVALUATED',
   'CAPABILITY_ISSUED',
   'CAPABILITY_VALIDATED',
   'CAPABILITY_AUTHORIZED',
   'CAPABILITY_DENIED',
 ] as const;
-
-export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number];
-
-export type AuditEvent = {
-  event_id: string;
-  event_type: AuditEventType;
-  occurred_at: string;
-  allowed?: boolean;
-  reason_code?: string;
-  subject_id?: string;
-  requester_id?: string;
-  resource?: string;
-  action?: string;
-  consent_id?: string | null;
-  capability_id?: string | null;
+export type LegacyAuditEventType = (typeof LEGACY_AUDIT_EVENT_TYPES)[number];
+export type LegacyAuditEvent = {
+  event_id: string; event_type: LegacyAuditEventType; occurred_at: string; allowed?: boolean; reason_code?: string;
+  subject_id?: string; requester_id?: string; resource?: string; action?: string; consent_id?: string | null; capability_id?: string | null;
   metadata?: Record<string, unknown>;
 };
-
-export type AuditEventQuery = {
-  event_type?: AuditEventType;
-  subject_id?: string;
-  requester_id?: string;
-  consent_id?: string;
-  capability_id?: string;
-  from?: Date;
-  to?: Date;
+export type LegacyAuditEventQuery = {
+  event_type?: LegacyAuditEventType; subject_id?: string; requester_id?: string; consent_id?: string; capability_id?: string; from?: Date; to?: Date;
 };

--- a/protocol/identity-policy/identity-pdp-adapter.ts
+++ b/protocol/identity-policy/identity-pdp-adapter.ts
@@ -1,3 +1,4 @@
+import type { IdentityPolicyContext } from './types';
 import { evaluateAccess } from '../policy/pdp';
 import type { PolicyDecision } from '../policy/types';
 import { evaluateIdentityPolicy } from './identity-policy-evaluator';
@@ -15,7 +16,8 @@ export function evaluateAccessWithIdentity(input: EvaluateAccessWithIdentityInpu
       evaluatedPolicies: ['policy.identity.precheck']
     };
 
-    return {
+    identityDecisionAuditHook?.({ eventType: 'identity_denied', actorId: input.identity.actor.actorId, action: input.identity.requestedAction, allow: false, reasons: identityDecision.reasons, obligations: identityDecision.obligations, delegationGrantIds: identityDecision.delegationGrantIds, trustChainRef: identityDecision.trustChainSummary?.rootActorId, metadata: { aiGovernanceFlags: identityDecision.aiGovernanceFlags } });
+  return {
       ...denied,
       identityReasons: identityDecision.reasons,
       identityTrace: {
@@ -40,6 +42,24 @@ export function evaluateAccessWithIdentity(input: EvaluateAccessWithIdentityInpu
     action: input.policyInput.action ?? input.identity.requestedAction
   });
 
+
+  identityDecisionAuditHook?.({
+    eventType: identityDecision.aiGovernanceFlags.blockedByAIScopeRestriction
+      ? 'ai_scope_blocked'
+      : identityDecision.aiGovernanceFlags.sensitiveActionEscalationRequired
+        ? 'ai_escalation_required'
+        : 'policy_decision',
+    actorId: input.identity.actor.actorId,
+    action: input.identity.requestedAction,
+    allow: pdpDecision.allow,
+    reasons: identityDecision.reasons,
+    obligations: Array.from(new Set([...(pdpDecision.obligations ?? []), ...identityDecision.obligations])),
+    traceId: pdpDecision.traceId,
+    delegationGrantIds: identityDecision.delegationGrantIds,
+    trustChainRef: identityDecision.trustChainSummary?.rootActorId,
+    metadata: { aiGovernanceFlags: identityDecision.aiGovernanceFlags }
+  });
+
   return {
     ...pdpDecision,
     obligations: Array.from(new Set([...(pdpDecision.obligations ?? []), ...identityDecision.obligations])),
@@ -52,3 +72,8 @@ export function evaluateAccessWithIdentity(input: EvaluateAccessWithIdentityInpu
     }
   };
 }
+
+
+export type IdentityDecisionAuditHook = (event: Record<string, unknown>) => void;
+let identityDecisionAuditHook: IdentityDecisionAuditHook | undefined;
+export function registerIdentityDecisionAuditHook(hook: IdentityDecisionAuditHook | undefined): void { identityDecisionAuditHook = hook; }

--- a/protocol/policy/pdp.ts
+++ b/protocol/policy/pdp.ts
@@ -30,6 +30,7 @@ function deny(
     resourceId: input.resource.id,
   };
   recordDecisionTrace(trace);
+  policyDecisionAuditHook?.({ eventType: 'policy_decision', traceId, actorId: input.actor.id, resourceId: input.resource.id, action: input.action, allow: true, reason, obligations, metadata: { evaluatedPolicies } });
 
   return {
     allow: false,
@@ -100,6 +101,7 @@ export function evaluateAccess(input: PolicyEvaluationInput): PolicyDecision {
     resourceId: input.resource.id,
   };
   recordDecisionTrace(trace);
+  policyDecisionAuditHook?.({ eventType: 'policy_decision', traceId, actorId: input.actor.id, resourceId: input.resource.id, action: input.action, allow: false, reason, obligations, metadata: { evaluatedPolicies } });
 
   return {
     allow: true,
@@ -109,3 +111,8 @@ export function evaluateAccess(input: PolicyEvaluationInput): PolicyDecision {
     evaluatedPolicies,
   };
 }
+
+
+export type PolicyDecisionAuditHook = (event: Record<string, unknown>) => void;
+let policyDecisionAuditHook: PolicyDecisionAuditHook | undefined;
+export function registerPolicyDecisionAuditHook(hook: PolicyDecisionAuditHook | undefined): void { policyDecisionAuditHook = hook; }


### PR DESCRIPTION
### Motivation
- Consolidate fragmented audit signals from PDP, identity-policy, relationships and delegation into a single canonical audit plane to improve explainability and traceability. 
- Provide first-class support for AI governance signals (blocked scopes, escalation obligations, human-review flags) without adding persistence or external infrastructure. 
- Preserve compatibility with existing runtime audit contracts while preparing a deterministic, replayable event model for future durability and compliance work. 

### Description
- Introduced a new `protocol/audit` module with canonical types in `types.ts`, event builder in `audit-event.ts`, normalization in `audit-normalization.ts`, correlation in `audit-correlation.ts`, query helpers in `audit-query.ts`, and an in-memory plane in `audit-plane.ts`, plus a `README.md` documenting intent. 
- Implemented `normalizeAuditEvent()` to convert heterogeneous payloads (legacy snake_case, PDP/identity emissions, AI flags) into a canonical `AuditEvent`, and `createAuditEvent()` + `inferEventTypeFromDecision()` for stable construction and event-type inference. 
- Added correlation primitives `createCorrelation()`, `attachRelatedEvent()`, and `resolveCorrelation()` and lightweight query helpers `getEventsForActor()`, `getEventsForRelationship()`, `getEventsForTrace()`, `getDeniedActions()`, and `getAIEscalationEvents()`. 
- Added composable emit hooks: `registerPolicyDecisionAuditHook()` in `protocol/policy/pdp.ts` and `registerIdentityDecisionAuditHook()` in `protocol/identity-policy/identity-pdp-adapter.ts`, and preserved legacy audit types for backward compatibility. 

### Testing
- Ran the targeted test file with `npm test -- --runTestsByPath protocol/audit/__tests__/audit-plane.test.ts`, which executed 5 tests and all passed. 
- Tests exercise normalization, correlation/attachment semantics, PDP hook emission, identity denial/AI escalation emission, and relationship + delegation lifecycle emissions, and they all succeeded. 
- Note: tests target the in-memory plane and hooks only and do not cover durable storage, concurrency, or large-scale performance characteristics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce00a69708325b96847cd1f56b16b)