### PR TITLE
Add governance-aware Capability Runtime Layer for AOC Core

### DIFF
--- a/runtime/__tests__/capabilities-runtime.test.ts
+++ b/runtime/__tests__/capabilities-runtime.test.ts
@@ -1,0 +1,83 @@
+import {
+  activateRuntimeCapability,
+  applyCapabilityRevocation,
+  createCapabilityRevocation,
+  createCapabilitySession,
+  evaluateCapabilityUse,
+  expireRuntimeCapability,
+  isCapabilityCurrentlyValid,
+  issueCapabilityFromGovernanceSession,
+} from '../capabilities';
+import type { GovernanceSession } from '../governance/types';
+
+function session(overrides: Partial<GovernanceSession> = {}): GovernanceSession {
+  return {
+    sessionId: 'gov_1',
+    actorId: 'actor_a',
+    relationshipId: 'rel_1',
+    policyTraceId: 'trace_1',
+    startedAt: '2026-05-01T00:00:00.000Z',
+    runtimeState: 'approved',
+    obligations: [],
+    escalationRefs: [],
+    auditRefs: [],
+    ...overrides,
+  };
+}
+
+describe('capability runtime layer', () => {
+  test('issue and activate lifecycle', () => {
+    const issued = issueCapabilityFromGovernanceSession({
+      capabilityId: 'cap_1', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://docs/'], governanceSession: session(),
+    });
+    const active = activateRuntimeCapability(issued);
+    expect(active.status).toBe('active');
+  });
+
+  test('revoked cannot reactivate', () => {
+    const issued = issueCapabilityFromGovernanceSession({ capabilityId: 'cap_2', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://'], governanceSession: session() });
+    const revoked = applyCapabilityRevocation(issued, createCapabilityRevocation({ revocationId: 'rev_1', capabilityId: 'cap_2', revokedByActorId: 'admin', reasonCodes: ['RISK'] }));
+    expect(() => activateRuntimeCapability(revoked)).toThrow(/Revoked capability/);
+  });
+
+  test('expired cannot reactivate', () => {
+    const issued = issueCapabilityFromGovernanceSession({ capabilityId: 'cap_3', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://'], governanceSession: session() });
+    const expired = expireRuntimeCapability(issued);
+    expect(() => activateRuntimeCapability(expired)).toThrow(/Expired capability/);
+  });
+
+  test('notBefore blocks validity', () => {
+    const issued = issueCapabilityFromGovernanceSession({ capabilityId: 'cap_4', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://'], governanceSession: session(), notBefore: '2099-01-01T00:00:00.000Z' });
+    const active = activateRuntimeCapability(issued);
+    expect(isCapabilityCurrentlyValid(active, '2026-01-01T00:00:00.000Z')).toBe(false);
+  });
+
+  test('governance session required for issuance', () => {
+    expect(() => issueCapabilityFromGovernanceSession({ capabilityId: 'cap_5', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://'], governanceSession: session({ runtimeState: 'pending' }) })).toThrow(/approved or completed/);
+  });
+
+  test('pending obligations block issuance', () => {
+    expect(() => issueCapabilityFromGovernanceSession({ capabilityId: 'cap_6', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://'], governanceSession: session({ obligations: [{ obligationId: 'o1', obligationType: 'purpose_assertion', status: 'pending', issuedAt: '2026-01-01T00:00:00.000Z' }] }) })).toThrow(/pending/);
+  });
+
+  test('capability use denied for disallowed action', () => {
+    const active = activateRuntimeCapability(issueCapabilityFromGovernanceSession({ capabilityId: 'cap_7', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://docs/'], governanceSession: session() }));
+    const result = evaluateCapabilityUse({ capability: active, session: createCapabilitySession({ sessionId: 'use_1', capabilityId: 'cap_7', actorId: 'grantee_1', action: 'write', resourceId: 'res://docs/a' }) });
+    expect(result.decision.decision).toBe('deny');
+    expect(result.decision.reasonCodes).toContain('ACTION_NOT_ALLOWED');
+  });
+
+  test('revocation application marks capability revoked', () => {
+    const issued = issueCapabilityFromGovernanceSession({ capabilityId: 'cap_8', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://'], governanceSession: session() });
+    const revoked = applyCapabilityRevocation(issued, createCapabilityRevocation({ revocationId: 'rev_8', capabilityId: 'cap_8', revokedByActorId: 'admin', reasonCodes: ['EMERGENCY_STOP'] }));
+    expect(revoked.status).toBe('revoked');
+    expect(revoked.revokedAt).toBeDefined();
+  });
+
+  test('AI boundary denial', () => {
+    const active = activateRuntimeCapability(issueCapabilityFromGovernanceSession({ capabilityId: 'cap_9', subjectActorId: 'subject_1', granteeActorId: 'grantee_1', allowedActions: ['read'], scope: ['res://'], governanceSession: session(), aiBoundary: { blockedScopes: ['res://secret/'] } }));
+    const result = evaluateCapabilityUse({ capability: active, session: createCapabilitySession({ sessionId: 'use_9', capabilityId: 'cap_9', actorId: 'grantee_1', action: 'read', resourceId: 'res://secret/doc1' }) });
+    expect(result.decision.decision).toBe('deny');
+    expect(result.decision.reasonCodes).toContain('AI_BLOCKED_SCOPE');
+  });
+});

--- a/runtime/capabilities/README.md
+++ b/runtime/capabilities/README.md
@@ -1,0 +1,68 @@
+# Capability Runtime Layer (AOC Core)
+
+The capability runtime converts capability primitives into **executable authority artifacts**. A runtime capability is not just a token-like descriptor; it is a live authority object that participates in governance state, obligation satisfaction, revocation, and audit emission.
+
+## Authority chain
+
+A runtime capability is issued only after governance confirms:
+1. Relationship context exists (`relationshipId`).
+2. PDP traceability exists (`policyTraceId`).
+3. Governance session is approved/completed.
+4. Obligations are not pending or failed.
+
+This enforces a chain: **consent + relationship + PDP evidence + governance completion => executable capability**.
+
+## Lifecycle awareness
+
+Capabilities are lifecycle-aware states (`issued`, `active`, `suspended`, `revoked`, `expired`) with strict transitions:
+- revoked/expired cannot reactivate.
+- `notBefore` and `expiresAt` are enforced at evaluation time.
+- suspended is non-executable until a future explicit restore path is introduced.
+
+## Revocation philosophy
+
+Revocation is authoritative and immediate in local semantics:
+- revocation record is canonical (`CapabilityRevocation`).
+- apply step marks runtime capability revoked.
+- local query can enumerate revoked capabilities.
+
+Distributed propagation is intentionally out of scope in this phase.
+
+## Capability use and PDP seam
+
+Capability use is sessionized (`CapabilitySession`) and evaluated via layered checks:
+1. capability validity/lifecycle window,
+2. actor/action/scope checks,
+3. optional PDP adapter decision.
+
+The PDP seam is adapter-based to avoid coupling to any single PDP runtime implementation.
+
+## AI-bounded capabilities
+
+Optional constraints:
+- `aiActorId`
+- `allowedPurposes`
+- `blockedScopes`
+- `requiresHumanReview`
+- `maxAutonomousUses`
+
+These are **boundary constraints only**, not orchestration. Denials are explicit when constraints are violated.
+
+## Audit hooks
+
+Composable audit hooks emit canonical runtime events:
+- `capability_issued`
+- `capability_activated`
+- `capability_suspended`
+- `capability_revoked`
+- `capability_expired`
+- `capability_use_evaluated`
+- `capability_denied`
+
+## Current limitations
+
+- No persistence layer (in-memory semantics only).
+- No distributed revocation fan-out.
+- No restore-from-suspended workflow yet.
+- No obligation execution engine in this module (it consumes governance outcomes).
+- No AI autonomy counter mutation service; boundary checks read current counter.

--- a/runtime/capabilities/capability-audit.ts
+++ b/runtime/capabilities/capability-audit.ts
@@ -1,0 +1,9 @@
+import type { CapabilityAuditEventType, CapabilityAuditHook } from './types';
+
+export function emitCapabilityAuditEvent(
+  auditHook: CapabilityAuditHook | undefined,
+  eventType: CapabilityAuditEventType,
+  payload: Record<string, unknown>
+): void {
+  auditHook?.(eventType, payload);
+}

--- a/runtime/capabilities/capability-lifecycle.ts
+++ b/runtime/capabilities/capability-lifecycle.ts
@@ -1,0 +1,47 @@
+import { emitCapabilityAuditEvent } from './capability-audit';
+import type { CapabilityAuditHook, RuntimeCapability } from './types';
+
+function nowIso(now?: string): string {
+  return now ?? new Date().toISOString();
+}
+
+export function issueRuntimeCapability(input: Omit<RuntimeCapability, 'issuedAt' | 'status'> & { issuedAt?: string }): RuntimeCapability {
+  return { ...input, issuedAt: nowIso(input.issuedAt), status: 'issued' };
+}
+
+export function activateRuntimeCapability(capability: RuntimeCapability, auditHook?: CapabilityAuditHook, at?: string): RuntimeCapability {
+  if (capability.status === 'revoked') throw new Error('Revoked capability cannot be reactivated.');
+  if (capability.status === 'expired') throw new Error('Expired capability cannot be reactivated.');
+  if (capability.status === 'suspended') throw new Error('Suspended capability requires explicit restore flow.');
+  const next = { ...capability, status: 'active' as const };
+  emitCapabilityAuditEvent(auditHook, 'capability_activated', { capabilityId: capability.capabilityId, at: nowIso(at) });
+  return next;
+}
+
+export function suspendRuntimeCapability(capability: RuntimeCapability, auditHook?: CapabilityAuditHook, at?: string): RuntimeCapability {
+  if (capability.status === 'revoked' || capability.status === 'expired') throw new Error('Terminal capability state cannot be suspended.');
+  const next = { ...capability, status: 'suspended' as const };
+  emitCapabilityAuditEvent(auditHook, 'capability_suspended', { capabilityId: capability.capabilityId, at: nowIso(at) });
+  return next;
+}
+
+export function revokeRuntimeCapability(capability: RuntimeCapability, at?: string, auditHook?: CapabilityAuditHook): RuntimeCapability {
+  const next = { ...capability, status: 'revoked' as const, revokedAt: nowIso(at) };
+  emitCapabilityAuditEvent(auditHook, 'capability_revoked', { capabilityId: capability.capabilityId, revokedAt: next.revokedAt });
+  return next;
+}
+
+export function expireRuntimeCapability(capability: RuntimeCapability, at?: string, auditHook?: CapabilityAuditHook): RuntimeCapability {
+  const next = { ...capability, status: 'expired' as const, expiresAt: capability.expiresAt ?? nowIso(at) };
+  emitCapabilityAuditEvent(auditHook, 'capability_expired', { capabilityId: capability.capabilityId, expiresAt: next.expiresAt });
+  return next;
+}
+
+export function isCapabilityCurrentlyValid(capability: RuntimeCapability, at?: string): boolean {
+  const now = new Date(nowIso(at));
+  if (capability.status !== 'active') return false;
+  if (capability.revokedAt !== undefined) return false;
+  if (capability.notBefore !== undefined && now < new Date(capability.notBefore)) return false;
+  if (capability.expiresAt !== undefined && now > new Date(capability.expiresAt)) return false;
+  return true;
+}

--- a/runtime/capabilities/capability-revocation.ts
+++ b/runtime/capabilities/capability-revocation.ts
@@ -1,0 +1,33 @@
+import { emitCapabilityAuditEvent } from './capability-audit';
+import { revokeRuntimeCapability } from './capability-lifecycle';
+import type { CapabilityAuditHook, CapabilityRevocation, RuntimeCapability } from './types';
+
+export function createCapabilityRevocation(input: {
+  revocationId: string;
+  capabilityId: string;
+  revokedByActorId: string;
+  reasonCodes: string[];
+  revokedAt?: string;
+}): CapabilityRevocation {
+  return { ...input, revokedAt: input.revokedAt ?? new Date().toISOString() };
+}
+
+export function applyCapabilityRevocation(
+  capability: RuntimeCapability,
+  revocation: CapabilityRevocation,
+  auditHook?: CapabilityAuditHook
+): RuntimeCapability {
+  if (capability.capabilityId !== revocation.capabilityId) throw new Error('Revocation capabilityId mismatch.');
+  const next = revokeRuntimeCapability(capability, revocation.revokedAt, auditHook);
+  emitCapabilityAuditEvent(auditHook, 'capability_revoked', {
+    capabilityId: capability.capabilityId,
+    revocationId: revocation.revocationId,
+    revokedByActorId: revocation.revokedByActorId,
+    reasonCodes: revocation.reasonCodes,
+  });
+  return next;
+}
+
+export function listRevokedCapabilities(capabilities: readonly RuntimeCapability[]): RuntimeCapability[] {
+  return capabilities.filter((capability) => capability.status === 'revoked' || capability.revokedAt !== undefined);
+}

--- a/runtime/capabilities/capability-runtime.ts
+++ b/runtime/capabilities/capability-runtime.ts
@@ -1,0 +1,41 @@
+import { emitCapabilityAuditEvent } from './capability-audit';
+import { issueRuntimeCapability } from './capability-lifecycle';
+import type { CapabilityAuditHook, GovernanceIssuanceInput, RuntimeCapability } from './types';
+
+export function issueCapabilityFromGovernanceSession(input: GovernanceIssuanceInput, auditHook?: CapabilityAuditHook): RuntimeCapability {
+  const { governanceSession } = input;
+  if (!['approved', 'completed'].includes(governanceSession.runtimeState)) {
+    throw new Error('Governance session must be approved or completed before capability issuance.');
+  }
+  if (governanceSession.obligations.some((entry) => entry.status === 'pending')) {
+    throw new Error('Cannot issue capability while obligations remain pending.');
+  }
+  if (governanceSession.obligations.some((entry) => entry.status === 'failed')) {
+    throw new Error('Cannot issue capability when obligations have failed.');
+  }
+  if (!governanceSession.policyTraceId) throw new Error('policyTraceId is required for capability issuance.');
+  if (!governanceSession.relationshipId) throw new Error('relationshipId is required for capability issuance.');
+
+  const capability = issueRuntimeCapability({
+    capabilityId: input.capabilityId,
+    subjectActorId: input.subjectActorId,
+    granteeActorId: input.granteeActorId,
+    relationshipId: governanceSession.relationshipId,
+    policyTraceId: governanceSession.policyTraceId,
+    governanceSessionId: governanceSession.sessionId,
+    scope: input.scope,
+    allowedActions: input.allowedActions,
+    notBefore: input.notBefore,
+    expiresAt: input.expiresAt,
+    aiBoundary: input.aiBoundary,
+  });
+
+  emitCapabilityAuditEvent(auditHook, 'capability_issued', {
+    capabilityId: capability.capabilityId,
+    relationshipId: capability.relationshipId,
+    governanceSessionId: capability.governanceSessionId,
+    policyTraceId: capability.policyTraceId,
+  });
+
+  return capability;
+}

--- a/runtime/capabilities/capability-session.ts
+++ b/runtime/capabilities/capability-session.ts
@@ -1,0 +1,71 @@
+import { emitCapabilityAuditEvent } from './capability-audit';
+import { isCapabilityCurrentlyValid } from './capability-lifecycle';
+import type { CapabilityAuditHook, CapabilitySession, CapabilityUseDecision, PdpCapabilityAdapter, RuntimeCapability } from './types';
+
+export function createCapabilitySession(input: {
+  sessionId: string;
+  capabilityId: string;
+  actorId: string;
+  action: string;
+  resourceId: string;
+  startedAt?: string;
+  purpose?: string;
+}): CapabilitySession {
+  return { ...input, startedAt: input.startedAt ?? new Date().toISOString(), auditRefs: [] };
+}
+
+export function evaluateCapabilityUse(input: {
+  capability: RuntimeCapability;
+  session: CapabilitySession;
+  pdpAdapter?: PdpCapabilityAdapter;
+  auditHook?: CapabilityAuditHook;
+}): { session: CapabilitySession; decision: CapabilityUseDecision } {
+  const { capability, session, pdpAdapter, auditHook } = input;
+
+  const deny = (reasonCodes: string[], requiresHumanReview = false): { session: CapabilitySession; decision: CapabilityUseDecision } => {
+    const decision: CapabilityUseDecision = {
+      decision: 'deny',
+      reasonCodes,
+      capabilityStatus: capability.status,
+      policyTraceId: capability.policyTraceId,
+      requiresHumanReview,
+    };
+    const finalized = { ...session, completedAt: new Date().toISOString(), decision: 'deny' as const, requiresHumanReview };
+    emitCapabilityAuditEvent(auditHook, 'capability_denied', { capabilityId: capability.capabilityId, sessionId: session.sessionId, reasonCodes });
+    return { session: finalized, decision };
+  };
+
+  if (!isCapabilityCurrentlyValid(capability)) return deny(['CAPABILITY_NOT_VALID']);
+  if (session.actorId !== capability.granteeActorId) return deny(['ACTOR_NOT_GRANTEE']);
+  if (!capability.allowedActions.includes(session.action)) return deny(['ACTION_NOT_ALLOWED']);
+  if (!capability.scope.some((scope) => session.resourceId.startsWith(scope))) return deny(['RESOURCE_OUT_OF_SCOPE']);
+
+  if (capability.aiBoundary?.blockedScopes?.some((scope) => session.resourceId.startsWith(scope))) return deny(['AI_BLOCKED_SCOPE']);
+  if (capability.aiBoundary?.allowedPurposes && session.purpose && !capability.aiBoundary.allowedPurposes.includes(session.purpose)) {
+    return deny(['AI_PURPOSE_NOT_ALLOWED']);
+  }
+  if (capability.aiBoundary?.maxAutonomousUses !== undefined) {
+    const used = capability.aiBoundary.autonomousUseCount ?? 0;
+    if (used >= capability.aiBoundary.maxAutonomousUses) return deny(['AI_MAX_AUTONOMOUS_USES_EXCEEDED'], true);
+  }
+  if (capability.aiBoundary?.requiresHumanReview) return deny(['AI_HUMAN_REVIEW_REQUIRED'], true);
+
+  if (pdpAdapter) {
+    const pdp = pdpAdapter({ capability, actorId: session.actorId, action: session.action, resourceId: session.resourceId, purpose: session.purpose });
+    if (!pdp.allow) return deny(pdp.reasonCodes ?? ['PDP_DENIED']);
+  }
+
+  const decision: CapabilityUseDecision = {
+    decision: 'allow',
+    reasonCodes: ['CAPABILITY_USE_ALLOWED'],
+    capabilityStatus: capability.status,
+    policyTraceId: capability.policyTraceId,
+  };
+  const finalized = { ...session, completedAt: new Date().toISOString(), decision: 'allow' as const };
+  emitCapabilityAuditEvent(auditHook, 'capability_use_evaluated', {
+    capabilityId: capability.capabilityId,
+    sessionId: session.sessionId,
+    decision: 'allow',
+  });
+  return { session: finalized, decision };
+}

--- a/runtime/capabilities/index.ts
+++ b/runtime/capabilities/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './capability-audit';
+export * from './capability-lifecycle';
+export * from './capability-runtime';
+export * from './capability-session';
+export * from './capability-revocation';

--- a/runtime/capabilities/types.ts
+++ b/runtime/capabilities/types.ts
@@ -1,0 +1,92 @@
+import type { GovernanceSession } from '../governance/types';
+
+export type RuntimeCapabilityStatus = 'issued' | 'active' | 'suspended' | 'revoked' | 'expired';
+
+export type AiCapabilityBoundary = {
+  aiActorId?: string;
+  allowedPurposes?: string[];
+  blockedScopes?: string[];
+  requiresHumanReview?: boolean;
+  maxAutonomousUses?: number;
+  autonomousUseCount?: number;
+};
+
+export type RuntimeCapability = {
+  capabilityId: string;
+  subjectActorId: string;
+  granteeActorId: string;
+  relationshipId: string;
+  policyTraceId: string;
+  governanceSessionId: string;
+  scope: string[];
+  allowedActions: string[];
+  issuedAt: string;
+  notBefore?: string;
+  expiresAt?: string;
+  revokedAt?: string;
+  status: RuntimeCapabilityStatus;
+  aiBoundary?: AiCapabilityBoundary;
+};
+
+export type CapabilitySessionDecision = 'allow' | 'deny';
+
+export type CapabilitySession = {
+  sessionId: string;
+  capabilityId: string;
+  actorId: string;
+  action: string;
+  resourceId: string;
+  startedAt: string;
+  completedAt?: string;
+  decision?: CapabilitySessionDecision;
+  auditRefs: string[];
+  purpose?: string;
+  requiresHumanReview?: boolean;
+};
+
+export type CapabilityRevocation = {
+  revocationId: string;
+  capabilityId: string;
+  revokedByActorId: string;
+  reasonCodes: string[];
+  revokedAt: string;
+};
+
+export type PdpCapabilityAdapter = (input: {
+  capability: RuntimeCapability;
+  actorId: string;
+  action: string;
+  resourceId: string;
+  purpose?: string;
+}) => { allow: boolean; reasonCodes?: string[] };
+
+export type CapabilityUseDecision = {
+  decision: CapabilitySessionDecision;
+  reasonCodes: string[];
+  capabilityStatus: RuntimeCapabilityStatus;
+  policyTraceId?: string;
+  requiresHumanReview?: boolean;
+};
+
+export type CapabilityAuditEventType =
+  | 'capability_issued'
+  | 'capability_activated'
+  | 'capability_suspended'
+  | 'capability_revoked'
+  | 'capability_expired'
+  | 'capability_use_evaluated'
+  | 'capability_denied';
+
+export type CapabilityAuditHook = (eventType: CapabilityAuditEventType, payload: Record<string, unknown>) => void;
+
+export type GovernanceIssuanceInput = {
+  capabilityId: string;
+  subjectActorId: string;
+  granteeActorId: string;
+  allowedActions: string[];
+  scope: string[];
+  governanceSession: GovernanceSession;
+  notBefore?: string;
+  expiresAt?: string;
+  aiBoundary?: AiCapabilityBoundary;
+};

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -43,3 +43,5 @@ export * from './controlPlane';
 export * from './governance';
 
 export * from './distributed';
+
+export * from './capabilities';


### PR DESCRIPTION
### Motivation
- Provide a lifecycle-aware runtime for capabilities so they become executable, auditable authority artifacts governed by identity, relationships, PDP traces, obligations, and governance sessions.
- Enforce governance-first issuance semantics to prevent capability creation from raw requests and to retain traceability (`policyTraceId`, `relationshipId`, `governanceSessionId`).
- Add revocation and audit foundations so capabilities can be immediately made non-executable and traced locally, and support AI safety boundaries for constrained autonomous uses.

### Description
- Added a new `runtime/capabilities` module with files: `types.ts`, `capability-runtime.ts`, `capability-lifecycle.ts`, `capability-session.ts`, `capability-revocation.ts`, `capability-audit.ts`, `index.ts`, and `README.md` implementing canonical types and behavior for runtime capabilities.
- Introduced canonical types including `RuntimeCapability`, `CapabilitySession`, `CapabilityRevocation`, `CapabilityUseDecision`, and `AiCapabilityBoundary` in `types.ts` and exported via the module barrel (`index.ts`).
- Implemented lifecycle functions `issueRuntimeCapability`, `activateRuntimeCapability`, `suspendRuntimeCapability`, `revokeRuntimeCapability`, `expireRuntimeCapability`, and `isCapabilityCurrentlyValid` with strict terminal-state rules and temporal checks in `capability-lifecycle.ts`.
- Implemented governance-gated issuance via `issueCapabilityFromGovernanceSession` which requires governance session `runtimeState` of `approved|completed`, no pending/failed obligations, and presence of `policyTraceId` and `relationshipId` in `capability-runtime.ts` and emits `capability_issued` audit events.
- Implemented sessionized capability use with `createCapabilitySession` and `evaluateCapabilityUse` that validates lifecycle, grantee binding, action/scope compatibility, an adapter seam for PDP checks, and AI boundary denials in `capability-session.ts`, emitting `capability_use_evaluated`/`capability_denied` audit events.
- Built local revocation foundation with `createCapabilityRevocation`, `applyCapabilityRevocation`, and `listRevokedCapabilities` in `capability-revocation.ts`, and a lightweight audit hook helper in `capability-audit.ts` to avoid tight coupling with the audit plane.
- Documented design, authority chain, lifecycle semantics, revocation philosophy, AI-boundary semantics, and current limitations in `runtime/capabilities/README.md` and re-exported the capabilities module from `runtime/index.ts`.

### Testing
- Ran the targeted test suite with `npx jest runtime/__tests__/capabilities-runtime.test.ts --runInBand` which covers lifecycle issuance/activation, revoked/expired reactivation blocking, `notBefore` enforcement, governance gating, pending-obligation blocking, disallowed-action denial, revocation application, and AI-boundary denial.
- Test outcome: `runtime/__tests__/capabilities-runtime.test.ts` passed, with 9 tests passing (9 total) in the run.
- Tests are unit-level and in-memory only; no persistence or distributed revocation behavior was tested by design in this phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf36b16188325bf132b89736668f8)