### PR TITLE
feat(auth-runtime): add deterministic Policy Condition AST and evaluation engine

### DIFF
--- a/packages/authorization-runtime/src/index.ts
+++ b/packages/authorization-runtime/src/index.ts
@@ -4,26 +4,360 @@ import { ConsentRuntime } from "@aoc-runtime/consent-runtime";
 import { GovernanceRuntime } from "@aoc-runtime/governance-runtime";
 import { ActorRef, GovernanceScope, NamespaceRef } from "@aoc-runtime/shared-types";
 
-export interface AuthorizationInput {
+export type PolicyValue = string | number | boolean | null | string[] | number[] | boolean[];
+
+export type PolicyFieldPath =
+  | `actor.${string}`
+  | `namespace.${string}`
+  | `workspace.${string}`
+  | `machine.${string}`
+  | `capability.${string}`
+  | `runtime.${string}`
+  | `temporal.${string}`
+  | string;
+
+export interface PolicyFieldRef {
+  path: PolicyFieldPath;
+}
+
+export type PolicyOperand = PolicyValue | PolicyFieldRef;
+
+interface BaseCondition {
+  id?: string;
+  source?: string;
+}
+
+export interface PolicyEqualsCondition extends BaseCondition {
+  op: "equals";
+  left: PolicyOperand;
+  right: PolicyOperand;
+}
+
+export interface PolicyNotEqualsCondition extends BaseCondition {
+  op: "not_equals";
+  left: PolicyOperand;
+  right: PolicyOperand;
+}
+
+export interface PolicyInCondition extends BaseCondition {
+  op: "in";
+  left: PolicyOperand;
+  right: PolicyOperand;
+}
+
+export interface PolicyNotInCondition extends BaseCondition {
+  op: "not_in";
+  left: PolicyOperand;
+  right: PolicyOperand;
+}
+
+export interface PolicyGreaterThanCondition extends BaseCondition {
+  op: "greater_than";
+  left: PolicyOperand;
+  right: PolicyOperand;
+}
+
+export interface PolicyLessThanCondition extends BaseCondition {
+  op: "less_than";
+  left: PolicyOperand;
+  right: PolicyOperand;
+}
+
+export interface PolicyContainsCondition extends BaseCondition {
+  op: "contains";
+  left: PolicyOperand;
+  right: PolicyOperand;
+}
+
+export interface PolicyExistsCondition extends BaseCondition {
+  op: "exists";
+  field: PolicyFieldRef;
+}
+
+export interface PolicyBeforeCondition extends BaseCondition {
+  op: "before";
+  at: PolicyOperand;
+}
+
+export interface PolicyAfterCondition extends BaseCondition {
+  op: "after";
+  at: PolicyOperand;
+}
+
+export interface PolicyExpiresInCondition extends BaseCondition {
+  op: "expires_in";
+  start: PolicyOperand;
+  durationSeconds: number;
+}
+
+export interface PolicyActiveWindowCondition extends BaseCondition {
+  op: "active_window";
+  start: PolicyOperand;
+  end: PolicyOperand;
+}
+
+export interface PolicyAndCondition extends BaseCondition {
+  op: "and";
+  conditions: PolicyCondition[];
+}
+
+export interface PolicyOrCondition extends BaseCondition {
+  op: "or";
+  conditions: PolicyCondition[];
+}
+
+export interface PolicyNotCondition extends BaseCondition {
+  op: "not";
+  condition: PolicyCondition;
+}
+
+export type PolicyCondition =
+  | PolicyEqualsCondition
+  | PolicyNotEqualsCondition
+  | PolicyInCondition
+  | PolicyNotInCondition
+  | PolicyGreaterThanCondition
+  | PolicyLessThanCondition
+  | PolicyContainsCondition
+  | PolicyExistsCondition
+  | PolicyBeforeCondition
+  | PolicyAfterCondition
+  | PolicyExpiresInCondition
+  | PolicyActiveWindowCondition
+  | PolicyAndCondition
+  | PolicyOrCondition
+  | PolicyNotCondition;
+
+export interface PolicyObligation {
+  code: string;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyFragment {
+  id: string;
+  condition: PolicyCondition;
+  source?: string;
+}
+
+export interface RuntimePolicy {
+  id: string;
+  source?: string;
+  effect: "allow" | "deny";
+  condition: PolicyCondition;
+  obligations?: PolicyObligation[];
+  extends?: string[];
+}
+
+export interface PolicyTraceEntry {
+  conditionId: string;
+  op: PolicyCondition["op"];
+  passed: boolean;
+  source?: string;
+  detail: string;
+}
+
+export interface PolicyEvaluationResult {
+  decision: "allow" | "deny";
+  obligations: PolicyObligation[];
+  traces: PolicyTraceEntry[];
+  matchedConditions: string[];
+  failedConditions: string[];
+  inheritedPolicySources: string[];
+  triggeredObligations: string[];
+}
+
+export interface PolicyRuntimeContext {
   actor: ActorRef;
   namespace: NamespaceRef;
   scope: GovernanceScope;
   action: string;
   resource: string;
   machineActor?: ActorRef;
+  capability?: Record<string, unknown>;
+  workspace?: Record<string, unknown>;
+  runtime?: Record<string, unknown>;
+  temporal?: {
+    now?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface AuthorizationInput extends PolicyRuntimeContext {
   at?: string;
+  policies?: RuntimePolicy[];
+  policyFragments?: PolicyFragment[];
+  providerMetadata?: Record<string, unknown>;
+  organizationTopology?: Record<string, unknown>;
 }
 
 export interface AuthorizationDecision {
   decision: "allow" | "deny";
   allowed: boolean;
-  failedStage?: "governance" | "capability" | "consent";
+  failedStage?: "policy" | "governance" | "capability" | "consent";
   reasoningChain: string[];
+  obligations: PolicyObligation[];
   provenance: Record<string, unknown>;
   explainability: Record<string, unknown>;
 }
 
+const asArray = (value: PolicyOperand): unknown[] => Array.isArray(value) ? value : [];
+
+const resolvePath = (obj: Record<string, unknown>, path: string): unknown => {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (current == null || typeof current !== "object") {
+      return undefined;
+    }
+    return (current as Record<string, unknown>)[segment];
+  }, obj);
+};
+
+const asNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+const asDateMs = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+class PolicyConditionEngine {
+  evaluate(policies: RuntimePolicy[], fragments: PolicyFragment[], context: PolicyRuntimeContext): PolicyEvaluationResult {
+    if (!policies.length) {
+      return {
+        decision: "allow", obligations: [], traces: [], matchedConditions: [], failedConditions: [],
+        inheritedPolicySources: [], triggeredObligations: []
+      };
+    }
+
+    const fragmentMap = new Map(fragments.map((fragment) => [fragment.id, fragment]));
+    const traces: PolicyTraceEntry[] = [];
+    const matchedConditions: string[] = [];
+    const failedConditions: string[] = [];
+    const inheritedPolicySources = new Set<string>();
+    const obligations: PolicyObligation[] = [];
+    const triggeredObligations: string[] = [];
+
+    for (const policy of policies) {
+      const expandedCondition = this.expandPolicyCondition(policy.condition, policy.extends ?? [], fragmentMap, inheritedPolicySources);
+      const passed = this.evalCondition(expandedCondition, context, traces, policy.source ?? policy.id);
+      if (passed) {
+        matchedConditions.push(policy.id);
+        for (const obligation of policy.obligations ?? []) {
+          obligations.push(obligation);
+          triggeredObligations.push(obligation.code);
+        }
+        if (policy.effect === "deny") {
+          return {
+            decision: "deny", obligations, traces, matchedConditions, failedConditions,
+            inheritedPolicySources: Array.from(inheritedPolicySources),
+            triggeredObligations
+          };
+        }
+      } else {
+        failedConditions.push(policy.id);
+      }
+    }
+
+    const anyAllowMatched = policies.some((policy) => policy.effect === "allow" && matchedConditions.includes(policy.id));
+    const hasAllowPolicies = policies.some((policy) => policy.effect === "allow");
+    const decision: "allow" | "deny" = hasAllowPolicies && !anyAllowMatched ? "deny" : "allow";
+
+    return {
+      decision,
+      obligations,
+      traces,
+      matchedConditions,
+      failedConditions,
+      inheritedPolicySources: Array.from(inheritedPolicySources),
+      triggeredObligations
+    };
+  }
+
+  private expandPolicyCondition(base: PolicyCondition, extensionIds: string[], fragmentMap: Map<string, PolicyFragment>, inheritedPolicySources: Set<string>): PolicyCondition {
+    if (!extensionIds.length) return base;
+    const composed: PolicyCondition[] = [base];
+    for (const extensionId of extensionIds) {
+      const fragment = fragmentMap.get(extensionId);
+      if (!fragment) continue;
+      if (fragment.source) inheritedPolicySources.add(fragment.source);
+      composed.push(fragment.condition);
+    }
+    return { op: "and", conditions: composed };
+  }
+
+  private resolve(operand: PolicyOperand, context: PolicyRuntimeContext): unknown {
+    if (typeof operand === "object" && operand !== null && "path" in operand) {
+      return resolvePath(context as unknown as Record<string, unknown>, operand.path);
+    }
+    return operand;
+  }
+
+  private evalCondition(condition: PolicyCondition, context: PolicyRuntimeContext, traces: PolicyTraceEntry[], source: string): boolean {
+    const conditionId = condition.id ?? `${source}:${condition.op}:${traces.length}`;
+    const record = (passed: boolean, detail: string): boolean => {
+      traces.push({ conditionId, op: condition.op, passed, source: condition.source ?? source, detail });
+      return passed;
+    };
+
+    switch (condition.op) {
+      case "equals": return record(this.resolve(condition.left, context) === this.resolve(condition.right, context), "equals check");
+      case "not_equals": return record(this.resolve(condition.left, context) !== this.resolve(condition.right, context), "not_equals check");
+      case "in": return record(asArray(this.resolve(condition.right, context) as PolicyOperand).includes(this.resolve(condition.left, context)), "in check");
+      case "not_in": return record(!asArray(this.resolve(condition.right, context) as PolicyOperand).includes(this.resolve(condition.left, context)), "not_in check");
+      case "contains": return record(asArray(this.resolve(condition.left, context) as PolicyOperand).includes(this.resolve(condition.right, context)), "contains check");
+      case "exists": return record(this.resolve(condition.field, context) !== undefined, "exists check");
+      case "greater_than": {
+        const l = asNumber(this.resolve(condition.left, context));
+        const r = asNumber(this.resolve(condition.right, context));
+        return record(l !== undefined && r !== undefined && l > r, "greater_than check");
+      }
+      case "less_than": {
+        const l = asNumber(this.resolve(condition.left, context));
+        const r = asNumber(this.resolve(condition.right, context));
+        return record(l !== undefined && r !== undefined && l < r, "less_than check");
+      }
+      case "before": {
+        const now = asDateMs(context.temporal?.now ?? context.at ?? new Date().toISOString());
+        const at = asDateMs(this.resolve(condition.at, context));
+        return record(now !== undefined && at !== undefined && now < at, "before check");
+      }
+      case "after": {
+        const now = asDateMs(context.temporal?.now ?? context.at ?? new Date().toISOString());
+        const at = asDateMs(this.resolve(condition.at, context));
+        return record(now !== undefined && at !== undefined && now > at, "after check");
+      }
+      case "expires_in": {
+        const now = asDateMs(context.temporal?.now ?? context.at ?? new Date().toISOString());
+        const start = asDateMs(this.resolve(condition.start, context));
+        const expiresAt = start !== undefined ? start + condition.durationSeconds * 1000 : undefined;
+        return record(now !== undefined && expiresAt !== undefined && now <= expiresAt, "expires_in check");
+      }
+      case "active_window": {
+        const now = asDateMs(context.temporal?.now ?? context.at ?? new Date().toISOString());
+        const start = asDateMs(this.resolve(condition.start, context));
+        const end = asDateMs(this.resolve(condition.end, context));
+        return record(now !== undefined && start !== undefined && end !== undefined && now >= start && now <= end, "active_window check");
+      }
+      case "and": return record(condition.conditions.every((nested) => this.evalCondition(nested, context, traces, source)), "and composition");
+      case "or": return record(condition.conditions.some((nested) => this.evalCondition(nested, context, traces, source)), "or composition");
+      case "not": return record(!this.evalCondition(condition.condition, context, traces, source), "not composition");
+    }
+  }
+}
+
 export class AuthorizationRuntime {
+  private readonly policyEngine = new PolicyConditionEngine();
+
   constructor(
     private readonly governance: GovernanceRuntime,
     private readonly capability: CapabilityRuntime,
@@ -32,21 +366,31 @@ export class AuthorizationRuntime {
   ) {}
 
   async evaluate(input: AuthorizationInput): Promise<AuthorizationDecision> {
+    const policy = this.policyEngine.evaluate(input.policies ?? [], input.policyFragments ?? [], input);
+    if (policy.decision === "deny") {
+      return this.audit.finalizeDecision({
+        decision: "deny", allowed: false, failedStage: "policy", obligations: policy.obligations,
+        reasoningChain: ["Policy condition engine denied request."],
+        provenance: { policySource: policy.matchedConditions, inheritedPolicySources: policy.inheritedPolicySources },
+        explainability: { policy }
+      });
+    }
+
     const governance = await this.governance.evaluate(input, `action:${input.action}`);
     if (!governance.allowed) {
       return this.audit.finalizeDecision({
-        decision: "deny", allowed: false, failedStage: "governance", reasoningChain: governance.reasons,
-        provenance: { policySource: governance.policySourceIds, inheritedScopeChain: governance.inheritedScopeChain },
-        explainability: { governance }
+        decision: "deny", allowed: false, failedStage: "governance", obligations: policy.obligations, reasoningChain: governance.reasons,
+        provenance: { policySource: governance.policySourceIds, inheritedScopeChain: governance.inheritedScopeChain, inheritedPolicySources: policy.inheritedPolicySources },
+        explainability: { policy, governance }
       });
     }
 
     const capability = await this.capability.evaluate(input);
     if (!capability.allowed || !capability.matchedCapability) {
       return this.audit.finalizeDecision({
-        decision: "deny", allowed: false, failedStage: "capability", reasoningChain: capability.reasons,
+        decision: "deny", allowed: false, failedStage: "capability", obligations: policy.obligations, reasoningChain: capability.reasons,
         provenance: { capabilitySource: capability.matchedCapability?.capabilityId, inheritedCapabilitySource: capability.inheritedFromNamespace },
-        explainability: { governance, capability }
+        explainability: { policy, governance, capability }
       });
     }
 
@@ -59,23 +403,25 @@ export class AuthorizationRuntime {
 
     if (!consent.allowed) {
       return this.audit.finalizeDecision({
-        decision: "deny", allowed: false, failedStage: "consent", reasoningChain: consent.reasons,
+        decision: "deny", allowed: false, failedStage: "consent", obligations: policy.obligations, reasoningChain: consent.reasons,
         provenance: { consentSource: consent.grant?.grantId },
-        explainability: { governance, capability, consent }
+        explainability: { policy, governance, capability, consent }
       });
     }
 
     return this.audit.finalizeDecision({
-      decision: "allow", allowed: true,
+      decision: "allow", allowed: true, obligations: policy.obligations,
       reasoningChain: [...governance.reasons, ...capability.reasons, ...consent.reasons],
       provenance: {
         policySource: governance.policySourceIds,
         capabilitySource: capability.matchedCapability.capabilityId,
         consentSource: consent.grant?.grantId,
         inheritedScopeChain: governance.inheritedScopeChain,
-        inheritedCapabilitySource: capability.inheritedFromNamespace
+        inheritedCapabilitySource: capability.inheritedFromNamespace,
+        inheritedPolicySources: policy.inheritedPolicySources,
+        triggeredObligations: policy.triggeredObligations
       },
-      explainability: { governance, capability, consent }
+      explainability: { policy, governance, capability, consent }
     });
   }
 }


### PR DESCRIPTION
### Motivation
- Replace static authorization checks with a programmable, deterministic policy condition engine to enable composable governance logic and temporal rules. 
- Surface policy-driven obligations as first-class outputs so operational workflows can react to triggered obligations. 
- Provide deterministic, serializable, and explainable evaluation traces for auditability and downstream replay. 
- Keep the runtime lightweight and provider-aware while enabling contextual evaluation across actor/namespace/workspace/machine/capability/runtime/temporal metadata. 

### Description
- Introduced a typed Policy Condition AST with operators including `equals`, `not_equals`, `in`, `not_in`, `greater_than`, `less_than`, `contains`, `exists`, `and`, `or`, `not` and temporal operators `before`, `after`, `expires_in`, `active_window` implemented in `PolicyCondition` types. 
- Implemented `PolicyConditionEngine` that deterministically evaluates policies against a `PolicyRuntimeContext`, produces `PolicyTraceEntry` explainability traces, collects `matchedConditions`/`failedConditions`/`inheritedPolicySources`, and returns `PolicyEvaluationResult` including `obligations` and `triggeredObligations`. 
- Added composable policy fragments via `PolicyFragment` and `RuntimePolicy.extends` and deterministic expansion into `and` compositions with inherited source tracking. 
- Integrated policy-stage evaluation into `AuthorizationRuntime.evaluate` so policy decisions and `PolicyObligation` results are produced and propagated before governance/capability/consent checks while expanding explainability payloads. 
- Changed file: `packages/authorization-runtime/src/index.ts`. 

### Testing
- Ran `npm run typecheck` which failed due to pre-existing TypeScript deprecation errors in multiple package `tsconfig.json` files (`baseUrl` and `moduleResolution=node10` deprecations) that prevent a full repo typecheck from completing. 
- No additional type errors attributable to the new policy engine were observed before the repository-wide TypeScript config deprecation issues stopped the build. 
- No other automated test runs were performed in this change; unit test coverage and policy fixtures are recommended as the next step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022a56b8648325aa9ed376f5f29a66)