### PR TITLE
Deterministic memory nutrient extraction engine (protocol/memory)

### DIFF
--- a/protocol/memory/__tests__/nutrient-engine.test.ts
+++ b/protocol/memory/__tests__/nutrient-engine.test.ts
@@ -1,0 +1,83 @@
+import {
+  consolidateDuplicateNutrients,
+  extractMemoryNutrients,
+  shouldPromoteNutrient,
+  type NutrientExtractionInput,
+  type NutrientExtractionPolicy
+} from '../index';
+
+const basePolicy: NutrientExtractionPolicy = {
+  minEvidenceCount: 2,
+  promoteConfidenceThreshold: 0.6,
+  recurringBlockerMinCount: 2,
+  stakeholderSignalMinCount: 2,
+  decisionTrailMinCount: 2,
+  contradictionClusterMinContradictions: 2,
+  operationalPatternMinCount: 2,
+  operationalPatternMinWeightAverage: 60,
+  riskEvolutionMinCount: 2,
+  strategicCrossDomainMinCount: 3,
+  strategicCrossDomainMinDomains: 2
+};
+
+describe('deterministic nutrient extraction engine', () => {
+  const now = '2026-05-11T00:00:00.000Z';
+
+  const memories: NutrientExtractionInput['memories'] = [
+    { memoryId: 'm1', createdAt: now, memoryWeight: 75, blockerKey: 'vendor-delay', stakeholderIds: ['ops'], decisionId: 'd1', policyIds: ['p1'], domain: 'ops', contradictionCount: 0, auditRequired: true },
+    { memoryId: 'm2', createdAt: now, memoryWeight: 72, blockerKey: 'vendor-delay', stakeholderIds: ['ops'], decisionId: 'd1', policyIds: ['p1'], domain: 'finance', contradictionCount: 1 },
+    { memoryId: 'm3', createdAt: now, memoryWeight: 65, stakeholderIds: ['ops'], decisionId: 'd1', linkedMemoryIds: ['m1'], domain: 'ops', contradictionCount: 3 },
+    { memoryId: 'm4', createdAt: now, memoryWeight: 80, contradictionCount: 3, riskTopic: 'counterparty', domain: 'risk' },
+    { memoryId: 'm5', createdAt: now, memoryWeight: 70, riskTopic: 'counterparty', domain: 'legal' }
+  ];
+
+  it('extracts recurring blockers deterministically', () => {
+    const result = extractMemoryNutrients({ memories, now, policy: basePolicy });
+    expect(result.nutrients.some((n) => n.nutrientType === 'RECURRING_BLOCKER')).toBe(true);
+  });
+
+  it('extracts stakeholder signals from repeated stakeholder references', () => {
+    const result = extractMemoryNutrients({ memories, now, policy: basePolicy });
+    const signal = result.nutrients.find((n) => n.nutrientType === 'STAKEHOLDER_SIGNAL');
+    expect(signal?.sourceMemoryIds).toEqual(['m1', 'm2', 'm3']);
+  });
+
+  it('extracts decision trails from linked decisions', () => {
+    const result = extractMemoryNutrients({ memories, now, policy: basePolicy });
+    expect(result.nutrients.some((n) => n.nutrientType === 'DECISION_TRAIL')).toBe(true);
+  });
+
+  it('extracts contradiction clusters for contradiction-heavy memories', () => {
+    const result = extractMemoryNutrients({ memories, now, policy: basePolicy });
+    const cluster = result.nutrients.find((n) => n.nutrientType === 'CONTRADICTION_CLUSTER');
+    expect(cluster?.sourceMemoryIds).toEqual(['m3', 'm4']);
+  });
+
+  it('propagates auditRequired from source memories', () => {
+    const result = extractMemoryNutrients({ memories, now, policy: basePolicy });
+    const blocker = result.nutrients.find((n) => n.nutrientType === 'RECURRING_BLOCKER');
+    expect(blocker?.auditRequired).toBe(true);
+  });
+
+  it('consolidates duplicate nutrients without losing lineage', () => {
+    const extracted = extractMemoryNutrients({ memories, now, policy: basePolicy }).nutrients;
+    const duplicateSet = [extracted[0], { ...extracted[0], extractionReason: 'duplicate reason' }];
+    const consolidated = consolidateDuplicateNutrients(duplicateSet);
+    expect(consolidated).toHaveLength(1);
+    expect(consolidated[0].sourceMemoryIds.length).toBeGreaterThan(0);
+  });
+
+  it('applies promotion thresholds deterministically', () => {
+    const result = extractMemoryNutrients({ memories, now, policy: basePolicy });
+    expect(result.promotedNutrients.length).toBeGreaterThan(0);
+    expect(result.nutrients.every((n) => n.promoted === shouldPromoteNutrient(n, basePolicy))).toBe(true);
+  });
+
+  it('preserves lineage and source evidence for every nutrient', () => {
+    const result = extractMemoryNutrients({ memories, now, policy: basePolicy });
+    for (const nutrient of result.nutrients) {
+      expect(nutrient.lineagePreserved).toBe(true);
+      expect(nutrient.sourceMemoryIds.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/protocol/memory/index.ts
+++ b/protocol/memory/index.ts
@@ -2,3 +2,5 @@ export * from './types';
 export * from './weighting-engine';
 
 export * from './decay-engine';
+
+export * from './nutrient-engine';

--- a/protocol/memory/nutrient-engine.ts
+++ b/protocol/memory/nutrient-engine.ts
@@ -1,0 +1,270 @@
+import { createHash } from 'crypto';
+
+export const NUTRIENT_TYPES = [
+  'OPERATIONAL_PATTERN',
+  'RECURRING_BLOCKER',
+  'DECISION_TRAIL',
+  'STAKEHOLDER_SIGNAL',
+  'GOVERNANCE_LESSON',
+  'RISK_EVOLUTION',
+  'EXECUTION_INSIGHT',
+  'POLICY_DEPENDENCY',
+  'CONTRADICTION_CLUSTER',
+  'STRATEGIC_SUMMARY_CANDIDATE'
+] as const;
+
+export type NutrientType = (typeof NUTRIENT_TYPES)[number];
+
+export type NutrientExtractionMemory = {
+  memoryId: string;
+  createdAt: string;
+  updatedAt?: string;
+  text?: string;
+  tags?: string[];
+  type?: string;
+  linkedMemoryIds?: string[];
+  stakeholderIds?: string[];
+  policyIds?: string[];
+  decisionId?: string;
+  riskTopic?: string;
+  contradictionCount?: number;
+  blockerKey?: string;
+  executionKey?: string;
+  memoryWeight: number;
+  auditRequired?: boolean;
+  governanceImpact?: number;
+  domain?: string;
+};
+
+export type NutrientExtractionPolicy = {
+  minEvidenceCount: number;
+  promoteConfidenceThreshold: number;
+  recurringBlockerMinCount: number;
+  stakeholderSignalMinCount: number;
+  decisionTrailMinCount: number;
+  contradictionClusterMinContradictions: number;
+  operationalPatternMinCount: number;
+  operationalPatternMinWeightAverage: number;
+  riskEvolutionMinCount: number;
+  strategicCrossDomainMinCount: number;
+  strategicCrossDomainMinDomains: number;
+};
+
+export type NutrientExtractionInput = {
+  memories: ReadonlyArray<NutrientExtractionMemory>;
+  now: string;
+  policy: NutrientExtractionPolicy;
+};
+
+export type MemoryNutrient = {
+  nutrientId: string;
+  nutrientType: NutrientType;
+  sourceMemoryIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  confidenceScore: number;
+  evidenceCount: number;
+  memoryWeightAverage: number;
+  extractionReason: string;
+  auditRequired: boolean;
+  lineagePreserved: true;
+  promoted: boolean;
+};
+
+export type NutrientExtractionResult = {
+  nutrients: MemoryNutrient[];
+  promotedNutrients: MemoryNutrient[];
+};
+
+const round2 = (value: number): number => Math.round(value * 100) / 100;
+const unique = (items: string[]): string[] => [...new Set(items)];
+
+const buildNutrientId = (type: NutrientType, sourceMemoryIds: string[]): string => {
+  const digest = createHash('sha256').update(`${type}::${unique(sourceMemoryIds).sort().join('|')}`).digest('hex').slice(0, 16);
+  return `nutrient-${type.toLowerCase()}-${digest}`;
+};
+
+export const buildNutrientLineage = (sourceMemoryIds: string[]): string[] => unique([...sourceMemoryIds]).sort();
+
+export const classifyNutrientType = (memory: NutrientExtractionMemory): NutrientType => {
+  if ((memory.blockerKey || memory.tags?.includes('blocker')) && (memory.contradictionCount ?? 0) > 1) return 'RECURRING_BLOCKER';
+  if ((memory.policyIds?.length ?? 0) > 0) return 'POLICY_DEPENDENCY';
+  if (memory.decisionId || memory.tags?.includes('decision')) return 'DECISION_TRAIL';
+  if ((memory.stakeholderIds?.length ?? 0) > 0) return 'STAKEHOLDER_SIGNAL';
+  if ((memory.contradictionCount ?? 0) > 0) return 'CONTRADICTION_CLUSTER';
+  if (memory.riskTopic || memory.tags?.includes('risk')) return 'RISK_EVOLUTION';
+  if (memory.executionKey || memory.tags?.includes('execution')) return 'EXECUTION_INSIGHT';
+  if (memory.tags?.includes('governance')) return 'GOVERNANCE_LESSON';
+  return 'OPERATIONAL_PATTERN';
+};
+
+export const calculateNutrientConfidence = (
+  nutrientType: NutrientType,
+  evidenceCount: number,
+  memoryWeightAverage: number,
+  crossDomainCount = 1
+): number => {
+  const typeBoost: Record<NutrientType, number> = {
+    OPERATIONAL_PATTERN: 0.02,
+    RECURRING_BLOCKER: 0.06,
+    DECISION_TRAIL: 0.05,
+    STAKEHOLDER_SIGNAL: 0.04,
+    GOVERNANCE_LESSON: 0.04,
+    RISK_EVOLUTION: 0.05,
+    EXECUTION_INSIGHT: 0.03,
+    POLICY_DEPENDENCY: 0.05,
+    CONTRADICTION_CLUSTER: 0.02,
+    STRATEGIC_SUMMARY_CANDIDATE: 0.08
+  };
+
+  const evidenceScore = Math.min(1, evidenceCount / 10) * 0.5;
+  const weightScore = Math.min(1, memoryWeightAverage / 100) * 0.35;
+  const domainScore = Math.min(1, crossDomainCount / 5) * 0.15;
+  return round2(Math.min(1, evidenceScore + weightScore + domainScore + typeBoost[nutrientType]));
+};
+
+export const shouldPromoteNutrient = (nutrient: MemoryNutrient, policy: NutrientExtractionPolicy): boolean => {
+  return nutrient.evidenceCount >= policy.minEvidenceCount && nutrient.confidenceScore >= policy.promoteConfidenceThreshold;
+};
+
+const composeNutrient = (
+  nutrientType: NutrientType,
+  sourceMemories: NutrientExtractionMemory[],
+  now: string,
+  extractionReason: string,
+  crossDomainCount = 1
+): MemoryNutrient => {
+  const sourceMemoryIds = buildNutrientLineage(sourceMemories.map((memory) => memory.memoryId));
+  const evidenceCount = sourceMemoryIds.length;
+  const memoryWeightAverage = round2(sourceMemories.reduce((acc, memory) => acc + memory.memoryWeight, 0) / Math.max(1, sourceMemories.length));
+  const auditRequired = sourceMemories.some((memory) => Boolean(memory.auditRequired));
+
+  return {
+    nutrientId: buildNutrientId(nutrientType, sourceMemoryIds),
+    nutrientType,
+    sourceMemoryIds,
+    createdAt: now,
+    updatedAt: now,
+    confidenceScore: calculateNutrientConfidence(nutrientType, evidenceCount, memoryWeightAverage, crossDomainCount),
+    evidenceCount,
+    memoryWeightAverage,
+    extractionReason,
+    auditRequired,
+    lineagePreserved: true,
+    promoted: false
+  };
+};
+
+export const consolidateDuplicateNutrients = (nutrients: MemoryNutrient[]): MemoryNutrient[] => {
+  const map = new Map<string, MemoryNutrient>();
+
+  for (const nutrient of nutrients) {
+    const key = `${nutrient.nutrientType}::${nutrient.sourceMemoryIds.join('|')}`;
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, nutrient);
+      continue;
+    }
+
+    map.set(key, {
+      ...existing,
+      updatedAt: nutrient.updatedAt > existing.updatedAt ? nutrient.updatedAt : existing.updatedAt,
+      confidenceScore: Math.max(existing.confidenceScore, nutrient.confidenceScore),
+      extractionReason: `${existing.extractionReason}; ${nutrient.extractionReason}`,
+      auditRequired: existing.auditRequired || nutrient.auditRequired,
+      promoted: existing.promoted || nutrient.promoted
+    });
+  }
+
+  return [...map.values()];
+};
+
+export const extractMemoryNutrients = (input: NutrientExtractionInput): NutrientExtractionResult => {
+  const { memories, now, policy } = input;
+  const nutrients: MemoryNutrient[] = [];
+
+  const byBlocker = new Map<string, NutrientExtractionMemory[]>();
+  const byStakeholder = new Map<string, NutrientExtractionMemory[]>();
+  const byDecision = new Map<string, NutrientExtractionMemory[]>();
+  const byPolicy = new Map<string, NutrientExtractionMemory[]>();
+  const byRiskTopic = new Map<string, NutrientExtractionMemory[]>();
+  const byOperation = new Map<string, NutrientExtractionMemory[]>();
+
+  for (const memory of memories) {
+    if (memory.blockerKey) byBlocker.set(memory.blockerKey, [...(byBlocker.get(memory.blockerKey) ?? []), memory]);
+    for (const stakeholder of memory.stakeholderIds ?? []) {
+      byStakeholder.set(stakeholder, [...(byStakeholder.get(stakeholder) ?? []), memory]);
+    }
+    if (memory.decisionId) byDecision.set(memory.decisionId, [...(byDecision.get(memory.decisionId) ?? []), memory]);
+    for (const policyId of memory.policyIds ?? []) {
+      byPolicy.set(policyId, [...(byPolicy.get(policyId) ?? []), memory]);
+    }
+    if (memory.riskTopic) byRiskTopic.set(memory.riskTopic, [...(byRiskTopic.get(memory.riskTopic) ?? []), memory]);
+    const opKey = memory.executionKey ?? memory.type;
+    if (opKey) byOperation.set(opKey, [...(byOperation.get(opKey) ?? []), memory]);
+  }
+
+  for (const [blockerKey, source] of byBlocker) {
+    if (source.length >= policy.recurringBlockerMinCount) {
+      nutrients.push(composeNutrient('RECURRING_BLOCKER', source, now, `Repeated blocker detected: ${blockerKey}`));
+    }
+  }
+  for (const [stakeholder, source] of byStakeholder) {
+    if (source.length >= policy.stakeholderSignalMinCount) {
+      nutrients.push(composeNutrient('STAKEHOLDER_SIGNAL', source, now, `Recurring stakeholder reference: ${stakeholder}`));
+    }
+  }
+  for (const [decisionId, source] of byDecision) {
+    if (source.length >= policy.decisionTrailMinCount || source.some((m) => (m.linkedMemoryIds?.length ?? 0) > 0)) {
+      nutrients.push(composeNutrient('DECISION_TRAIL', source, now, `Linked decision trail: ${decisionId}`));
+    }
+  }
+  for (const [policyId, source] of byPolicy) {
+    nutrients.push(composeNutrient('POLICY_DEPENDENCY', source, now, `Policy-linked evidence: ${policyId}`));
+  }
+
+  const contradictionSource = memories.filter((memory) => (memory.contradictionCount ?? 0) >= policy.contradictionClusterMinContradictions);
+  if (contradictionSource.length > 0) {
+    nutrients.push(composeNutrient('CONTRADICTION_CLUSTER', contradictionSource, now, 'Contradiction-heavy memory cluster'));
+  }
+
+  for (const [operationKey, source] of byOperation) {
+    const weightAverage = source.reduce((acc, memory) => acc + memory.memoryWeight, 0) / source.length;
+    if (source.length >= policy.operationalPatternMinCount && weightAverage >= policy.operationalPatternMinWeightAverage) {
+      nutrients.push(composeNutrient('OPERATIONAL_PATTERN', source, now, `Repeated high-weight operational signal: ${operationKey}`));
+    }
+  }
+
+  for (const [riskTopic, source] of byRiskTopic) {
+    if (source.length >= policy.riskEvolutionMinCount) {
+      nutrients.push(composeNutrient('RISK_EVOLUTION', source, now, `Risk evolution over time: ${riskTopic}`));
+    }
+  }
+
+  const crossDomainHighWeight = memories.filter((memory) => memory.memoryWeight >= 65);
+  const crossDomainCount = new Set(crossDomainHighWeight.map((memory) => memory.domain ?? 'unknown')).size;
+  if (
+    crossDomainHighWeight.length >= policy.strategicCrossDomainMinCount &&
+    crossDomainCount >= policy.strategicCrossDomainMinDomains
+  ) {
+    nutrients.push(
+      composeNutrient(
+        'STRATEGIC_SUMMARY_CANDIDATE',
+        crossDomainHighWeight,
+        now,
+        'High-confidence cross-domain pattern ready for strategic summarization',
+        crossDomainCount
+      )
+    );
+  }
+
+  const consolidated = consolidateDuplicateNutrients(nutrients).map((nutrient) => ({
+    ...nutrient,
+    promoted: shouldPromoteNutrient(nutrient, policy)
+  }));
+
+  return {
+    nutrients: consolidated,
+    promotedNutrients: consolidated.filter((nutrient) => nutrient.promoted)
+  };
+};


### PR DESCRIPTION
### Motivation

- Provide a provenance-first, deterministic layer that converts sovereign memories into auditable organizational nutrients without any AI calls or storage assumptions. 
- Capture repeatable patterns (blockers, stakeholders, decisions, policy links, contradictions, risks, operational signals, and strategic cross-domain patterns) as first-class nutrients for downstream governance and summarization. 
- Ensure nutrients always preserve source lineage and propagate audit requirements so the protocol remains verifiable and non-destructive.

### Description

- Added a new deterministic nutrient extraction engine at `protocol/memory/nutrient-engine.ts` with full TypeScript typings for `NutrientType`, `MemoryNutrient`, `NutrientExtractionInput`, `NutrientExtractionResult`, and `NutrientExtractionPolicy` and provenance-first fields such as `sourceMemoryIds`, `auditRequired`, and `lineagePreserved`. 
- Implemented core deterministic APIs: `extractMemoryNutrients`, `classifyNutrientType`, `calculateNutrientConfidence`, `consolidateDuplicateNutrients`, `buildNutrientLineage`, and `shouldPromoteNutrient`, and deterministic nutrient ID generation via a hashed lineage key. 
- Encoded rule-based extraction for the requested nutrient categories (`RECURRING_BLOCKER`, `STAKEHOLDER_SIGNAL`, `DECISION_TRAIL`, `POLICY_DEPENDENCY`, `CONTRADICTION_CLUSTER`, `OPERATIONAL_PATTERN`, `RISK_EVOLUTION`, `STRATEGIC_SUMMARY_CANDIDATE`) and deterministic promotion logic driven by `NutrientExtractionPolicy`. 
- Enforced lineage and governance constraints: every nutrient preserves `sourceMemoryIds`, audit-required sources set `auditRequired=true` on nutrients, consolidation is non-destructive and provenance-preserving, and no vector DB / storage / AI assumptions are introduced. 
- Exported the nutrient engine from `protocol/memory/index.ts` so it is available through the module root API surface via existing exports (e.g., `export * from './nutrient-engine'`).

### Testing

- Added unit tests at `protocol/memory/__tests__/nutrient-engine.test.ts` covering recurring blocker extraction, stakeholder signal extraction, decision trail extraction, contradiction cluster extraction, audit propagation, duplicate consolidation, promotion threshold behavior, and lineage preservation. 
- Test execution was attempted with `npm test` but failed in this environment because `jest` was not available locally (`jest: not found`). 
- A direct attempt to run `npx jest` also failed because the environment cannot fetch `jest` from the npm registry (npm registry access returned `403 Forbidden`), so automated tests could not be run here. 
- The tests are present and deterministic; they should pass in a standard developer environment with `jest` available and normal npm registry access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02386b0af88325ae5d9185a5345579)