### PR TITLE
Add autonomous machine governance runtime and contracts

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -72,6 +72,12 @@ export interface GovernanceScope { scopeId: string; namespace: NamespaceRef; all
 export interface GovernancePolicy { policyId: string; version: string; scopeId: string; rules: Array<{ condition: string; effect: "allow" | "deny" }>; updatedAt: string; }
 export interface ConsentGrant { grantId: string; subjectActorId: string; delegateActorId?: string; capability: CapabilityRef; issuedAt: string; expiresAt?: string; revokedAt?: string; }
 
+
+export interface MachineAuthoritySnapshot { authorityProfiles: Array<{ authorityId: string; machineActorId: string; issuedByActorId: string; trustPath: string[]; delegationChain: string[]; issuedAt: string; expiresAt?: string; revokedAt?: string; }>; grants: Array<{ grantId: string; authorityId: string; grantedToMachineActorId: string; grantedByActorId: string; issuedAt: string; expiresAt?: string; revokedAt?: string; }>; }
+export interface MachineDelegationTopology { edges: Array<{ fromMachineActorId: string; toMachineActorId: string; scopeCapabilityIds: string[]; scopeNamespacePaths: string[]; delegatedAt: string; revokedAt?: string; }>; }
+export interface MachineBehaviorConstraintState { policies: Array<{ policyId: string; executionCeiling: number; actionQuota: number; escalationThreshold: number; restrictedDomains: string[]; approvalGateRequired: boolean; humanRequiredBoundary: string; }>; }
+export interface MachineObligationHistory { obligations: Array<{ obligationId: string; machineActorId: string; obligationType: string; status: 'pending' | 'completed' | 'failed'; issuedAt: string; completedAt?: string; }>; }
+
 export interface PortableCognitionPackage {
   packageId: string;
   sourceOrganizationId: string;
@@ -84,7 +90,7 @@ export interface PortableCognitionPackage {
 }
 
 export interface CognitionTopology { namespaces: NamespaceRef[]; actorBindings: Array<{ namespacePath: string; actorId: string }>; }
-export interface GovernanceSnapshot { policies: GovernancePolicy[]; capabilities: CapabilityRef[]; consentGrants: ConsentGrant[]; }
+export interface GovernanceSnapshot { policies: GovernancePolicy[]; capabilities: CapabilityRef[]; consentGrants: ConsentGrant[]; machineAuthority?: MachineAuthoritySnapshot; machineDelegation?: MachineDelegationTopology; machineConstraintState?: MachineBehaviorConstraintState; machineObligationHistory?: MachineObligationHistory; }
 
 export interface AuditEvent { eventId: string; eventType: string; actor: ActorRef; namespace: NamespaceRef; timestamp: string; payload: Record<string, unknown>; }
 export interface AuditContinuity { chainId: string; lastEventId: string; events: AuditEvent[]; }

--- a/runtime/governance/__tests__/autonomous-governance-runtime.test.ts
+++ b/runtime/governance/__tests__/autonomous-governance-runtime.test.ts
@@ -1,0 +1,77 @@
+import { AutonomousGovernanceRuntime } from '../autonomous-governance-runtime';
+import type { AutonomousGovernanceInput } from '../types';
+
+describe('AutonomousGovernanceRuntime', () => {
+  const runtime = new AutonomousGovernanceRuntime();
+
+  const baseInput: AutonomousGovernanceInput = {
+    nowIso: '2026-05-11T00:00:00.000Z',
+    humanOverride: { active: false },
+    actor: {
+      machineActorId: 'machine_scheduler',
+      actorLabel: 'Scheduling Agent',
+      status: 'active',
+      delegatedFromMachineActorId: 'machine_ops',
+      machineAncestry: ['machine_ops', 'machine_scheduler'],
+      capabilityEnvelope: {
+        envelopeId: 'env_1',
+        capabilityIds: ['cap.schedule.run'],
+        namespaceAllowList: ['org.enterprise/scheduling'],
+        operationalCeilings: { executionCeiling: 20, actionQuota: 50, escalationThreshold: 2 },
+      },
+    },
+    authority: {
+      authorityId: 'auth_1',
+      machineActorId: 'machine_scheduler',
+      issuedByActorId: 'human_admin',
+      capabilityAllowList: ['cap.schedule.run'],
+      namespaceAllowList: ['org.enterprise/scheduling'],
+      trustPath: ['enterprise_runtime', 'machine_ops', 'machine_scheduler'],
+      delegationChain: ['machine_ops'],
+      issuedAt: '2026-05-10T00:00:00.000Z',
+    },
+    grant: {
+      grantId: 'grant_1',
+      authorityId: 'auth_1',
+      grantedToMachineActorId: 'machine_scheduler',
+      grantedByActorId: 'machine_ops',
+      scope: { capabilityIds: ['cap.schedule.run'], namespacePaths: ['org.enterprise/scheduling'] },
+      issuedAt: '2026-05-10T00:00:00.000Z',
+    },
+    constraintPolicy: {
+      policyId: 'policy_1',
+      executionCeiling: 20,
+      actionQuota: 50,
+      escalationThreshold: 2,
+      restrictedDomains: ['org.enterprise/finance'],
+      approvalGateRequired: true,
+      humanRequiredBoundary: 'org.enterprise/payments',
+    },
+    request: {
+      requestId: 'req_1',
+      capabilityId: 'cap.schedule.run',
+      namespacePath: 'org.enterprise/scheduling',
+      usage: { executionCount: 2, actionCount: 4, escalationCount: 0, hasHumanApproval: true },
+    },
+  };
+
+  it('permits bounded autonomous execution with explainability and obligations', () => {
+    const result = runtime.validateAutonomousExecution(baseInput);
+    expect(result.permitted).toBe(true);
+    expect(result.deniedReasonCodes).toEqual([]);
+    expect(result.obligations).toHaveLength(5);
+    expect(result.lineage.grantId).toBe('grant_1');
+  });
+
+  it('denies execution when human override is active', () => {
+    const denied = runtime.validateAutonomousExecution({
+      ...baseInput,
+      humanOverride: { active: true, overrideActorId: 'human_admin' },
+      request: { ...baseInput.request, requestId: 'req_2' },
+    });
+
+    expect(denied.permitted).toBe(false);
+    expect(denied.deniedReasonCodes).toContain('HUMAN_OVERRIDE_ACTIVE');
+    expect(denied.escalations).toHaveLength(1);
+  });
+});

--- a/runtime/governance/autonomous-governance-runtime.ts
+++ b/runtime/governance/autonomous-governance-runtime.ts
@@ -1,0 +1,161 @@
+import type {
+  AutonomousExecutionGrant,
+  AutonomousGovernanceDecision,
+  AutonomousGovernanceInput,
+  BehaviorConstraintPolicy,
+  EscalationPath,
+  GovernanceObligation,
+  MachineAuthorityProfile,
+  RuntimeMachineActor,
+} from './types';
+
+const MACHINE_OBLIGATION_TYPES: GovernanceObligation['obligationType'][] = [
+  'machine_audit',
+  'machine_escalation',
+  'machine_approval',
+  'machine_reconciliation',
+  'machine_expiration',
+];
+
+export class AutonomousGovernanceRuntime {
+  validateAutonomousExecution(input: AutonomousGovernanceInput): AutonomousGovernanceDecision {
+    const deniedReasonCodes: string[] = [];
+    const obligations: GovernanceObligation[] = [];
+
+    if (input.humanOverride.active) {
+      deniedReasonCodes.push('HUMAN_OVERRIDE_ACTIVE');
+    }
+
+    if (isExpired(input.grant.expiresAt, input.nowIso)) {
+      deniedReasonCodes.push('AUTONOMOUS_GRANT_EXPIRED');
+    }
+
+    if (input.actor.status !== 'active') {
+      deniedReasonCodes.push('MACHINE_ACTOR_INACTIVE');
+    }
+
+    if (input.authority.revokedAt || input.grant.revokedAt) {
+      deniedReasonCodes.push('MACHINE_AUTHORITY_REVOKED');
+    }
+
+    if (!input.authority.namespaceAllowList.includes(input.request.namespacePath)) {
+      deniedReasonCodes.push('NAMESPACE_RESTRICTION_VIOLATION');
+    }
+
+    if (!input.authority.capabilityAllowList.includes(input.request.capabilityId)) {
+      deniedReasonCodes.push('CAPABILITY_RESTRICTION_VIOLATION');
+    }
+
+    const behaviorViolations = validateBehavior(input.constraintPolicy, input.request.usage);
+    deniedReasonCodes.push(...behaviorViolations);
+
+    const violatesDelegation = !validateDelegationChain(input.actor, input.authority, input.grant);
+    if (violatesDelegation) {
+      deniedReasonCodes.push('DELEGATED_SCOPE_VIOLATION');
+    }
+
+    for (const obligationType of MACHINE_OBLIGATION_TYPES) {
+      obligations.push({
+        obligationId: `${obligationType}_${input.request.requestId}`,
+        obligationType,
+        status: 'pending',
+        issuedAt: input.nowIso,
+        metadata: {
+          machineActorId: input.actor.machineActorId,
+          requestId: input.request.requestId,
+          delegatedFrom: input.actor.delegatedFromMachineActorId,
+        },
+      });
+    }
+
+    const lineage = {
+      machineActorId: input.actor.machineActorId,
+      authorityId: input.authority.authorityId,
+      grantId: input.grant.grantId,
+      delegatedFromMachineActorId: input.actor.delegatedFromMachineActorId,
+      delegationChain: input.authority.delegationChain,
+      trustPath: input.authority.trustPath,
+      capabilityProvenance: input.request.capabilityId,
+      constraintPolicyId: input.constraintPolicy.policyId,
+    };
+
+    const escalations: EscalationPath[] = deniedReasonCodes.length
+      ? [
+          {
+            escalationId: `autonomous_escalation_${input.request.requestId}`,
+            escalationType: 'human_review_required',
+            triggeredBy: input.actor.machineActorId,
+            targetActorId: input.authority.issuedByActorId,
+            reasonCodes: deniedReasonCodes,
+            status: 'active',
+            createdAt: input.nowIso,
+          },
+        ]
+      : [];
+
+    return {
+      permitted: deniedReasonCodes.length === 0,
+      deniedReasonCodes,
+      obligations,
+      lineage,
+      escalations,
+      explainability: {
+        decisionAt: input.nowIso,
+        appliedConstraints: summarizeConstraintPolicy(input.constraintPolicy),
+        authoritySource: input.authority.issuedByActorId,
+      },
+    };
+  }
+
+  revokeMachineAuthority(profile: MachineAuthorityProfile, revokedAt: string, revokedByActorId: string): MachineAuthorityProfile {
+    return {
+      ...profile,
+      revokedAt,
+      revocationReason: `revoked_by_${revokedByActorId}`,
+    };
+  }
+
+  emergencyShutdown(actor: RuntimeMachineActor, at: string): RuntimeMachineActor {
+    return {
+      ...actor,
+      status: 'frozen',
+      frozenAt: at,
+    };
+  }
+}
+
+function validateDelegationChain(
+  actor: RuntimeMachineActor,
+  authority: MachineAuthorityProfile,
+  grant: AutonomousExecutionGrant
+): boolean {
+  if (!actor.delegatedFromMachineActorId) return true;
+  if (!authority.delegationChain.length) return false;
+  return authority.delegationChain[authority.delegationChain.length - 1] === grant.grantedByActorId;
+}
+
+function isExpired(expiresAt: string | undefined, nowIso: string): boolean {
+  if (!expiresAt) return false;
+  return Date.parse(expiresAt) < Date.parse(nowIso);
+}
+
+function validateBehavior(policy: BehaviorConstraintPolicy, usage: AutonomousGovernanceInput['request']['usage']): string[] {
+  const reasons: string[] = [];
+  if (usage.executionCount > policy.executionCeiling) reasons.push('EXECUTION_CEILING_EXCEEDED');
+  if (usage.actionCount > policy.actionQuota) reasons.push('ACTION_QUOTA_EXCEEDED');
+  if (usage.escalationCount > policy.escalationThreshold) reasons.push('ESCALATION_THRESHOLD_EXCEEDED');
+  if (policy.approvalGateRequired && !usage.hasHumanApproval) reasons.push('APPROVAL_GATE_REQUIRED');
+  return reasons;
+}
+
+function summarizeConstraintPolicy(policy: BehaviorConstraintPolicy): Record<string, unknown> {
+  return {
+    policyId: policy.policyId,
+    executionCeiling: policy.executionCeiling,
+    actionQuota: policy.actionQuota,
+    escalationThreshold: policy.escalationThreshold,
+    restrictedDomains: policy.restrictedDomains,
+    approvalGateRequired: policy.approvalGateRequired,
+    humanRequiredBoundary: policy.humanRequiredBoundary,
+  };
+}

--- a/runtime/governance/index.ts
+++ b/runtime/governance/index.ts
@@ -5,3 +5,4 @@ export * from './obligation-runtime';
 export * from './escalation-runtime';
 export * from './human-review';
 export * from './governance-runtime';
+export * from './autonomous-governance-runtime';

--- a/runtime/governance/types.ts
+++ b/runtime/governance/types.ts
@@ -14,7 +14,12 @@ export type GovernanceObligationType =
   | 'ai_escalation'
   | 'human_review'
   | 'relationship_validation'
-  | 'consent_reaffirmation';
+  | 'consent_reaffirmation'
+  | 'machine_audit'
+  | 'machine_escalation'
+  | 'machine_approval'
+  | 'machine_reconciliation'
+  | 'machine_expiration';
 
 export type GovernanceObligationStatus = 'pending' | 'completed' | 'failed';
 
@@ -80,4 +85,99 @@ export type AiGovernanceFlags = {
   requiresEscalation?: boolean;
   requiresHumanReview?: boolean;
   reasonCodes?: string[];
+};
+
+
+export type MachineCapabilityEnvelope = {
+  envelopeId: string;
+  capabilityIds: string[];
+  namespaceAllowList: string[];
+  operationalCeilings: { executionCeiling: number; actionQuota: number; escalationThreshold: number };
+};
+
+export type MachineAuthorityProfile = {
+  authorityId: string;
+  machineActorId: string;
+  issuedByActorId: string;
+  capabilityAllowList: string[];
+  namespaceAllowList: string[];
+  trustPath: string[];
+  delegationChain: string[];
+  issuedAt: string;
+  expiresAt?: string;
+  revokedAt?: string;
+  revocationReason?: string;
+};
+
+export type AutonomousExecutionGrant = {
+  grantId: string;
+  authorityId: string;
+  grantedToMachineActorId: string;
+  grantedByActorId: string;
+  scope: { capabilityIds: string[]; namespacePaths: string[] };
+  issuedAt: string;
+  expiresAt?: string;
+  revokedAt?: string;
+};
+
+export type RuntimeMachineActor = {
+  machineActorId: string;
+  actorLabel: string;
+  status: 'active' | 'frozen' | 'revoked';
+  delegatedFromMachineActorId?: string;
+  machineAncestry: string[];
+  capabilityEnvelope: MachineCapabilityEnvelope;
+  frozenAt?: string;
+};
+
+export type BehaviorConstraintPolicy = {
+  policyId: string;
+  executionCeiling: number;
+  actionQuota: number;
+  escalationThreshold: number;
+  restrictedDomains: string[];
+  approvalGateRequired: boolean;
+  humanRequiredBoundary: string;
+};
+
+export type AutonomousGovernanceInput = {
+  nowIso: string;
+  actor: RuntimeMachineActor;
+  authority: MachineAuthorityProfile;
+  grant: AutonomousExecutionGrant;
+  constraintPolicy: BehaviorConstraintPolicy;
+  request: {
+    requestId: string;
+    capabilityId: string;
+    namespacePath: string;
+    usage: {
+      executionCount: number;
+      actionCount: number;
+      escalationCount: number;
+      hasHumanApproval: boolean;
+    };
+  };
+  humanOverride: { active: boolean; overrideActorId?: string };
+};
+
+export type AutonomousGovernanceDecision = {
+  permitted: boolean;
+  deniedReasonCodes: string[];
+  obligations: GovernanceObligation[];
+  lineage: {
+    machineActorId: string;
+    authorityId: string;
+    grantId: string;
+    delegatedFromMachineActorId?: string;
+    delegationChain: string[];
+    trustPath: string[];
+    capabilityProvenance: string;
+    constraintPolicyId: string;
+  };
+  escalations: EscalationPath[];
+  explainability: {
+    decisionAt: string;
+    appliedConstraints: Record<string, unknown>;
+    authoritySource: string;
+  };
 };


### PR DESCRIPTION
### Motivation
- Enable bounded, explainable autonomous execution by introducing machine authority, grants, and runtime machine actors so machines can hold scoped, temporal, and revocable authority.
- Support safe machine-to-machine delegation and enforce behavior constraints so delegated execution is limited by capability, namespace, quotas, and escalation thresholds.
- Preserve human sovereignty and auditability by emitting obligations, explainability lineage, and revocation/emergency shutdown primitives.

### Description
- Added new governance types in `runtime/governance/types.ts` including `MachineAuthorityProfile`, `AutonomousExecutionGrant`, `RuntimeMachineActor`, `MachineCapabilityEnvelope`, `BehaviorConstraintPolicy`, `AutonomousGovernanceInput`, and `AutonomousGovernanceDecision`.
- Implemented `AutonomousGovernanceRuntime` in `runtime/governance/autonomous-governance-runtime.ts` which validates autonomous execution, enforces namespace/capability/behavior constraints, validates delegation chains, emits machine obligations and escalations, and offers `revokeMachineAuthority` and `emergencyShutdown` helpers.
- Extended shared portable models in `packages/shared-types/src/index.ts` to include `MachineAuthoritySnapshot`, `MachineDelegationTopology`, `MachineBehaviorConstraintState`, and `MachineObligationHistory` so portable cognition preserves machine-governance continuity.
- Exported the autonomous runtime from `runtime/governance/index.ts` and added unit tests at `runtime/governance/__tests__/autonomous-governance-runtime.test.ts` covering permit and deny (human override) flows.

### Testing
- Ran type checking with `npm run typecheck`; the run failed due to existing TypeScript deprecation settings in multiple package `tsconfig.json` files (`baseUrl` / `moduleResolution=node10`), which are pre-existing and not caused by these code changes.
- Added automated unit tests (`runtime/governance/__tests__/autonomous-governance-runtime.test.ts`) validating permitted and human-override denial scenarios; these tests were created but not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023b1fbd108325bb07c78b95372ae1)