### PR TITLE
Add Runtime Governance Layer orchestration primitives for AOC Core

### DIFF
--- a/runtime/governance/README.md
+++ b/runtime/governance/README.md
@@ -1,0 +1,42 @@
+# AOC Runtime Governance Layer
+
+This module introduces the canonical governance execution runtime for AOC Core.
+
+## Why this runtime exists
+
+PDP, identity policy, relationship state, and audit each existed as separate protocol primitives. This runtime coordinates them into deterministic execution semantics for real governance decisions.
+
+## Policy evaluation vs governance orchestration
+
+- **Policy evaluation (PDP / identity-policy):** computes decision context, reason codes, obligations, and governance flags.
+- **Governance orchestration (this module):** turns those outputs into runtime state transitions, executable obligations, escalation paths, and human-review checkpoints.
+
+## Obligation execution philosophy
+
+Obligations are represented as first-class runtime objects (`pending` / `completed` / `failed`) and are tracked in-session. They are not externally executed by engines yet; the runtime only enforces deterministic obligation lifecycle and failure propagation.
+
+## AI escalation semantics
+
+AI governance flags can trigger:
+
+- explicit escalation records
+- runtime transition to `escalated`
+- optional human review transition to `awaiting_human_review`
+
+Escalations must be resolved before completion paths can continue.
+
+## Human review semantics
+
+Human review is modeled as protocol-level primitives (`create`, `approve`, `deny`) with strict state implications:
+
+- pending review gates completion
+- approval returns runtime to evaluation
+- denial transitions governance outcome to denied
+
+## Audit continuity goals
+
+The runtime supports lightweight audit propagation hooks so governance orchestration emits canonical events without rewriting the durable audit plane.
+
+## Future enterprise implications
+
+This module intentionally avoids workflow engines, distributed infra, queues, and UI concerns. It establishes deterministic governance semantics now, so enterprise orchestration can later scale without semantic drift.

--- a/runtime/governance/__tests__/governance-runtime.test.ts
+++ b/runtime/governance/__tests__/governance-runtime.test.ts
@@ -1,0 +1,119 @@
+import { GovernanceRuntime } from '../governance-runtime';
+import { completeGovernanceSession, createGovernanceSession, startGovernanceEvaluation } from '../governance-session';
+import { createEscalation, getActiveEscalations, resolveEscalation } from '../escalation-runtime';
+import { approveHumanReview, createHumanReviewRequest, denyHumanReview } from '../human-review';
+import { completeObligation, failObligation, listPendingObligations, registerObligation } from '../obligation-runtime';
+
+describe('runtime/governance', () => {
+  it('runs governance session lifecycle', () => {
+    let session = createGovernanceSession({
+      sessionId: 'sess_1',
+      actorId: 'actor_1',
+      relationshipId: 'rel_1',
+      policyTraceId: 'trace_1',
+      startedAt: '2026-01-01T00:00:00Z',
+    });
+
+    session = startGovernanceEvaluation(session);
+    session = registerObligation(session, { obligationId: 'obl_1', obligationType: 'purpose_assertion' });
+    session = completeObligation(session, 'obl_1');
+    session = completeGovernanceSession(session, '2026-01-01T00:05:00Z');
+
+    expect(session.runtimeState).toBe('completed');
+    expect(session.completedAt).toBe('2026-01-01T00:05:00Z');
+  });
+
+  it('tracks obligation registration and pending list', () => {
+    let session = startGovernanceEvaluation(
+      createGovernanceSession({ sessionId: 'sess_2', actorId: 'actor_2', relationshipId: 'rel_2', policyTraceId: 'trace_2' })
+    );
+    session = registerObligation(session, { obligationId: 'obl_1', obligationType: 'consent_reaffirmation' });
+    session = registerObligation(session, { obligationId: 'obl_2', obligationType: 'relationship_validation' });
+    session = completeObligation(session, 'obl_1');
+
+    const pending = listPendingObligations(session);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].obligationId).toBe('obl_2');
+  });
+
+  it('handles escalation creation and resolution', () => {
+    const session = startGovernanceEvaluation(
+      createGovernanceSession({ sessionId: 'sess_3', actorId: 'actor_3', relationshipId: 'rel_3', policyTraceId: 'trace_3' })
+    );
+    const created = createEscalation(session, {
+      escalationId: 'esc_1',
+      escalationType: 'blocked_scope',
+      triggeredBy: 'pdp',
+      targetActorId: 'actor_3',
+      reasonCodes: ['SCOPE_BLOCKED'],
+    });
+
+    const active = getActiveEscalations([created.escalation]);
+    expect(active).toHaveLength(1);
+
+    const resolved = resolveEscalation(created.escalation);
+    expect(resolved.status).toBe('resolved');
+  });
+
+  it('supports human review approval and denial paths', () => {
+    let session = startGovernanceEvaluation(
+      createGovernanceSession({ sessionId: 'sess_4', actorId: 'actor_4', relationshipId: 'rel_4', policyTraceId: 'trace_4' })
+    );
+    const created = createHumanReviewRequest(session, {
+      reviewId: 'rev_1',
+      actorId: 'actor_4',
+      requestedAction: 'sensitive_write',
+      requestedScopes: ['records:write'],
+      reasonCodes: ['SENSITIVE_ACTION'],
+    });
+    expect(created.session.runtimeState).toBe('awaiting_human_review');
+
+    const approved = approveHumanReview(created.session, created.review);
+    expect(approved.review.reviewStatus).toBe('approved');
+    expect(approved.session.runtimeState).toBe('evaluating');
+
+    const denied = denyHumanReview(created.session, { ...created.review, reviewId: 'rev_2' });
+    expect(denied.review.reviewStatus).toBe('denied');
+    expect(denied.session.runtimeState).toBe('denied');
+  });
+
+  it('enforces governance state transition constraints', () => {
+    const session = createGovernanceSession({ sessionId: 'sess_5', actorId: 'actor_5', relationshipId: 'rel_5', policyTraceId: 'trace_5' });
+    expect(() => completeGovernanceSession(session)).toThrow('Invalid governance state transition: pending -> approved');
+  });
+
+  it('propagates failed obligations to failed governance session', () => {
+    let session = startGovernanceEvaluation(
+      createGovernanceSession({ sessionId: 'sess_6', actorId: 'actor_6', relationshipId: 'rel_6', policyTraceId: 'trace_6' })
+    );
+    session = registerObligation(session, { obligationId: 'obl_fail', obligationType: 'frequency_enforcement' });
+    session = failObligation(session, 'obl_fail');
+
+    expect(session.runtimeState).toBe('failed');
+  });
+
+  it('runs ai escalation and human review orchestration hooks', () => {
+    const events: string[] = [];
+    const runtime = new GovernanceRuntime({ auditHook: (eventType) => events.push(eventType) });
+
+    let session = runtime.startGovernanceEvaluation(
+      runtime.createGovernanceSession({
+        sessionId: 'sess_7',
+        actorId: 'actor_7',
+        relationshipId: 'rel_7',
+        policyTraceId: 'trace_7',
+      })
+    );
+
+    const applied = runtime.applyIdentityGovernanceFlags(session, {
+      requiresEscalation: true,
+      requiresHumanReview: true,
+      reasonCodes: ['AI_FLAGGED'],
+    });
+
+    expect(applied.session.runtimeState).toBe('awaiting_human_review');
+    expect(applied.escalations).toHaveLength(1);
+    expect(applied.humanReview?.reviewStatus).toBe('pending');
+    expect(events).toContain('AI_GOVERNANCE_FLAGS_APPLIED');
+  });
+});

--- a/runtime/governance/escalation-runtime.ts
+++ b/runtime/governance/escalation-runtime.ts
@@ -1,0 +1,35 @@
+import { setSessionState } from './governance-session';
+import type { EscalationPath, EscalationType, GovernanceSession } from './types';
+
+export function createEscalation(
+  session: GovernanceSession,
+  input: {
+    escalationId: string;
+    escalationType: EscalationType;
+    triggeredBy: string;
+    targetActorId: string;
+    reasonCodes: string[];
+    createdAt?: string;
+  }
+): { session: GovernanceSession; escalation: EscalationPath } {
+  const escalation: EscalationPath = {
+    escalationId: input.escalationId,
+    escalationType: input.escalationType,
+    triggeredBy: input.triggeredBy,
+    targetActorId: input.targetActorId,
+    reasonCodes: input.reasonCodes,
+    status: 'active',
+    createdAt: input.createdAt ?? new Date().toISOString(),
+  };
+  const nextSession = setSessionState({ ...session, escalationRefs: [...session.escalationRefs, escalation.escalationId] }, 'escalated');
+  return { session: nextSession, escalation };
+}
+
+export function resolveEscalation(escalation: EscalationPath, resolvedAt?: string): EscalationPath {
+  if (escalation.status === 'resolved') return escalation;
+  return { ...escalation, status: 'resolved', resolvedAt: resolvedAt ?? new Date().toISOString() };
+}
+
+export function getActiveEscalations(escalations: readonly EscalationPath[]): EscalationPath[] {
+  return escalations.filter((entry) => entry.status === 'active');
+}

--- a/runtime/governance/governance-runtime.ts
+++ b/runtime/governance/governance-runtime.ts
@@ -1,0 +1,111 @@
+import {
+  completeGovernanceSession,
+  createGovernanceSession,
+  failGovernanceSession,
+  setSessionState,
+  startGovernanceEvaluation,
+} from './governance-session';
+import { createEscalation, resolveEscalation } from './escalation-runtime';
+import { approveHumanReview, createHumanReviewRequest, denyHumanReview } from './human-review';
+import { completeObligation, failObligation, registerObligation } from './obligation-runtime';
+import type {
+  AiGovernanceFlags,
+  AuditHook,
+  EscalationPath,
+  GovernanceObligation,
+  GovernanceSession,
+  HumanReviewRequest,
+  RelationshipValidationHook,
+} from './types';
+
+export class GovernanceRuntime {
+  private readonly auditHook?: AuditHook;
+  private readonly relationshipValidationHook?: RelationshipValidationHook;
+
+  constructor(deps: { auditHook?: AuditHook; relationshipValidationHook?: RelationshipValidationHook } = {}) {
+    this.auditHook = deps.auditHook;
+    this.relationshipValidationHook = deps.relationshipValidationHook;
+  }
+
+  createGovernanceSession = createGovernanceSession;
+  startGovernanceEvaluation = startGovernanceEvaluation;
+  completeGovernanceSession = completeGovernanceSession;
+  failGovernanceSession = failGovernanceSession;
+
+  applyPdpObligations(session: GovernanceSession, obligations: readonly GovernanceObligation[]): GovernanceSession {
+    let current = session;
+    for (const obligation of obligations) {
+      current = registerObligation(current, obligation);
+    }
+    this.emit('PDP_OBLIGATIONS_REGISTERED', { sessionId: current.sessionId, obligationCount: obligations.length });
+    return current;
+  }
+
+  applyIdentityGovernanceFlags(
+    session: GovernanceSession,
+    flags: AiGovernanceFlags
+  ): { session: GovernanceSession; escalations: EscalationPath[]; humanReview?: HumanReviewRequest } {
+    let current = session;
+    const escalations: EscalationPath[] = [];
+    let review: HumanReviewRequest | undefined;
+
+    if (flags.requiresEscalation) {
+      const result = createEscalation(current, {
+        escalationId: `esc_${current.sessionId}`,
+        escalationType: 'ai_governance_restriction',
+        triggeredBy: 'identity_policy',
+        targetActorId: current.actorId,
+        reasonCodes: flags.reasonCodes ?? ['AI_GOVERNANCE_ESCALATION'],
+      });
+      current = result.session;
+      escalations.push(result.escalation);
+    }
+
+    if (flags.requiresHumanReview) {
+      const created = createHumanReviewRequest(current, {
+        reviewId: `review_${current.sessionId}`,
+        actorId: current.actorId,
+        requestedAction: 'resolve_ai_governance_restriction',
+        requestedScopes: [],
+        reasonCodes: flags.reasonCodes ?? ['HUMAN_REVIEW_REQUIRED'],
+        escalationRef: escalations[0]?.escalationId,
+      });
+      current = created.session;
+      review = created.review;
+    }
+
+    this.emit('AI_GOVERNANCE_FLAGS_APPLIED', { sessionId: current.sessionId, flags });
+    return { session: current, escalations, humanReview: review };
+  }
+
+  validateRelationship(session: GovernanceSession): GovernanceSession {
+    if (this.relationshipValidationHook === undefined) return session;
+    const validation = this.relationshipValidationHook(session.actorId, session.relationshipId);
+    if (!validation.valid) {
+      const failed = failGovernanceSession(session);
+      this.emit('RELATIONSHIP_VALIDATION_FAILED', {
+        sessionId: failed.sessionId,
+        reasonCodes: validation.reasonCodes ?? ['RELATIONSHIP_VALIDATION_FAILED'],
+      });
+      return failed;
+    }
+    this.emit('RELATIONSHIP_VALIDATED', { sessionId: session.sessionId });
+    return session;
+  }
+
+  resolveEscalationAndResume(session: GovernanceSession, escalation: EscalationPath): { session: GovernanceSession; escalation: EscalationPath } {
+    const resolved = resolveEscalation(escalation);
+    const resumed = setSessionState(session, 'evaluating');
+    return { session: resumed, escalation: resolved };
+  }
+
+  approveHumanReview = approveHumanReview;
+  denyHumanReview = denyHumanReview;
+  registerObligation = registerObligation;
+  completeObligation = completeObligation;
+  failObligation = failObligation;
+
+  private emit(eventType: string, payload: Record<string, unknown>): void {
+    this.auditHook?.(eventType, payload);
+  }
+}

--- a/runtime/governance/governance-session.ts
+++ b/runtime/governance/governance-session.ts
@@ -1,0 +1,63 @@
+import { assertStateTransition } from './runtime-state';
+import type { GovernanceObligation, GovernanceRuntimeState, GovernanceSession } from './types';
+
+export function createGovernanceSession(input: {
+  sessionId: string;
+  actorId: string;
+  relationshipId: string;
+  policyTraceId: string;
+  startedAt?: string;
+}): GovernanceSession {
+  return {
+    sessionId: input.sessionId,
+    actorId: input.actorId,
+    relationshipId: input.relationshipId,
+    policyTraceId: input.policyTraceId,
+    startedAt: input.startedAt ?? new Date().toISOString(),
+    runtimeState: 'pending',
+    obligations: [],
+    escalationRefs: [],
+    auditRefs: [],
+  };
+}
+
+export function startGovernanceEvaluation(session: GovernanceSession): GovernanceSession {
+  return transition(session, 'evaluating');
+}
+
+export function completeGovernanceSession(session: GovernanceSession, completedAt?: string): GovernanceSession {
+  if (session.runtimeState === 'escalated') {
+    throw new Error('Cannot complete governance session while escalations are active.');
+  }
+  if (session.runtimeState === 'awaiting_human_review') {
+    throw new Error('Cannot complete governance session while human review is pending.');
+  }
+  if (session.obligations.some((obligation) => obligation.status === 'pending')) {
+    throw new Error('Cannot complete governance session with pending obligations.');
+  }
+  if (session.obligations.some((obligation) => obligation.status === 'failed')) {
+    throw new Error('Cannot complete governance session with failed obligations.');
+  }
+
+  const resolved: GovernanceSession = session.runtimeState === 'denied' ? transition(session, 'completed') : transition(transition(session, 'approved'), 'completed');
+  return { ...resolved, completedAt: completedAt ?? new Date().toISOString() };
+}
+
+export function failGovernanceSession(session: GovernanceSession, completedAt?: string): GovernanceSession {
+  return { ...transition(session, 'failed'), completedAt: completedAt ?? new Date().toISOString() };
+}
+
+export function setSessionState(session: GovernanceSession, runtimeState: GovernanceRuntimeState): GovernanceSession {
+  return transition(session, runtimeState);
+}
+
+export function upsertObligation(session: GovernanceSession, obligation: GovernanceObligation): GovernanceSession {
+  const obligations = session.obligations.filter((entry) => entry.obligationId !== obligation.obligationId);
+  obligations.push(obligation);
+  return { ...session, obligations };
+}
+
+function transition(session: GovernanceSession, to: GovernanceRuntimeState): GovernanceSession {
+  assertStateTransition(session.runtimeState, to);
+  return { ...session, runtimeState: to };
+}

--- a/runtime/governance/human-review.ts
+++ b/runtime/governance/human-review.ts
@@ -1,0 +1,35 @@
+import { setSessionState } from './governance-session';
+import type { HumanReviewRequest, GovernanceSession } from './types';
+
+export function createHumanReviewRequest(
+  session: GovernanceSession,
+  input: {
+    reviewId: string;
+    actorId: string;
+    requestedAction: string;
+    requestedScopes: string[];
+    reasonCodes: string[];
+    escalationRef?: string;
+  }
+): { session: GovernanceSession; review: HumanReviewRequest } {
+  const review: HumanReviewRequest = {
+    reviewId: input.reviewId,
+    actorId: input.actorId,
+    requestedAction: input.requestedAction,
+    requestedScopes: input.requestedScopes,
+    reasonCodes: input.reasonCodes,
+    escalationRef: input.escalationRef,
+    reviewStatus: 'pending',
+  };
+  return { session: setSessionState(session, 'awaiting_human_review'), review };
+}
+
+export function approveHumanReview(session: GovernanceSession, review: HumanReviewRequest): { session: GovernanceSession; review: HumanReviewRequest } {
+  if (review.reviewStatus !== 'pending') throw new Error(`Review already resolved: ${review.reviewId}`);
+  return { session: setSessionState(session, 'evaluating'), review: { ...review, reviewStatus: 'approved' } };
+}
+
+export function denyHumanReview(session: GovernanceSession, review: HumanReviewRequest): { session: GovernanceSession; review: HumanReviewRequest } {
+  if (review.reviewStatus !== 'pending') throw new Error(`Review already resolved: ${review.reviewId}`);
+  return { session: setSessionState(session, 'denied'), review: { ...review, reviewStatus: 'denied' } };
+}

--- a/runtime/governance/index.ts
+++ b/runtime/governance/index.ts
@@ -1,0 +1,7 @@
+export * from './types';
+export * from './runtime-state';
+export * from './governance-session';
+export * from './obligation-runtime';
+export * from './escalation-runtime';
+export * from './human-review';
+export * from './governance-runtime';

--- a/runtime/governance/obligation-runtime.ts
+++ b/runtime/governance/obligation-runtime.ts
@@ -1,0 +1,41 @@
+import { failGovernanceSession, setSessionState, upsertObligation } from './governance-session';
+import type { GovernanceObligation, GovernanceObligationType, GovernanceSession } from './types';
+
+export function registerObligation(
+  session: GovernanceSession,
+  input: { obligationId: string; obligationType: GovernanceObligationType; issuedAt?: string; metadata?: Record<string, unknown> }
+): GovernanceSession {
+  const obligation: GovernanceObligation = {
+    obligationId: input.obligationId,
+    obligationType: input.obligationType,
+    status: 'pending',
+    issuedAt: input.issuedAt ?? new Date().toISOString(),
+    metadata: input.metadata,
+  };
+  return upsertObligation(session, obligation);
+}
+
+export function completeObligation(session: GovernanceSession, obligationId: string, completedAt?: string): GovernanceSession {
+  const found = session.obligations.find((entry) => entry.obligationId === obligationId);
+  if (found === undefined) throw new Error(`Obligation not found: ${obligationId}`);
+  if (found.status === 'failed') throw new Error(`Cannot complete failed obligation: ${obligationId}`);
+  return upsertObligation(session, { ...found, status: 'completed', completedAt: completedAt ?? new Date().toISOString() });
+}
+
+export function failObligation(session: GovernanceSession, obligationId: string, completedAt?: string): GovernanceSession {
+  const found = session.obligations.find((entry) => entry.obligationId === obligationId);
+  if (found === undefined) throw new Error(`Obligation not found: ${obligationId}`);
+  const updated = upsertObligation(session, { ...found, status: 'failed', completedAt: completedAt ?? new Date().toISOString() });
+  return failGovernanceSession(updated, completedAt);
+}
+
+export function listPendingObligations(session: GovernanceSession): GovernanceObligation[] {
+  return session.obligations.filter((entry) => entry.status === 'pending');
+}
+
+export function canFinalizeEvaluation(session: GovernanceSession): GovernanceSession {
+  if (listPendingObligations(session).length > 0) {
+    return setSessionState(session, 'evaluating');
+  }
+  return setSessionState(session, 'approved');
+}

--- a/runtime/governance/runtime-state.ts
+++ b/runtime/governance/runtime-state.ts
@@ -1,0 +1,19 @@
+import type { GovernanceRuntimeState } from './types';
+
+const ALLOWED_TRANSITIONS: Record<GovernanceRuntimeState, GovernanceRuntimeState[]> = {
+  pending: ['evaluating', 'failed'],
+  evaluating: ['approved', 'denied', 'escalated', 'awaiting_human_review', 'failed'],
+  approved: ['completed', 'failed'],
+  denied: ['completed'],
+  escalated: ['evaluating', 'awaiting_human_review', 'failed'],
+  awaiting_human_review: ['evaluating', 'denied', 'failed'],
+  completed: [],
+  failed: [],
+};
+
+export function assertStateTransition(from: GovernanceRuntimeState, to: GovernanceRuntimeState): void {
+  const allowed = ALLOWED_TRANSITIONS[from];
+  if (!allowed.includes(to)) {
+    throw new Error(`Invalid governance state transition: ${from} -> ${to}`);
+  }
+}

--- a/runtime/governance/types.ts
+++ b/runtime/governance/types.ts
@@ -1,0 +1,83 @@
+export type GovernanceRuntimeState =
+  | 'pending'
+  | 'evaluating'
+  | 'approved'
+  | 'denied'
+  | 'escalated'
+  | 'awaiting_human_review'
+  | 'completed'
+  | 'failed';
+
+export type GovernanceObligationType =
+  | 'purpose_assertion'
+  | 'frequency_enforcement'
+  | 'ai_escalation'
+  | 'human_review'
+  | 'relationship_validation'
+  | 'consent_reaffirmation';
+
+export type GovernanceObligationStatus = 'pending' | 'completed' | 'failed';
+
+export type GovernanceObligation = {
+  obligationId: string;
+  obligationType: GovernanceObligationType;
+  status: GovernanceObligationStatus;
+  issuedAt: string;
+  completedAt?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type EscalationType =
+  | 'ai_governance_restriction'
+  | 'blocked_scope'
+  | 'sensitive_action'
+  | 'delegation_depth_violation'
+  | 'human_review_required';
+
+export type EscalationStatus = 'active' | 'resolved';
+
+export type EscalationPath = {
+  escalationId: string;
+  escalationType: EscalationType;
+  triggeredBy: string;
+  targetActorId: string;
+  reasonCodes: string[];
+  status: EscalationStatus;
+  createdAt: string;
+  resolvedAt?: string;
+};
+
+export type HumanReviewStatus = 'pending' | 'approved' | 'denied';
+
+export type HumanReviewRequest = {
+  reviewId: string;
+  actorId: string;
+  requestedAction: string;
+  requestedScopes: string[];
+  reasonCodes: string[];
+  escalationRef?: string;
+  reviewStatus: HumanReviewStatus;
+};
+
+export type GovernanceSession = {
+  sessionId: string;
+  actorId: string;
+  relationshipId: string;
+  policyTraceId: string;
+  startedAt: string;
+  completedAt?: string;
+  runtimeState: GovernanceRuntimeState;
+  obligations: GovernanceObligation[];
+  escalationRefs: string[];
+  auditRefs: string[];
+};
+
+export type AuditHook = (eventType: string, payload: Record<string, unknown>) => void;
+
+export type RelationshipValidationHook = (actorId: string, relationshipId: string) => { valid: boolean; reasonCodes?: string[] };
+
+export type AiGovernanceFlags = {
+  requiresEscalation?: boolean;
+  requiresHumanReview?: boolean;
+  reasonCodes?: string[];
+};

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -40,5 +40,6 @@ export type {
 
 export * from './audit';
 export * from './controlPlane';
+export * from './governance';
 
 export * from './distributed';


### PR DESCRIPTION
### Motivation
- Provide a canonical runtime orchestration layer that coordinates PDP decisions, identity flags, obligations, escalation paths, and human-review checkpoints in one deterministic runtime.
- Ensure governance decisions are auditable and deterministic without introducing external workflow engines, queues, databases, or UI concerns.
- Convert passive PDP/identity outputs into executable, session-scoped governance primitives to enforce protocol-level semantics and failure propagation.

### Description
- Add a new module `runtime/governance` (created `types.ts`, `runtime-state.ts`, `governance-session.ts`, `obligation-runtime.ts`, `escalation-runtime.ts`, `human-review.ts`, `governance-runtime.ts`, `index.ts`, and `README.md`) defining canonical types and behavior for sessions, obligations, escalations, and human review requests.
- Implement deterministic state transition guardrails in `runtime-state.ts` and session lifecycle operations (`createGovernanceSession`, `startGovernanceEvaluation`, `completeGovernanceSession`, `failGovernanceSession`) in `governance-session.ts`.
- Implement obligation runtime primitives (`registerObligation`, `completeObligation`, `failObligation`, `listPendingObligations`) and propagate failed obligations to fail the containing governance session in `obligation-runtime.ts`.
- Implement escalation primitives (`createEscalation`, `resolveEscalation`, `getActiveEscalations`) in `escalation-runtime.ts` and human-review primitives (`createHumanReviewRequest`, `approveHumanReview`, `denyHumanReview`) in `human-review.ts` with explicit session-state impacts.
- Add `GovernanceRuntime` orchestration class in `governance-runtime.ts` with light integration hooks for PDP obligation ingestion (`applyPdpObligations`), identity-policy AI governance flags (`applyIdentityGovernanceFlags`), relationship validation callbacks, and an `auditHook` for audit propagation; export the module from `runtime/index.ts`.
- Add targeted unit tests `runtime/governance/__tests__/governance-runtime.test.ts` covering lifecycle, obligations, escalations, human review, state transitions, failure propagation, and AI escalation flows; include a descriptive README explaining scope and semantics.

### Testing
- Ran targeted Jest suite: `npx jest runtime/governance/__tests__/governance-runtime.test.ts --runInBand` and all tests passed (7 tests, suite: PASS).
- Tests exercise session lifecycle, obligation registration/completion/failure propagation, escalation creation/resolution, human review approve/deny paths, state-transition constraints, and AI escalation+human-review orchestration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf0b3b1e88325b392e973ea81286c)