### PR TITLE
Add Governance Execution Fabric semantic runtime foundations

### DIFF
--- a/runtime/execution-fabric/README.md
+++ b/runtime/execution-fabric/README.md
@@ -1,0 +1,56 @@
+# Governance Execution Fabric (AOC Core)
+
+The Governance Execution Fabric provides semantic execution coordination for AOC Core governance flows across runtimes and trust domains.
+
+## Why this exists
+
+AOC had governance decisioning and distributed governance primitives, but it lacked a resumable execution layer that could:
+- pause and resume execution,
+- preserve ownership via leases,
+- route work through continuations,
+- preserve obligation and attestation continuity,
+- and capture failure/retry semantics.
+
+## Why this is not a workflow engine
+
+This module does **not** introduce orchestration infrastructure, transport, or external schedulers. It defines protocol/runtime semantics for governance execution state, dependencies, leases, continuation records, and attestation references. It is execution-governance state logic, not a generic BPMN/workflow replacement.
+
+## Governance internet foundation
+
+Execution fabric enables governance work to move between runtimes while maintaining:
+- explicit execution ownership,
+- trust-domain-aware continuation points,
+- auditable state transitions,
+- and obligation/attestation continuity.
+
+This is a foundational layer for future distributed execution.
+
+## Plan vs session
+
+- **Governance Session**: policy/governance context and decision envelope.
+- **Execution Plan**: concrete execution graph for actions, obligations, dependencies, leases, and continuation states.
+
+## Leases and continuations
+
+- **Execution leases**: time-bounded execution ownership claims.
+- **Execution continuations**: resumable hand-off contracts between runtimes or between automation and human review.
+
+## Distributed obligation coordination
+
+Obligations are attached at step level and tracked through required/optional semantics. Required-step failure fails the plan; optional-step failure is tolerated.
+
+## Human review continuation
+
+Steps such as `request_human_review` and continuation type `remote_human_review` enable pause-and-resume around human approvals.
+
+## Attestation continuity
+
+No cryptography is implemented here. The fabric only handles attestation references, validation seams, and step-level attestation requirements.
+
+## Current limitations
+
+- No networking or transport.
+- No consensus, distributed locks, or global clock guarantees.
+- In-memory state only.
+- No persistence/recovery guarantees.
+- No automated backoff/scheduling logic.

--- a/runtime/execution-fabric/__tests__/execution-fabric.test.ts
+++ b/runtime/execution-fabric/__tests__/execution-fabric.test.ts
@@ -1,0 +1,90 @@
+import { ExecutionFabric } from '../execution-fabric';
+import { GovernanceExecutionPlan } from '../types';
+
+const basePlan = (): GovernanceExecutionPlan => ({
+  executionPlanId: 'plan-1',
+  governanceSessionId: 'session-1',
+  sourceRuntimeId: 'runtime-a',
+  targetRuntimeIds: ['runtime-b'],
+  relationshipId: 'rel-1',
+  capabilityRefs: ['cap-1'],
+  requiredObligations: ['obl-1'],
+  executionSteps: [],
+  status: 'planned',
+  createdAt: new Date().toISOString(),
+});
+
+describe('ExecutionFabric', () => {
+  it('supports execution plan lifecycle', () => {
+    const fabric = new ExecutionFabric();
+    fabric.createExecutionPlan(basePlan());
+    fabric.startExecutionPlan('plan-1');
+    fabric.pauseExecutionPlan('plan-1');
+    fabric.startExecutionPlan('plan-1');
+    fabric.completeExecutionPlan('plan-1');
+
+    expect(() => fabric.startExecutionPlan('plan-1')).toThrow(/cannot start/i);
+  });
+
+  it('enforces dependency-gated and blocked step listing', () => {
+    const fabric = new ExecutionFabric();
+    fabric.createExecutionPlan(basePlan());
+    fabric.addExecutionStep('plan-1', { stepId: 's1', stepType: 'evaluate_policy', runtimeId: 'runtime-a', status: 'planned', dependsOn: [], obligationRefs: [], attestationRefs: [] });
+    fabric.addExecutionStep('plan-1', { stepId: 's2', stepType: 'validate_identity', runtimeId: 'runtime-a', status: 'planned', dependsOn: ['s1'], obligationRefs: [], attestationRefs: [] });
+
+    expect(fabric.listExecutableSteps('plan-1').map((s) => s.stepId)).toEqual(['s1']);
+    expect(fabric.listBlockedSteps('plan-1').map((s) => s.stepId)).toEqual(['s2']);
+  });
+
+  it('fails plan on failed required step but not optional step', () => {
+    const fabric = new ExecutionFabric();
+    const plan = fabric.createExecutionPlan(basePlan());
+    fabric.startExecutionPlan(plan.executionPlanId);
+
+    fabric.addExecutionStep('plan-1', { stepId: 'required', stepType: 'execute_obligation', runtimeId: 'runtime-a', status: 'planned', dependsOn: [], obligationRefs: ['obl-1'], attestationRefs: [] });
+    fabric.failExecutionStep('plan-1', 'required', 'boom');
+    expect(() => fabric.startExecutionPlan('plan-1')).toThrow();
+
+    const fabric2 = new ExecutionFabric();
+    fabric2.createExecutionPlan({ ...basePlan(), executionPlanId: 'plan-2' });
+    fabric2.startExecutionPlan('plan-2');
+    fabric2.addExecutionStep('plan-2', { stepId: 'optional', stepType: 'emit_attestation', runtimeId: 'runtime-a', status: 'planned', dependsOn: [], obligationRefs: [], attestationRefs: [], optional: true });
+    fabric2.failExecutionStep('plan-2', 'optional', 'non-critical');
+    fabric2.completeExecutionPlan('plan-2');
+  });
+
+  it('supports lease validation/release/revocation', () => {
+    const fabric = new ExecutionFabric();
+    fabric.issueExecutionLease({ leaseId: 'lease-1', executionPlanId: 'plan-1', runtimeId: 'runtime-a', holderActorId: 'actor-1', issuedAt: new Date().toISOString(), expiresAt: '2999-01-01T00:00:00.000Z', status: 'active' });
+    expect(fabric.validateExecutionLease('lease-1')).toBe(true);
+    fabric.releaseExecutionLease('lease-1');
+    expect(fabric.validateExecutionLease('lease-1')).toBe(false);
+    fabric.revokeExecutionLease('lease-1');
+    expect(fabric.validateExecutionLease('lease-1')).toBe(false);
+  });
+
+  it('supports continuation creation and resolution', () => {
+    const fabric = new ExecutionFabric();
+    fabric.createExecutionContinuation({ continuationId: 'cont-1', executionPlanId: 'plan-1', sourceRuntimeId: 'runtime-a', targetRuntimeId: 'runtime-b', continuationType: 'remote_governance', statePayloadRef: 'state://1', requiredAttestationRefs: [], createdAt: new Date().toISOString(), status: 'pending' });
+    expect(fabric.listPendingContinuations('plan-1')).toHaveLength(1);
+    fabric.resolveExecutionContinuation('cont-1');
+    expect(fabric.listPendingContinuations('plan-1')).toHaveLength(0);
+  });
+
+  it('derives retry recommendations', () => {
+    const fabric = new ExecutionFabric();
+    fabric.recordExecutionFailure({ failureId: 'f1', executionPlanId: 'plan-1', stepId: 's1', runtimeId: 'runtime-a', reasonCode: 'remote_runtime_timeout', retryable: true, occurredAt: new Date().toISOString() });
+    expect(fabric.isFailureRetryable('f1')).toBe(true);
+    expect(fabric.deriveRetryRecommendation('f1')).toBe('retry_remote_runtime');
+  });
+
+  it('enforces attestation-required step validation', () => {
+    const fabric = new ExecutionFabric();
+    fabric.createExecutionPlan(basePlan());
+    fabric.addExecutionStep('plan-1', { stepId: 'att-step', stepType: 'emit_attestation', runtimeId: 'runtime-a', status: 'planned', dependsOn: [], obligationRefs: [], attestationRefs: [] });
+    fabric.requireStepAttestation('plan-1', 'att-step');
+    expect(() => fabric.completeExecutionStep('plan-1', 'att-step')).toThrow(/attestation/i);
+    fabric.attachExecutionAttestation('plan-1', 'att-step', 'att-1');
+    fabric.completeExecutionStep('plan-1', 'att-step');
+  });
+});

--- a/runtime/execution-fabric/execution-attestation.ts
+++ b/runtime/execution-fabric/execution-attestation.ts
@@ -1,0 +1,10 @@
+import { ExecutionAttestationRef } from './types';
+
+export function buildExecutionAttestationRef(executionPlanId: string, stepId: string, attestationRef: string): ExecutionAttestationRef {
+  return {
+    executionPlanId,
+    stepId,
+    attestationRef,
+    attachedAt: new Date().toISOString(),
+  };
+}

--- a/runtime/execution-fabric/execution-continuation.ts
+++ b/runtime/execution-fabric/execution-continuation.ts
@@ -1,0 +1,5 @@
+import { ExecutionContinuation } from './types';
+
+export function isPendingContinuation(continuation: ExecutionContinuation): boolean {
+  return continuation.status === 'pending';
+}

--- a/runtime/execution-fabric/execution-fabric.ts
+++ b/runtime/execution-fabric/execution-fabric.ts
@@ -1,0 +1,225 @@
+import { buildExecutionAttestationRef } from './execution-attestation';
+import { isPendingContinuation } from './execution-continuation';
+import { deriveRecommendation, failureRetryable } from './execution-failure';
+import { isLeaseActive } from './execution-lease';
+import { canStartPlan, findStep, hasUnfinishedRequiredSteps, planIsWaiting } from './execution-plan';
+import { dependenciesCompleted, listBlocked, listExecutable } from './execution-step';
+import {
+  ExecutionAttestationRef,
+  ExecutionContinuation,
+  ExecutionFabricAdapters,
+  ExecutionFailure,
+  ExecutionLease,
+  GovernanceExecutionPlan,
+  GovernanceExecutionStep,
+  RetryRecommendation,
+} from './types';
+
+export class ExecutionFabric {
+  private readonly plans = new Map<string, GovernanceExecutionPlan>();
+  private readonly leases = new Map<string, ExecutionLease>();
+  private readonly continuations = new Map<string, ExecutionContinuation>();
+  private readonly failures = new Map<string, ExecutionFailure>();
+  private readonly stepAttestations = new Map<string, ExecutionAttestationRef[]>();
+
+  constructor(private readonly adapters: ExecutionFabricAdapters = {}) {}
+
+  createExecutionPlan(plan: GovernanceExecutionPlan): GovernanceExecutionPlan {
+    this.plans.set(plan.executionPlanId, { ...plan, status: 'planned', createdAt: plan.createdAt ?? new Date().toISOString() });
+    return this.getPlan(plan.executionPlanId);
+  }
+
+  startExecutionPlan(executionPlanId: string): GovernanceExecutionPlan {
+    const plan = this.getPlan(executionPlanId);
+    if (!canStartPlan(plan.status)) throw new Error(`Plan cannot start from state ${plan.status}`);
+    plan.status = 'running';
+    return plan;
+  }
+
+  pauseExecutionPlan(executionPlanId: string): GovernanceExecutionPlan {
+    const plan = this.getPlan(executionPlanId);
+    if (plan.status !== 'running') throw new Error('Only running plans can be paused');
+    plan.status = 'paused';
+    return plan;
+  }
+
+  completeExecutionPlan(executionPlanId: string): GovernanceExecutionPlan {
+    const plan = this.getPlan(executionPlanId);
+    if (planIsWaiting(plan)) throw new Error('Plan waiting on remote runtime or human review cannot complete');
+    if (hasUnfinishedRequiredSteps(plan)) throw new Error('Plan has unfinished required steps');
+    plan.status = 'completed';
+    plan.completedAt = new Date().toISOString();
+    return plan;
+  }
+
+  cancelExecutionPlan(executionPlanId: string): GovernanceExecutionPlan {
+    const plan = this.getPlan(executionPlanId);
+    if (plan.status === 'completed') throw new Error('Completed plan cannot be cancelled');
+    plan.status = 'cancelled';
+    plan.completedAt = new Date().toISOString();
+    return plan;
+  }
+
+  failExecutionPlan(executionPlanId: string): GovernanceExecutionPlan {
+    const plan = this.getPlan(executionPlanId);
+    if (plan.status === 'completed' || plan.status === 'cancelled') throw new Error('Terminal plan cannot be failed');
+    plan.status = 'failed';
+    return plan;
+  }
+
+  addExecutionStep(executionPlanId: string, step: GovernanceExecutionStep): GovernanceExecutionPlan {
+    const plan = this.getPlan(executionPlanId);
+    plan.executionSteps.push(step);
+    return plan;
+  }
+
+  startExecutionStep(executionPlanId: string, stepId: string): GovernanceExecutionStep {
+    const plan = this.getPlan(executionPlanId);
+    const step = findStep(plan, stepId);
+    if (!dependenciesCompleted(plan, step)) throw new Error('Step dependencies are not completed');
+    step.status = 'running';
+    step.startedAt = new Date().toISOString();
+    this.adapters.governanceRuntime?.beginGovernanceStep(step);
+    return step;
+  }
+
+  completeExecutionStep(executionPlanId: string, stepId: string): GovernanceExecutionStep {
+    const plan = this.getPlan(executionPlanId);
+    const step = findStep(plan, stepId);
+    if (step.stepType === 'emit_attestation' && step.attestationRefs.length === 0) throw new Error('Attestation step requires attestation references');
+    if (step.requiresAttestation && step.attestationRefs.length === 0) throw new Error('Step requires attestation references');
+    step.status = 'completed';
+    step.completedAt = new Date().toISOString();
+    this.adapters.governanceRuntime?.completeGovernanceStep(step);
+    return step;
+  }
+
+  failExecutionStep(executionPlanId: string, stepId: string, reason: string): GovernanceExecutionStep {
+    const plan = this.getPlan(executionPlanId);
+    const step = findStep(plan, stepId);
+    step.status = 'failed';
+    step.failureReason = reason;
+    if (!step.optional) this.failExecutionPlan(executionPlanId);
+    return step;
+  }
+
+  listExecutableSteps(executionPlanId: string): GovernanceExecutionStep[] {
+    return listExecutable(this.getPlan(executionPlanId));
+  }
+
+  listBlockedSteps(executionPlanId: string): GovernanceExecutionStep[] {
+    return listBlocked(this.getPlan(executionPlanId));
+  }
+
+  issueExecutionLease(lease: ExecutionLease): ExecutionLease {
+    this.leases.set(lease.leaseId, { ...lease, status: 'active' });
+    return this.getLease(lease.leaseId);
+  }
+
+  validateExecutionLease(leaseId: string): boolean {
+    const lease = this.getLease(leaseId);
+    return isLeaseActive(lease, new Date().toISOString());
+  }
+
+  releaseExecutionLease(leaseId: string): ExecutionLease {
+    const lease = this.getLease(leaseId);
+    lease.status = 'released';
+    return lease;
+  }
+
+  revokeExecutionLease(leaseId: string): ExecutionLease {
+    const lease = this.getLease(leaseId);
+    lease.status = 'revoked';
+    return lease;
+  }
+
+  expireExecutionLease(leaseId: string): ExecutionLease {
+    const lease = this.getLease(leaseId);
+    lease.status = 'expired';
+    return lease;
+  }
+
+  createExecutionContinuation(continuation: ExecutionContinuation): ExecutionContinuation {
+    this.continuations.set(continuation.continuationId, { ...continuation, status: 'pending' });
+    this.adapters.distributedGovernance?.notifyContinuation(continuation);
+    return this.getContinuation(continuation.continuationId);
+  }
+
+  resolveExecutionContinuation(continuationId: string): ExecutionContinuation {
+    const continuation = this.getContinuation(continuationId);
+    continuation.status = 'resolved';
+    continuation.resolvedAt = new Date().toISOString();
+    return continuation;
+  }
+
+  listPendingContinuations(executionPlanId: string): ExecutionContinuation[] {
+    return Array.from(this.continuations.values()).filter((continuation) => continuation.executionPlanId === executionPlanId && isPendingContinuation(continuation));
+  }
+
+  recordExecutionFailure(failure: ExecutionFailure): ExecutionFailure {
+    this.failures.set(failure.failureId, failure);
+    return failure;
+  }
+
+  markFailureResolved(failureId: string): ExecutionFailure {
+    const failure = this.getFailure(failureId);
+    failure.resolvedAt = new Date().toISOString();
+    return failure;
+  }
+
+  isFailureRetryable(failureId: string): boolean {
+    return failureRetryable(this.getFailure(failureId));
+  }
+
+  deriveRetryRecommendation(failureId: string): RetryRecommendation {
+    return deriveRecommendation(this.getFailure(failureId));
+  }
+
+  createExecutionAttestationRef(executionPlanId: string, stepId: string, attestationRef: string): ExecutionAttestationRef {
+    return buildExecutionAttestationRef(executionPlanId, stepId, attestationRef);
+  }
+
+  attachExecutionAttestation(executionPlanId: string, stepId: string, attestationRef: string): ExecutionAttestationRef {
+    if (this.adapters.attestationLayer && !this.adapters.attestationLayer.validateAttestationRef(attestationRef)) {
+      throw new Error(`Invalid attestation reference: ${attestationRef}`);
+    }
+    const record = this.createExecutionAttestationRef(executionPlanId, stepId, attestationRef);
+    const key = `${executionPlanId}:${stepId}`;
+    const existing = this.stepAttestations.get(key) ?? [];
+    existing.push(record);
+    this.stepAttestations.set(key, existing);
+    const step = findStep(this.getPlan(executionPlanId), stepId);
+    step.attestationRefs.push(attestationRef);
+    return record;
+  }
+
+  requireStepAttestation(executionPlanId: string, stepId: string): GovernanceExecutionStep {
+    const step = findStep(this.getPlan(executionPlanId), stepId);
+    step.requiresAttestation = true;
+    return step;
+  }
+
+  private getPlan(executionPlanId: string): GovernanceExecutionPlan {
+    const plan = this.plans.get(executionPlanId);
+    if (!plan) throw new Error(`Execution plan not found: ${executionPlanId}`);
+    return plan;
+  }
+
+  private getLease(leaseId: string): ExecutionLease {
+    const lease = this.leases.get(leaseId);
+    if (!lease) throw new Error(`Execution lease not found: ${leaseId}`);
+    return lease;
+  }
+
+  private getContinuation(continuationId: string): ExecutionContinuation {
+    const continuation = this.continuations.get(continuationId);
+    if (!continuation) throw new Error(`Execution continuation not found: ${continuationId}`);
+    return continuation;
+  }
+
+  private getFailure(failureId: string): ExecutionFailure {
+    const failure = this.failures.get(failureId);
+    if (!failure) throw new Error(`Execution failure not found: ${failureId}`);
+    return failure;
+  }
+}

--- a/runtime/execution-fabric/execution-failure.ts
+++ b/runtime/execution-fabric/execution-failure.ts
@@ -1,0 +1,13 @@
+import { ExecutionFailure, RetryRecommendation } from './types';
+
+export function failureRetryable(failure: ExecutionFailure): boolean {
+  return failure.retryable && !failure.resolvedAt;
+}
+
+export function deriveRecommendation(failure: ExecutionFailure): RetryRecommendation {
+  if (failure.reasonCode.includes('revocation_ack')) return 'wait_for_revocation_ack';
+  if (failure.reasonCode.includes('human_review')) return 'require_human_review';
+  if (failure.reasonCode.includes('remote_runtime')) return 'retry_remote_runtime';
+  if (failure.retryable) return 'retry_same_runtime';
+  return 'abort_execution';
+}

--- a/runtime/execution-fabric/execution-lease.ts
+++ b/runtime/execution-fabric/execution-lease.ts
@@ -1,0 +1,5 @@
+import { ExecutionLease } from './types';
+
+export function isLeaseActive(lease: ExecutionLease, nowIso: string): boolean {
+  return lease.status === 'active' && lease.expiresAt > nowIso;
+}

--- a/runtime/execution-fabric/execution-plan.ts
+++ b/runtime/execution-fabric/execution-plan.ts
@@ -1,0 +1,19 @@
+import { GovernanceExecutionPlan, GovernanceExecutionPlanStatus, GovernanceExecutionStep } from './types';
+
+export function canStartPlan(status: GovernanceExecutionPlanStatus): boolean {
+  return status === 'planned' || status === 'paused';
+}
+
+export function hasUnfinishedRequiredSteps(plan: GovernanceExecutionPlan): boolean {
+  return plan.executionSteps.some((step) => !step.optional && step.status !== 'completed');
+}
+
+export function planIsWaiting(plan: GovernanceExecutionPlan): boolean {
+  return plan.status === 'waiting_remote_runtime' || plan.status === 'waiting_human_review';
+}
+
+export function findStep(plan: GovernanceExecutionPlan, stepId: string): GovernanceExecutionStep {
+  const step = plan.executionSteps.find((candidate) => candidate.stepId === stepId);
+  if (!step) throw new Error(`Execution step not found: ${stepId}`);
+  return step;
+}

--- a/runtime/execution-fabric/execution-step.ts
+++ b/runtime/execution-fabric/execution-step.ts
@@ -1,0 +1,13 @@
+import { GovernanceExecutionPlan, GovernanceExecutionStep } from './types';
+
+export function dependenciesCompleted(plan: GovernanceExecutionPlan, step: GovernanceExecutionStep): boolean {
+  return step.dependsOn.every((stepId) => plan.executionSteps.some((candidate) => candidate.stepId === stepId && candidate.status === 'completed'));
+}
+
+export function listExecutable(plan: GovernanceExecutionPlan): GovernanceExecutionStep[] {
+  return plan.executionSteps.filter((step) => step.status === 'planned' && dependenciesCompleted(plan, step));
+}
+
+export function listBlocked(plan: GovernanceExecutionPlan): GovernanceExecutionStep[] {
+  return plan.executionSteps.filter((step) => step.status === 'planned' && !dependenciesCompleted(plan, step));
+}

--- a/runtime/execution-fabric/index.ts
+++ b/runtime/execution-fabric/index.ts
@@ -1,0 +1,2 @@
+export * from './execution-fabric';
+export * from './types';

--- a/runtime/execution-fabric/types.ts
+++ b/runtime/execution-fabric/types.ts
@@ -1,0 +1,152 @@
+export type GovernanceExecutionPlanStatus =
+  | 'planned'
+  | 'running'
+  | 'paused'
+  | 'waiting_remote_runtime'
+  | 'waiting_human_review'
+  | 'failed'
+  | 'completed'
+  | 'cancelled';
+
+export type GovernanceExecutionStepType =
+  | 'evaluate_policy'
+  | 'validate_identity'
+  | 'validate_relationship'
+  | 'issue_capability'
+  | 'evaluate_capability_use'
+  | 'execute_obligation'
+  | 'request_human_review'
+  | 'await_remote_decision'
+  | 'emit_attestation'
+  | 'propagate_revocation';
+
+export type GovernanceExecutionStepStatus = 'planned' | 'running' | 'blocked' | 'completed' | 'failed' | 'skipped';
+
+export type ExecutionLeaseStatus = 'active' | 'expired' | 'released' | 'revoked';
+
+export type ExecutionContinuationType =
+  | 'remote_governance'
+  | 'remote_human_review'
+  | 'remote_capability_validation'
+  | 'remote_revocation_propagation'
+  | 'remote_audit_resolution';
+
+export type ExecutionContinuationStatus = 'pending' | 'resolved' | 'failed' | 'cancelled';
+
+export type RetryRecommendation =
+  | 'retry_same_runtime'
+  | 'retry_remote_runtime'
+  | 'require_human_review'
+  | 'abort_execution'
+  | 'wait_for_revocation_ack';
+
+export interface GovernanceExecutionStep {
+  stepId: string;
+  stepType: GovernanceExecutionStepType;
+  runtimeId: string;
+  status: GovernanceExecutionStepStatus;
+  dependsOn: string[];
+  obligationRefs: string[];
+  attestationRefs: string[];
+  optional?: boolean;
+  requiresAttestation?: boolean;
+  startedAt?: string;
+  completedAt?: string;
+  failureReason?: string;
+}
+
+export interface GovernanceExecutionPlan {
+  executionPlanId: string;
+  governanceSessionId: string;
+  sourceRuntimeId: string;
+  targetRuntimeIds: string[];
+  relationshipId: string;
+  capabilityRefs: string[];
+  requiredObligations: string[];
+  executionSteps: GovernanceExecutionStep[];
+  status: GovernanceExecutionPlanStatus;
+  createdAt: string;
+  completedAt?: string;
+}
+
+export interface ExecutionLease {
+  leaseId: string;
+  executionPlanId: string;
+  runtimeId: string;
+  holderActorId: string;
+  issuedAt: string;
+  expiresAt: string;
+  status: ExecutionLeaseStatus;
+}
+
+export interface ExecutionContinuation {
+  continuationId: string;
+  executionPlanId: string;
+  sourceRuntimeId: string;
+  targetRuntimeId: string;
+  continuationType: ExecutionContinuationType;
+  statePayloadRef: string;
+  requiredAttestationRefs: string[];
+  createdAt: string;
+  resolvedAt?: string;
+  status: ExecutionContinuationStatus;
+}
+
+export interface ExecutionFailure {
+  failureId: string;
+  executionPlanId: string;
+  stepId: string;
+  runtimeId: string;
+  reasonCode: string;
+  retryable: boolean;
+  occurredAt: string;
+  resolvedAt?: string;
+}
+
+export interface ExecutionAttestationRef {
+  executionPlanId: string;
+  stepId: string;
+  attestationRef: string;
+  attachedAt: string;
+}
+
+export interface GovernanceRuntimeAdapter {
+  beginGovernanceStep(step: GovernanceExecutionStep): void;
+  completeGovernanceStep(step: GovernanceExecutionStep): void;
+}
+
+export interface CapabilityRuntimeAdapter {
+  validateCapabilityRef(capabilityRef: string): boolean;
+}
+
+export interface DistributedGovernanceAdapter {
+  notifyContinuation(continuation: ExecutionContinuation): void;
+}
+
+export interface AuditPlaneAdapter {
+  recordExecutionEvent(eventType: string, payload: Record<string, unknown>): void;
+}
+
+export interface AttestationLayerAdapter {
+  validateAttestationRef(attestationRef: string): boolean;
+}
+
+export interface HumanReviewAdapter {
+  requestHumanReview(executionPlanId: string, stepId: string): string;
+}
+
+export interface AIGovernanceFlags {
+  requiresEscalation?: boolean;
+  requiresHumanReview?: boolean;
+  reasonCodes?: string[];
+}
+
+export interface ExecutionFabricAdapters {
+  governanceRuntime?: GovernanceRuntimeAdapter;
+  capabilityRuntime?: CapabilityRuntimeAdapter;
+  distributedGovernance?: DistributedGovernanceAdapter;
+  auditPlane?: AuditPlaneAdapter;
+  attestationLayer?: AttestationLayerAdapter;
+  humanReview?: HumanReviewAdapter;
+  aiGovernanceFlags?: AIGovernanceFlags;
+}

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -47,3 +47,4 @@ export * from './distributed';
 export * from './capabilities';
 
 export * from './attestations';
+export * from './execution-fabric';


### PR DESCRIPTION
### Motivation
- Provide a resumable, protocol-level execution fabric to coordinate governance work across runtimes, trust domains, obligations, attestations, and human reviews without introducing runtime networking or distributed infra. 
- Create a clear, in-memory semantic foundation that supports leases, continuations, failure/retry semantics, and attestation seams as a step toward future distributed execution. 

### Description
- Add a new `runtime/execution-fabric` module with canonical types in `types.ts` and adapter seams for `GovernanceRuntime`, `CapabilityRuntime`, `DistributedGovernance`, `AuditPlane`, `AttestationLayer`, `HumanReview`, and AI governance flags. 
- Implement `ExecutionFabric` service (`execution-fabric.ts`) providing plan lifecycle APIs (`create/start/pause/complete/cancel/fail`), step engine APIs (`add/start/complete/fail`, `listExecutableSteps`, `listBlockedSteps`), and enforcement rules for dependencies, required/optional steps, and attestation gates. 
- Implement lease semantics (`execution-lease.ts` + APIs to `issue/validate/release/revoke/expire`) as local, time-bounded ownership claims and continuations (`execution-continuation.ts` + create/resolve/listPending) for resumable hand-offs. 
- Implement failure tracking and retry recommendation logic (`execution-failure.ts`) and attestation reference creation/attachment (`execution-attestation.ts`), plus `README.md` documenting design boundaries and current limitations. 
- Export the module from the runtime public API (`runtime/index.ts`) and include targeted unit tests in `__tests__/execution-fabric.test.ts`.

### Testing
- Ran the targeted Jest suite with `npx jest runtime/execution-fabric/__tests__/execution-fabric.test.ts`, covering plan lifecycle, dependency-gated step listing, blocked steps, required vs optional failure behavior, lease validation/release/revocation, continuation creation/resolution, retry recommendation derivation, and attestation-required validation. 
- All tests passed: the suite ran and reported `PASS` (7 tests, 1 test suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfde0c3148325b34b92e8e2d7712f)