### PR TITLE
Add deterministic sovereign memory weighting engine

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ export * from './protocol/consent';
 export * from './protocol/enforcement';
 export * from './protocol/execution';
 export * from './protocol/adapters';
+export * from './protocol/memory';
 export * from './aoc/capabilities';
 export * from './aoc/sdk';
 export * from './interpreter';

--- a/protocol/memory/__tests__/weighting-engine.test.ts
+++ b/protocol/memory/__tests__/weighting-engine.test.ts
@@ -1,0 +1,77 @@
+import {
+  calculateMemoryWeight,
+  classifyMemoryByPolicyThreshold,
+  decayMemoryWeight,
+  reinforceMemoryWeight,
+  updateMemoryWeight,
+  type MemoryWeightState
+} from '../index';
+
+describe('sovereign memory weighting engine', () => {
+  const baseState: MemoryWeightState = {
+    score: 0,
+    dimensions: {
+      governanceImpact: 8,
+      operationalRecurrence: 7,
+      stakeholderAuthority: 9,
+      legalSignificance: 8,
+      referenceFrequency: 4,
+      temporalFreshness: 6,
+      crossDomainLinkage: 7,
+      policyDependency: 8,
+      contradictionPresence: 1,
+      executionOutcomeImpact: 9
+    },
+    referenceCount: 0,
+    linkedExecutiveSummaryCount: 0,
+    approvedDecisionCount: 0,
+    isTransient: false,
+    lastAccessedAt: '2026-05-01T00:00:00.000Z',
+    createdAt: '2026-05-01T00:00:00.000Z'
+  };
+
+  it('calculates deterministic base weight', () => {
+    expect(calculateMemoryWeight(baseState.dimensions)).toBe(67.6);
+  });
+
+  it('reinforces on repeated references and approved decisions', () => {
+    const seeded = { ...baseState, score: 50 };
+    const reinforced = reinforceMemoryWeight(seeded, {
+      additionalReferences: 3,
+      additionalExecutiveSummaryLinks: 2,
+      additionalApprovedDecisions: 1
+    });
+    expect(reinforced.score).toBe(66.25);
+    expect(reinforced.referenceCount).toBe(3);
+    expect(reinforced.approvedDecisionCount).toBe(1);
+  });
+
+  it('updates and applies event reinforcement deterministically', () => {
+    const updated = updateMemoryWeight(baseState, {
+      referenced: true,
+      linkedExecutiveSummary: true,
+      approvedDecision: true,
+      dimensions: { referenceFrequency: 8 }
+    });
+
+    expect(updated.score).toBeGreaterThan(calculateMemoryWeight(baseState.dimensions));
+    expect(updated.referenceCount).toBe(1);
+    expect(updated.linkedExecutiveSummaryCount).toBe(1);
+    expect(updated.approvedDecisionCount).toBe(1);
+  });
+
+  it('decays transient context faster than non-transient', () => {
+    const active = { ...baseState, score: 80, isTransient: false };
+    const transient = { ...baseState, score: 80, isTransient: true };
+    const now = '2026-05-11T00:00:00.000Z';
+    expect(decayMemoryWeight(transient, now).score).toBeLessThan(decayMemoryWeight(active, now).score);
+  });
+
+  it('classifies policy thresholds deterministically', () => {
+    const thresholds = { archivalThreshold: 70, compressionThreshold: 45, purgeThreshold: 20 };
+    expect(classifyMemoryByPolicyThreshold(80, thresholds)).toBe('retain_active');
+    expect(classifyMemoryByPolicyThreshold(60, thresholds)).toBe('archive');
+    expect(classifyMemoryByPolicyThreshold(30, thresholds)).toBe('compress');
+    expect(classifyMemoryByPolicyThreshold(10, thresholds)).toBe('purge');
+  });
+});

--- a/protocol/memory/index.ts
+++ b/protocol/memory/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './weighting-engine';

--- a/protocol/memory/types.ts
+++ b/protocol/memory/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Deterministic sovereign memory weighting inputs.
+ *
+ * Every field is intentionally bounded to numeric or boolean primitives so
+ * protocol participants can independently recompute the same score.
+ */
+export type MemoryWeightDimensions = {
+  governanceImpact: number;
+  operationalRecurrence: number;
+  stakeholderAuthority: number;
+  legalSignificance: number;
+  referenceFrequency: number;
+  temporalFreshness: number;
+  crossDomainLinkage: number;
+  policyDependency: number;
+  contradictionPresence: number;
+  executionOutcomeImpact: number;
+};
+
+export type MemoryWeightPolicyThresholds = {
+  archivalThreshold: number;
+  compressionThreshold: number;
+  purgeThreshold: number;
+};
+
+export type MemoryWeightState = {
+  score: number;
+  dimensions: MemoryWeightDimensions;
+  referenceCount: number;
+  linkedExecutiveSummaryCount: number;
+  approvedDecisionCount: number;
+  isTransient: boolean;
+  lastAccessedAt: string;
+  createdAt: string;
+};
+
+export type MemoryWeightUpdateInput = {
+  dimensions?: Partial<MemoryWeightDimensions>;
+  referenced?: boolean;
+  linkedExecutiveSummary?: boolean;
+  approvedDecision?: boolean;
+  lastAccessedAt?: string;
+};
+
+export type MemoryWeightReinforcementInput = {
+  additionalReferences?: number;
+  additionalExecutiveSummaryLinks?: number;
+  additionalApprovedDecisions?: number;
+};

--- a/protocol/memory/weighting-engine.ts
+++ b/protocol/memory/weighting-engine.ts
@@ -1,0 +1,133 @@
+import {
+  MemoryWeightDimensions,
+  MemoryWeightPolicyThresholds,
+  MemoryWeightReinforcementInput,
+  MemoryWeightState,
+  MemoryWeightUpdateInput
+} from './types';
+
+const DIMENSION_WEIGHTS: Record<keyof MemoryWeightDimensions, number> = {
+  governanceImpact: 0.16,
+  operationalRecurrence: 0.1,
+  stakeholderAuthority: 0.11,
+  legalSignificance: 0.14,
+  referenceFrequency: 0.09,
+  temporalFreshness: 0.07,
+  crossDomainLinkage: 0.09,
+  policyDependency: 0.11,
+  contradictionPresence: -0.08,
+  executionOutcomeImpact: 0.11
+};
+
+const REFERENCE_REINFORCEMENT_FACTOR = 1.75;
+const EXEC_SUMMARY_REINFORCEMENT_FACTOR = 2.5;
+const APPROVED_DECISION_PERMANENT_BOOST = 6;
+const TRANSIENT_DAILY_DECAY = 0.8;
+const NON_TRANSIENT_DAILY_DECAY = 0.2;
+const MAX_SCORE = 100;
+const MIN_SCORE = 0;
+
+const clamp = (value: number, min = MIN_SCORE, max = MAX_SCORE): number => Math.max(min, Math.min(max, value));
+const normalizeDimension = (value: number): number => clamp(value, 0, 10);
+
+/**
+ * Calculates a deterministic base memory score using a weighted linear model.
+ *
+ * Architecture note:
+ * - We avoid probabilistic models and random tie-breaking.
+ * - All dimensions are normalized into [0..10], then projected to [0..100].
+ * - Contradiction is a negative dimension to prevent volatile/conflicting memory
+ *   from dominating retrieval and retention decisions.
+ */
+export const calculateMemoryWeight = (dimensions: MemoryWeightDimensions): number => {
+  let weightedTotal = 0;
+  for (const key of Object.keys(DIMENSION_WEIGHTS) as Array<keyof MemoryWeightDimensions>) {
+    const normalizedValue = normalizeDimension(dimensions[key]);
+    weightedTotal += normalizedValue * DIMENSION_WEIGHTS[key];
+  }
+  return clamp(Math.round(weightedTotal * 10 * 100) / 100);
+};
+
+/**
+ * Applies deterministic event-based reinforcements.
+ *
+ * Architecture note:
+ * Reinforcement is additive, not multiplicative, so the same event stream always
+ * produces the same terminal score independent of execution host.
+ */
+export const reinforceMemoryWeight = (
+  state: MemoryWeightState,
+  input: MemoryWeightReinforcementInput = {}
+): MemoryWeightState => {
+  const additionalReferences = Math.max(0, Math.floor(input.additionalReferences ?? 0));
+  const additionalExecutiveSummaryLinks = Math.max(0, Math.floor(input.additionalExecutiveSummaryLinks ?? 0));
+  const additionalApprovedDecisions = Math.max(0, Math.floor(input.additionalApprovedDecisions ?? 0));
+
+  const reinforcementDelta =
+    additionalReferences * REFERENCE_REINFORCEMENT_FACTOR +
+    additionalExecutiveSummaryLinks * EXEC_SUMMARY_REINFORCEMENT_FACTOR +
+    additionalApprovedDecisions * APPROVED_DECISION_PERMANENT_BOOST;
+
+  return {
+    ...state,
+    referenceCount: state.referenceCount + additionalReferences,
+    linkedExecutiveSummaryCount: state.linkedExecutiveSummaryCount + additionalExecutiveSummaryLinks,
+    approvedDecisionCount: state.approvedDecisionCount + additionalApprovedDecisions,
+    score: clamp(Math.round((state.score + reinforcementDelta) * 100) / 100)
+  };
+};
+
+/**
+ * Time-based decay. Unused transient context decays faster to privilege durable
+ * protocol memory over ephemeral chatter.
+ */
+export const decayMemoryWeight = (state: MemoryWeightState, now: string): MemoryWeightState => {
+  const lastAccess = new Date(state.lastAccessedAt).getTime();
+  const nowTime = new Date(now).getTime();
+  const elapsedMs = Math.max(0, nowTime - lastAccess);
+  const elapsedDays = elapsedMs / (1000 * 60 * 60 * 24);
+
+  const decayRate = state.isTransient ? TRANSIENT_DAILY_DECAY : NON_TRANSIENT_DAILY_DECAY;
+  const decayAmount = elapsedDays * decayRate;
+
+  return {
+    ...state,
+    score: clamp(Math.round((state.score - decayAmount) * 100) / 100)
+  };
+};
+
+export const updateMemoryWeight = (state: MemoryWeightState, input: MemoryWeightUpdateInput): MemoryWeightState => {
+  const dimensions: MemoryWeightDimensions = {
+    ...state.dimensions,
+    ...input.dimensions
+  };
+
+  const recalculatedBase = calculateMemoryWeight(dimensions);
+  let nextState: MemoryWeightState = {
+    ...state,
+    dimensions,
+    score: recalculatedBase,
+    lastAccessedAt: input.lastAccessedAt ?? state.lastAccessedAt
+  };
+
+  nextState = reinforceMemoryWeight(nextState, {
+    additionalReferences: input.referenced ? 1 : 0,
+    additionalExecutiveSummaryLinks: input.linkedExecutiveSummary ? 1 : 0,
+    additionalApprovedDecisions: input.approvedDecision ? 1 : 0
+  });
+
+  return nextState;
+};
+
+/**
+ * Threshold classifier used by retention, retrieval, compression, and purge flows.
+ */
+export const classifyMemoryByPolicyThreshold = (
+  score: number,
+  thresholds: MemoryWeightPolicyThresholds
+): 'retain_active' | 'archive' | 'compress' | 'purge' => {
+  if (score >= thresholds.archivalThreshold) return 'retain_active';
+  if (score >= thresholds.compressionThreshold) return 'archive';
+  if (score >= thresholds.purgeThreshold) return 'compress';
+  return 'purge';
+};


### PR DESCRIPTION
### Motivation
- Provide a deterministic, protocol-level mechanism to score and prioritize memory objects so AOC can distinguish signal from noise at the protocol layer.
- Ensure retention, retrieval priority, compression resistance, and purge eligibility are driven by a reproducible numeric score rather than randomized/ML behavior.
- Capture governance, operational, legal, temporal and linkage signals plus reinforcement and decay patterns in a compact engine.

### Description
- Added a new memory subsystem under `protocol/memory` with types in `types.ts` and the core logic in `weighting-engine.ts`, and exported the module from the repository root via `index.ts`.
- Implemented deterministic functions `calculateMemoryWeight()`, `updateMemoryWeight()`, `decayMemoryWeight()`, and `reinforceMemoryWeight()` with rich inline architecture comments and bounded numeric dimensions.
- Modeled ten weighting dimensions (governance impact, operational recurrence, stakeholder authority, legal significance, reference frequency, temporal freshness, cross-domain linkage, policy dependency, contradiction presence, execution outcome impact) and additive reinforcement patterns (references, executive summary links, approved decision boosts, transient decay).
- Added configurable policy thresholds (`archivalThreshold`, `compressionThreshold`, `purgeThreshold`) and a deterministic classifier `classifyMemoryByPolicyThreshold()` plus unit tests covering scoring, reinforcement, decay and threshold classification in `protocol/memory/__tests__/weighting-engine.test.ts`.

### Testing
- Type-checked the codebase with `npx tsc --noEmit` and it succeeded. 
- Added Jest unit tests in `protocol/memory/__tests__/weighting-engine.test.ts`, but running `npm test` failed in this environment because `jest` is not installed (`sh: 1: jest: not found`).
- The tests assert deterministic base score computation, additive reinforcement behavior, faster decay for transient context, and deterministic policy classification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022b64015c8325bbab6af6a7c7fe8b)