### PR TITLE
Add Governance Attestation Layer foundations for AOC Core

### DIFF
--- a/runtime/attestations/README.md
+++ b/runtime/attestations/README.md
@@ -1,0 +1,78 @@
+# Governance Attestation Layer (AOC Core)
+
+This module defines **canonical governance attestations** for AOC Core runtimes.
+
+## Why attestations exist
+
+Operational logs are useful for debugging, but governance evidence requires stronger semantics:
+- stable identifiers
+- explicit linkage to policy traces and sessions
+- integrity proof references
+- chain continuity across decisions/events
+
+Attestations are structured evidence envelopes that can later be verified by stronger trust systems.
+
+## Logs vs attestations
+
+- **Logs**: append-only runtime narratives; often implementation-specific.
+- **Attestations**: canonical governance facts with typed fields, integrity references, and chain semantics.
+
+Logs can contain attestations, but attestations are intentionally compact and deterministic so they can be replayed and reconstructed.
+
+## Integrity proof philosophy
+
+Current proofs are local and lightweight (`sha256` over payload serialization).
+They provide:
+- tamper-evidence baseline
+- deterministic hash identity for payload snapshots
+- parent-proof linkage for chained proofs
+
+They do **not** yet provide decentralized trust or signer identity assurances.
+
+## Attestation chaining philosophy
+
+Attestations can reference `previousAttestationRef` and be aggregated by chain ID.
+This supports:
+- replay continuity checks
+- timestamp monotonicity validation
+- governance reconstruction and forensic ordering
+
+## Replay-safe governance evidence
+
+Replay-safety currently relies on:
+- proof parent linkage
+- attestation previous linkage
+- timestamp regressions detection
+
+This is a foundation for stronger anti-replay guarantees in later phases.
+
+## AI attestation reasoning
+
+AI attestations capture:
+- allowed scopes
+- executed actions
+- autonomous use counts
+- human-review and escalation references
+
+Validation can enforce policy-like constraints without coupling to any single AI provider or network service.
+
+## Remote governance verification goals
+
+Remote governance attestations record:
+- source/target runtime pairing
+- federation reference
+- remote decision linkage
+- remote audit references
+
+Validation guards federation compatibility and trust-boundary pairing.
+
+## Current limitations
+
+- local-only storage (in-memory maps)
+- no PKI signatures or hardware roots
+- no distributed consensus
+- no network trust synchronization
+- no persistent anti-replay nonce store
+- hash covers `JSON.stringify` serialization (ordering caveats for non-canonical objects)
+
+These semantics are intentionally lightweight foundations for future cryptographic hardening.

--- a/runtime/attestations/__tests__/attestations.test.ts
+++ b/runtime/attestations/__tests__/attestations.test.ts
@@ -1,0 +1,97 @@
+import {
+  appendAttestationChain,
+  clearAttestationChains,
+  clearGovernanceAttestations,
+  clearIntegrityProofs,
+  createAIAttestation,
+  createCapabilityAttestation,
+  createChainedIntegrityProof,
+  createGovernanceAttestation,
+  createIntegrityProof,
+  createRemoteGovernanceAttestation,
+  validateAIAttestation,
+  validateAttestationChain,
+  validateCapabilityAttestation,
+  validateGovernanceAttestation,
+  validateIntegrityProof,
+  validateRemoteGovernanceAttestation
+} from '../index';
+
+describe('governance attestation layer', () => {
+  beforeEach(() => {
+    clearIntegrityProofs();
+    clearGovernanceAttestations();
+    clearAttestationChains();
+  });
+
+  it('creates and validates governance attestations', () => {
+    const proof = createIntegrityProof({ proofId: 'p1', proofType: 'local_hash', payload: { d: 1 } });
+    const att = createGovernanceAttestation({
+      attestationId: 'a1', attestationType: 'governance_decision', actorId: 'actor', governanceSessionId: 'gs',
+      policyTraceId: 'pt', relationshipId: 'rel', capabilityRefs: ['cap-a'], decision: 'allow',
+      issuedAt: new Date().toISOString(), integrityProofRef: proof.proofId
+    });
+    expect(validateGovernanceAttestation(att).valid).toBe(true);
+  });
+
+  it('validates integrity proof chains', () => {
+    const root = createIntegrityProof({ proofId: 'root', proofType: 'local_hash', payload: { x: 1 } });
+    const child = createChainedIntegrityProof({ proofId: 'child', parentProofRef: root.proofId, payload: { x: 2 } });
+    expect(validateIntegrityProof(child).valid).toBe(true);
+  });
+
+  it('validates chained attestation continuity', () => {
+    const p1 = createIntegrityProof({ proofId: 'cp1', proofType: 'local_hash', payload: { i: 1 } });
+    const a1 = createGovernanceAttestation({
+      attestationId: 'ca1', attestationType: 'governance_decision', actorId: 'actor', governanceSessionId: 'gs',
+      policyTraceId: 'pt', relationshipId: 'rel', capabilityRefs: [], decision: 'allow',
+      issuedAt: '2026-01-01T00:00:00.000Z', integrityProofRef: p1.proofId
+    });
+    const p2 = createChainedIntegrityProof({ proofId: 'cp2', parentProofRef: p1.proofId, payload: { i: 2 } });
+    const a2 = createGovernanceAttestation({
+      attestationId: 'ca2', attestationType: 'capability_used', actorId: 'actor', governanceSessionId: 'gs',
+      policyTraceId: 'pt2', relationshipId: 'rel', capabilityRefs: ['cap'], decision: 'conditional',
+      issuedAt: '2026-01-02T00:00:00.000Z', integrityProofRef: p2.proofId, previousAttestationRef: a1.attestationId
+    });
+    appendAttestationChain('chain-1', a1);
+    appendAttestationChain('chain-1', a2);
+    expect(validateAttestationChain('chain-1').valid).toBe(true);
+  });
+
+  it('validates capability attestations', () => {
+    const p = createIntegrityProof({ proofId: 'cap-proof', proofType: 'local_hash', payload: { c: 1 } });
+    const g = createGovernanceAttestation({
+      attestationId: 'cap-g', attestationType: 'capability_issued', actorId: 'actor', governanceSessionId: 'gs',
+      policyTraceId: 'pt', relationshipId: 'rel', capabilityRefs: ['cap-a'], decision: 'allow',
+      issuedAt: new Date().toISOString(), integrityProofRef: p.proofId
+    });
+    const cap = createCapabilityAttestation({
+      capabilityId: 'cap-a', issuingRuntimeId: 'runtime-a', governanceAttestationRef: g.attestationId,
+      validityWindow: { notBefore: '2026-01-01T00:00:00.000Z', notAfter: '2026-12-31T00:00:00.000Z' }, revocationRefs: []
+    });
+    expect(validateCapabilityAttestation(cap).valid).toBe(true);
+  });
+
+  it('enforces AI attestation constraints', () => {
+    const ai = createAIAttestation({
+      aiActorId: 'ai-agent', allowedScopes: ['read_policy', 'execute_low_risk'], executedActions: ['execute_low_risk'],
+      humanReviewRefs: ['review-1'], escalationRefs: ['esc-1'], autonomousUseCount: 2
+    });
+    expect(validateAIAttestation(ai, {
+      maxAutonomousUseCount: 3,
+      humanReviewRequiredActions: ['execute_low_risk'],
+      escalationRequiredActions: ['execute_low_risk']
+    }).valid).toBe(true);
+  });
+
+  it('validates remote governance attestations and trust boundaries', () => {
+    const remote = createRemoteGovernanceAttestation({
+      sourceRuntimeId: 'runtime-a', targetRuntimeId: 'runtime-b', federationRef: 'fed-1',
+      remoteDecisionRef: 'decision-1', remoteAuditRefs: ['audit-1']
+    });
+    expect(validateRemoteGovernanceAttestation(remote, {
+      allowedFederationRefs: ['fed-1'],
+      allowedTrustDomainPairs: [{ sourceRuntimeId: 'runtime-a', targetRuntimeId: 'runtime-b' }]
+    }).valid).toBe(true);
+  });
+});

--- a/runtime/attestations/ai-attestation.ts
+++ b/runtime/attestations/ai-attestation.ts
@@ -1,0 +1,36 @@
+import { AIAttestation, AIAttestationValidationOptions, ValidationResult } from './types';
+
+const aiAttestations = new Map<string, AIAttestation>();
+
+export function createAIAttestation(input: AIAttestation): AIAttestation {
+  aiAttestations.set(input.aiActorId, input);
+  return input;
+}
+
+export function validateAIAttestation(input: AIAttestation, options: AIAttestationValidationOptions = {}): ValidationResult {
+  const reasons: string[] = [];
+  if (!input.aiActorId || input.allowedScopes.length === 0) reasons.push('missing_required_fields');
+
+  const unauthorizedActions = input.executedActions.filter((action) => !input.allowedScopes.includes(action));
+  if (unauthorizedActions.length > 0) reasons.push('allowed_scope_incompatible');
+
+  if (typeof options.maxAutonomousUseCount === 'number' && input.autonomousUseCount > options.maxAutonomousUseCount) {
+    reasons.push('autonomous_use_limit_exceeded');
+  }
+
+  const humanReviewRequired = options.humanReviewRequiredActions ?? [];
+  if (input.executedActions.some((action) => humanReviewRequired.includes(action)) && input.humanReviewRefs.length === 0) {
+    reasons.push('human_review_required');
+  }
+
+  const escalationRequired = options.escalationRequiredActions ?? [];
+  if (input.executedActions.some((action) => escalationRequired.includes(action)) && input.escalationRefs.length === 0) {
+    reasons.push('escalation_required');
+  }
+
+  return { valid: reasons.length === 0, reasons };
+}
+
+export function resolveAIAttestation(aiActorId: string): AIAttestation | undefined {
+  return aiAttestations.get(aiActorId);
+}

--- a/runtime/attestations/attestation-chain.ts
+++ b/runtime/attestations/attestation-chain.ts
@@ -1,0 +1,46 @@
+import { resolveGovernanceAttestation, validateGovernanceAttestation } from './governance-attestation';
+import { GovernanceAttestation, ValidationResult } from './types';
+
+const chains = new Map<string, GovernanceAttestation[]>();
+
+export function appendAttestationChain(chainId: string, attestation: GovernanceAttestation): GovernanceAttestation[] {
+  const chain = chains.get(chainId) ?? [];
+  chains.set(chainId, [...chain, attestation]);
+  return chains.get(chainId)!;
+}
+
+export function validateAttestationChain(chainId: string): ValidationResult {
+  const chain = chains.get(chainId) ?? [];
+  const reasons: string[] = [];
+  for (let i = 0; i < chain.length; i += 1) {
+    const current = chain[i];
+    const result = validateGovernanceAttestation(current);
+    if (!result.valid) reasons.push(...result.reasons.map((r) => `${current.attestationId}:${r}`));
+
+    if (i > 0) {
+      const previous = chain[i - 1];
+      if (current.previousAttestationRef !== previous.attestationId) reasons.push(`${current.attestationId}:chain_continuity_broken`);
+      if (Date.parse(current.issuedAt) < Date.parse(previous.issuedAt)) reasons.push(`${current.attestationId}:chain_timestamp_regression`);
+    }
+  }
+
+  return { valid: reasons.length === 0, reasons };
+}
+
+export function resolveAttestationChain(chainId: string): GovernanceAttestation[] {
+  return chains.get(chainId) ?? [];
+}
+
+export function reconstructAttestationChainFromTail(tailAttestationId: string): GovernanceAttestation[] {
+  const reconstructed: GovernanceAttestation[] = [];
+  let cursor = resolveGovernanceAttestation(tailAttestationId);
+  while (cursor) {
+    reconstructed.unshift(cursor);
+    cursor = cursor.previousAttestationRef ? resolveGovernanceAttestation(cursor.previousAttestationRef) : undefined;
+  }
+  return reconstructed;
+}
+
+export function clearAttestationChains(): void {
+  chains.clear();
+}

--- a/runtime/attestations/capability-attestation.ts
+++ b/runtime/attestations/capability-attestation.ts
@@ -1,0 +1,25 @@
+import { resolveGovernanceAttestation } from './governance-attestation';
+import { CapabilityAttestation, ValidationResult } from './types';
+
+const capabilityAttestations = new Map<string, CapabilityAttestation>();
+
+export function createCapabilityAttestation(input: CapabilityAttestation): CapabilityAttestation {
+  capabilityAttestations.set(input.capabilityId, input);
+  return input;
+}
+
+export function validateCapabilityAttestation(input: CapabilityAttestation): ValidationResult {
+  const reasons: string[] = [];
+  if (!input.capabilityId || !input.issuingRuntimeId || !input.governanceAttestationRef) reasons.push('missing_required_fields');
+  if (!resolveGovernanceAttestation(input.governanceAttestationRef)) reasons.push('governance_attestation_not_found');
+
+  const { notBefore, notAfter } = input.validityWindow;
+  if (Number.isNaN(Date.parse(notBefore)) || Number.isNaN(Date.parse(notAfter))) reasons.push('invalid_validity_window');
+  if (Date.parse(notBefore) > Date.parse(notAfter)) reasons.push('validity_window_inverted');
+
+  return { valid: reasons.length === 0, reasons };
+}
+
+export function resolveCapabilityAttestation(capabilityId: string): CapabilityAttestation | undefined {
+  return capabilityAttestations.get(capabilityId);
+}

--- a/runtime/attestations/governance-attestation.ts
+++ b/runtime/attestations/governance-attestation.ts
@@ -1,0 +1,55 @@
+import { resolveIntegrityProof } from './integrity-proof';
+import { GovernanceAttestation, ValidationResult } from './types';
+
+const governanceAttestations = new Map<string, GovernanceAttestation>();
+
+type IntegrationHook = (attestation: GovernanceAttestation) => void;
+const hooks: Record<string, IntegrationHook[]> = {
+  governance_session_completion: [],
+  capability_issuance: [],
+  capability_use: [],
+  delegation_validation: [],
+  ai_execution: [],
+  remote_governance_decision: []
+};
+
+export function registerAttestationIntegrationHook(event: keyof typeof hooks, hook: IntegrationHook): void {
+  hooks[event].push(hook);
+}
+
+export function emitAttestationIntegrationEvent(event: keyof typeof hooks, attestation: GovernanceAttestation): void {
+  hooks[event].forEach((hook) => hook(attestation));
+}
+
+export function createGovernanceAttestation(input: GovernanceAttestation): GovernanceAttestation {
+  governanceAttestations.set(input.attestationId, input);
+  return input;
+}
+
+export function validateGovernanceAttestation(input: GovernanceAttestation): ValidationResult {
+  const reasons: string[] = [];
+  if (!input.attestationId || !input.actorId || !input.integrityProofRef) reasons.push('missing_required_fields');
+  if (!input.governanceSessionId || !input.policyTraceId || !input.relationshipId) reasons.push('missing_required_refs');
+  if (input.capabilityRefs.some((ref) => !ref)) reasons.push('invalid_capability_ref');
+  if (Number.isNaN(Date.parse(input.issuedAt))) reasons.push('invalid_issued_at');
+  if (!resolveIntegrityProof(input.integrityProofRef)) reasons.push('integrity_proof_not_found');
+
+  if (input.previousAttestationRef) {
+    const previous = governanceAttestations.get(input.previousAttestationRef);
+    if (!previous) {
+      reasons.push('previous_attestation_not_found');
+    } else if (Date.parse(previous.issuedAt) > Date.parse(input.issuedAt)) {
+      reasons.push('previous_attestation_after_current');
+    }
+  }
+
+  return { valid: reasons.length === 0, reasons };
+}
+
+export function resolveGovernanceAttestation(attestationId: string): GovernanceAttestation | undefined {
+  return governanceAttestations.get(attestationId);
+}
+
+export function clearGovernanceAttestations(): void {
+  governanceAttestations.clear();
+}

--- a/runtime/attestations/index.ts
+++ b/runtime/attestations/index.ts
@@ -1,0 +1,7 @@
+export * from './types';
+export * from './integrity-proof';
+export * from './governance-attestation';
+export * from './attestation-chain';
+export * from './capability-attestation';
+export * from './ai-attestation';
+export * from './remote-attestation';

--- a/runtime/attestations/integrity-proof.ts
+++ b/runtime/attestations/integrity-proof.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'crypto';
+import { IntegrityProof, ValidationResult } from './types';
+
+const proofs = new Map<string, IntegrityProof>();
+
+function hashPayload(payload: unknown): string {
+  return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+}
+
+export function createIntegrityProof(input: Omit<IntegrityProof, 'payloadHash' | 'generatedAt'> & { payload: unknown }): IntegrityProof {
+  const proof: IntegrityProof = {
+    proofId: input.proofId,
+    proofType: input.proofType,
+    payloadHash: hashPayload(input.payload),
+    generatedAt: new Date().toISOString(),
+    parentProofRef: input.parentProofRef
+  };
+
+  proofs.set(proof.proofId, proof);
+  return proof;
+}
+
+export function createChainedIntegrityProof(input: Omit<IntegrityProof, 'payloadHash' | 'generatedAt' | 'proofType'> & { payload: unknown; parentProofRef: string }): IntegrityProof {
+  return createIntegrityProof({ ...input, proofType: 'chained_hash' });
+}
+
+export function validateIntegrityProof(proof: IntegrityProof): ValidationResult {
+  const reasons: string[] = [];
+  if (!proof.proofId || !proof.payloadHash || !proof.generatedAt) reasons.push('missing_required_fields');
+  if (Number.isNaN(Date.parse(proof.generatedAt))) reasons.push('invalid_generated_at');
+  if (proof.proofType === 'chained_hash' && !proof.parentProofRef) reasons.push('missing_parent_proof_ref');
+  if (proof.parentProofRef && !proofs.has(proof.parentProofRef)) reasons.push('parent_proof_not_found');
+  return { valid: reasons.length === 0, reasons };
+}
+
+export function resolveIntegrityProof(proofId: string): IntegrityProof | undefined {
+  return proofs.get(proofId);
+}
+
+export function clearIntegrityProofs(): void {
+  proofs.clear();
+}

--- a/runtime/attestations/remote-attestation.ts
+++ b/runtime/attestations/remote-attestation.ts
@@ -1,0 +1,43 @@
+import { RemoteGovernanceAttestation, RemoteGovernanceValidationOptions, ValidationResult } from './types';
+
+const remoteAttestations = new Map<string, RemoteGovernanceAttestation>();
+
+function attestationKey(input: RemoteGovernanceAttestation): string {
+  return `${input.sourceRuntimeId}::${input.targetRuntimeId}::${input.remoteDecisionRef}`;
+}
+
+export function createRemoteGovernanceAttestation(input: RemoteGovernanceAttestation): RemoteGovernanceAttestation {
+  remoteAttestations.set(attestationKey(input), input);
+  return input;
+}
+
+export function validateRemoteGovernanceAttestation(
+  input: RemoteGovernanceAttestation,
+  options: RemoteGovernanceValidationOptions = {}
+): ValidationResult {
+  const reasons: string[] = [];
+  if (!input.federationRef || !input.remoteDecisionRef) reasons.push('missing_required_fields');
+  if (input.sourceRuntimeId === input.targetRuntimeId) reasons.push('trust_domain_boundary_violated');
+  if (input.remoteAuditRefs.length === 0) reasons.push('missing_remote_audit_refs');
+
+  if (options.allowedFederationRefs && !options.allowedFederationRefs.includes(input.federationRef)) {
+    reasons.push('federation_incompatible');
+  }
+
+  if (options.allowedTrustDomainPairs) {
+    const compatible = options.allowedTrustDomainPairs.some(
+      (pair) => pair.sourceRuntimeId === input.sourceRuntimeId && pair.targetRuntimeId === input.targetRuntimeId
+    );
+    if (!compatible) reasons.push('trust_domain_pair_incompatible');
+  }
+
+  return { valid: reasons.length === 0, reasons };
+}
+
+export function resolveRemoteGovernanceAttestation(
+  sourceRuntimeId: string,
+  targetRuntimeId: string,
+  remoteDecisionRef: string
+): RemoteGovernanceAttestation | undefined {
+  return remoteAttestations.get(`${sourceRuntimeId}::${targetRuntimeId}::${remoteDecisionRef}`);
+}

--- a/runtime/attestations/types.ts
+++ b/runtime/attestations/types.ts
@@ -1,0 +1,79 @@
+export type AttestationType =
+  | 'governance_decision'
+  | 'capability_issued'
+  | 'capability_used'
+  | 'delegation_validated'
+  | 'ai_execution'
+  | 'remote_governance'
+  | 'audit_snapshot';
+
+export type IntegrityProofType = 'local_hash' | 'chained_hash' | 'replay_guard';
+
+export interface IntegrityProof {
+  proofId: string;
+  proofType: IntegrityProofType;
+  payloadHash: string;
+  generatedAt: string;
+  parentProofRef?: string;
+}
+
+export interface GovernanceAttestation {
+  attestationId: string;
+  attestationType: AttestationType;
+  actorId: string;
+  governanceSessionId: string;
+  policyTraceId: string;
+  relationshipId: string;
+  capabilityRefs: string[];
+  decision: 'allow' | 'deny' | 'conditional';
+  issuedAt: string;
+  integrityProofRef: string;
+  previousAttestationRef?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CapabilityValidityWindow {
+  notBefore: string;
+  notAfter: string;
+}
+
+export interface CapabilityAttestation {
+  capabilityId: string;
+  issuingRuntimeId: string;
+  governanceAttestationRef: string;
+  validityWindow: CapabilityValidityWindow;
+  revocationRefs: string[];
+}
+
+export interface AIAttestation {
+  aiActorId: string;
+  allowedScopes: string[];
+  executedActions: string[];
+  humanReviewRefs: string[];
+  escalationRefs: string[];
+  autonomousUseCount: number;
+}
+
+export interface RemoteGovernanceAttestation {
+  sourceRuntimeId: string;
+  targetRuntimeId: string;
+  federationRef: string;
+  remoteDecisionRef: string;
+  remoteAuditRefs: string[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  reasons: string[];
+}
+
+export interface AIAttestationValidationOptions {
+  maxAutonomousUseCount?: number;
+  humanReviewRequiredActions?: string[];
+  escalationRequiredActions?: string[];
+}
+
+export interface RemoteGovernanceValidationOptions {
+  allowedFederationRefs?: string[];
+  allowedTrustDomainPairs?: Array<{ sourceRuntimeId: string; targetRuntimeId: string }>;
+}

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -45,3 +45,5 @@ export * from './governance';
 export * from './distributed';
 
 export * from './capabilities';
+
+export * from './attestations';


### PR DESCRIPTION
### Motivation
- Provide canonical, replay-safe governance evidence semantics so runtimes can produce attested records for decisions, capabilities, AI boundaries and remote governance without adding distributed cryptography or external trust systems.
- Keep the design lightweight and local-only to serve as a foundational phase for future cryptographic hardening while honoring constraints (no blockchain, PKI, networking, consensus, external signers, or databases).

### Description
- Added a new `runtime/attestations` module with core types and files: `types.ts`, `integrity-proof.ts`, `governance-attestation.ts`, `attestation-chain.ts`, `capability-attestation.ts`, `ai-attestation.ts`, `remote-attestation.ts`, `index.ts`, and `README.md` and exported the module from `runtime/index.ts`.
- Implemented integrity proof primitives (`createIntegrityProof`, `createChainedIntegrityProof`, `validateIntegrityProof`) using local SHA-256 payload hashing, plus governance attestation primitives (`createGovernanceAttestation`, `validateGovernanceAttestation`, `resolveGovernanceAttestation`) with integrity-proof and previous-link checks, and composable integration hooks via `registerAttestationIntegrationHook` / `emitAttestationIntegrationEvent`.
- Implemented attestation chain utilities (`appendAttestationChain`, `validateAttestationChain`, `resolveAttestationChain`, `reconstructAttestationChainFromTail`) and capability/AI/remote attestation creation and validation functions (`createCapabilityAttestation`/`validateCapabilityAttestation`, `createAIAttestation`/`validateAIAttestation`, `createRemoteGovernanceAttestation`/`validateRemoteGovernanceAttestation`) enforcing scope, validity windows, human-review/escalation requirements, federation compatibility and trust-pair checks.
- Intentional limitations remain: in-memory storage only, no signer identity/PKI, no distributed consensus, no persistent anti-replay ledger, and `JSON.stringify`-based hashing (non-canonical JSON caveat).

### Testing
- Ran targeted Jest tests: `npm test -- runtime/attestations/__tests__/attestations.test.ts`.
- Result: 1 test suite passed with 6 tests passing (all targeted attestation tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfa4d0f6c83259178dfdac228831d)