### PR TITLE
Add interoperable capability marketplace and brokerage runtime

### DIFF
--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -53,3 +53,5 @@ export * from './sovereign-runtime';
 export * from './runtime-negotiation';
 
 export * from './governance-treaties';
+
+export * from './marketplace';

--- a/runtime/marketplace/__tests__/brokerageRuntime.test.ts
+++ b/runtime/marketplace/__tests__/brokerageRuntime.test.ts
@@ -1,0 +1,93 @@
+import { CapabilityBrokerageRuntime } from '../brokerageRuntime';
+import { CapabilityMarketplace } from '../types';
+
+describe('CapabilityBrokerageRuntime', () => {
+  it('routes explainably, creates agreements, and supports revocation + continuity export', () => {
+    const market: CapabilityMarketplace = {
+      providers: [
+        {
+          providerId: 'provider-enterprise-audit',
+          runtimeId: 'runtime-enterprise',
+          federationId: 'fed-alpha',
+          capabilityIds: ['cap.audit'],
+          consentPolicyRefs: ['consent.audit.v1'],
+          executionRegions: ['us'],
+        },
+      ],
+      offers: [
+        {
+          offerId: 'offer-audit-1',
+          providerId: 'provider-enterprise-audit',
+          capabilityId: 'cap.audit',
+          scope: ['bounded-audit', 'trace-export'],
+          maxBudget: 25,
+          obligations: ['audit-log-preserved'],
+          constraints: ['no-data-exfiltration'],
+          expiresAt: '2027-01-01T00:00:00.000Z',
+          revocable: true,
+        },
+      ],
+      agreements: [],
+      leases: [],
+      reputations: [
+        {
+          profileId: 'rep-provider-enterprise-audit',
+          providerId: 'provider-enterprise-audit',
+          records: [],
+          trustScore: { providerId: 'provider-enterprise-audit', score: 75, asOf: '2026-01-01T00:00:00.000Z', evidenceRefs: ['att:1'] },
+          portabilityRef: 'portable://provider-enterprise-audit/v1',
+          exposure: 'federated',
+        },
+      ],
+    };
+
+    const broker = new CapabilityBrokerageRuntime(market);
+    const decision = broker.route({
+      requestId: 'req-pmfreak-1',
+      consumer: {
+        consumerId: 'consumer-pmfreak',
+        runtimeId: 'runtime-pmfreak',
+        federationId: 'fed-alpha',
+        budgetCeiling: 50,
+        acceptedPolicyRefs: ['consent.audit.v1'],
+      },
+      capabilityId: 'cap.audit',
+      requiredScope: ['bounded-audit'],
+      maxBudget: 40,
+      federationId: 'fed-alpha',
+      requireConsentRef: 'consent.audit.v1',
+      lineage: ['consumer-pmfreak', 'runtime-pmfreak'],
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.selectedProviderId).toBe('provider-enterprise-audit');
+    expect(decision.trustPath).toContain('provider-enterprise-audit');
+
+    const agreement = broker.createExecutionAgreement(decision);
+    expect(agreement).toBeDefined();
+
+    const lease = broker.activateLease(agreement!.agreementId);
+    expect(lease?.status).toBe('active');
+
+    const revoked = broker.revokeLease(lease!.leaseId, 'human-sovereign-override');
+    expect(revoked?.status).toBe('revoked');
+
+    broker.appendReputationRecord({
+      recordId: 'rec-1',
+      providerId: 'provider-enterprise-audit',
+      consumerId: 'consumer-pmfreak',
+      capabilityId: 'cap.audit',
+      fulfilled: true,
+      obligationsMet: 1,
+      obligationsTotal: 1,
+      escalationResolved: true,
+      auditIntegrityScore: 100,
+      recordedAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const exportBundle = broker.exportPortableContinuity('provider-enterprise-audit');
+    expect(exportBundle?.agreements.length).toBe(1);
+    expect(exportBundle?.leases.length).toBe(1);
+    expect(exportBundle?.reputationProfile.trustScore.score).toBeGreaterThan(0);
+  });
+});

--- a/runtime/marketplace/brokerageRuntime.ts
+++ b/runtime/marketplace/brokerageRuntime.ts
@@ -1,0 +1,165 @@
+import {
+  BrokerageRequest,
+  CapabilityExecutionAgreement,
+  CapabilityLease,
+  CapabilityMarketplace,
+  CapabilityOffer,
+  CapabilityProvider,
+  ExecutionReputationRecord,
+  ExplainableBrokerageDecision,
+  MachineReputationProfile,
+  PortableMarketContinuityExport,
+} from './types';
+
+export class CapabilityBrokerageRuntime {
+  constructor(private readonly market: CapabilityMarketplace) {}
+
+  publishProvider(provider: CapabilityProvider): void {
+    this.market.providers.push(provider);
+  }
+
+  publishOffer(offer: CapabilityOffer): void {
+    this.market.offers.push(offer);
+  }
+
+  route(request: BrokerageRequest): ExplainableBrokerageDecision {
+    const candidateOffers = this.market.offers.filter((offer) => offer.capabilityId === request.capabilityId);
+    const ranked = candidateOffers
+      .map((offer) => ({ offer, provider: this.market.providers.find((p) => p.providerId === offer.providerId) }))
+      .filter((row): row is { offer: CapabilityOffer; provider: CapabilityProvider } => Boolean(row.provider))
+      .filter((row) => !row.provider.sovereignOptOut)
+      .sort((a, b) => this.reputationScore(b.provider.providerId) - this.reputationScore(a.provider.providerId));
+
+    for (const row of ranked) {
+      const decision = this.evaluateRow(request, row.offer, row.provider);
+      if (decision.allowed) return decision;
+    }
+
+    return {
+      decisionId: `${request.requestId}:deny`,
+      requestId: request.requestId,
+      allowed: false,
+      reasons: ['No eligible provider matched capability, consent, scope, federation, and budget constraints.'],
+      trustPath: request.lineage,
+      budgetEvaluation: { requested: request.maxBudget, offered: 0, consumerCeiling: request.consumer.budgetCeiling, pass: false },
+      federationCompatibility: { pass: false, reason: 'No compatible federation route.' },
+      consentEvaluation: { pass: false, requiredRef: request.requireConsentRef, providerSupportsRef: false, consumerAcceptsRef: false },
+      constraintEvaluation: { pass: false, missingScopes: request.requiredScope, violatedConstraints: ['no-provider-match'] },
+    };
+  }
+
+  createExecutionAgreement(decision: ExplainableBrokerageDecision): CapabilityExecutionAgreement | undefined {
+    if (!decision.allowed || !decision.selectedOfferId || !decision.selectedProviderId) return undefined;
+    const offer = this.market.offers.find((o) => o.offerId === decision.selectedOfferId);
+    if (!offer) return undefined;
+    const now = new Date().toISOString();
+    const agreement: CapabilityExecutionAgreement = {
+      agreementId: `${offer.offerId}:agreement:${this.market.agreements.length + 1}`,
+      offerId: offer.offerId,
+      providerId: offer.providerId,
+      consumerId: decision.requestId,
+      capabilityId: offer.capabilityId,
+      scope: offer.scope,
+      budgetLimit: offer.maxBudget,
+      federationBoundary: 'enforced',
+      delegationLineage: decision.trustPath,
+      obligations: offer.obligations,
+      behavioralConstraints: offer.constraints,
+      expiresAt: offer.expiresAt,
+      createdAt: now,
+      revocable: true,
+    };
+    this.market.agreements.push(agreement);
+    return agreement;
+  }
+
+  activateLease(agreementId: string): CapabilityLease | undefined {
+    const agreement = this.market.agreements.find((item) => item.agreementId === agreementId);
+    if (!agreement) return undefined;
+    const lease: CapabilityLease = {
+      leaseId: `${agreementId}:lease`,
+      agreementId,
+      status: 'active',
+      startedAt: new Date().toISOString(),
+      expiresAt: agreement.expiresAt,
+    };
+    this.market.leases.push(lease);
+    return lease;
+  }
+
+  revokeLease(leaseId: string, reason: string): CapabilityLease | undefined {
+    const lease = this.market.leases.find((item) => item.leaseId === leaseId);
+    if (!lease) return undefined;
+    lease.status = 'revoked';
+    lease.revokedAt = new Date().toISOString();
+    lease.revocationReason = reason;
+    return lease;
+  }
+
+  appendReputationRecord(record: ExecutionReputationRecord): void {
+    const profile = this.market.reputations.find((item) => item.providerId === record.providerId);
+    if (!profile) return;
+    profile.records.push(record);
+    profile.trustScore = this.computeTrustScore(profile);
+  }
+
+  exportPortableContinuity(providerId: string): PortableMarketContinuityExport | undefined {
+    const profile = this.market.reputations.find((item) => item.providerId === providerId);
+    if (!profile) return undefined;
+    return {
+      exportedAt: new Date().toISOString(),
+      providerId,
+      reputationProfile: profile,
+      agreements: this.market.agreements.filter((item) => item.providerId === providerId),
+      leases: this.market.leases.filter((lease) =>
+        this.market.agreements.some((agreement) => agreement.providerId === providerId && agreement.agreementId === lease.agreementId),
+      ),
+      trustRelationships: [profile.portabilityRef, ...profile.trustScore.evidenceRefs],
+    };
+  }
+
+  private evaluateRow(request: BrokerageRequest, offer: CapabilityOffer, provider: CapabilityProvider): ExplainableBrokerageDecision {
+    const missingScopes = request.requiredScope.filter((scope) => !offer.scope.includes(scope));
+    const budgetPass = offer.maxBudget <= request.maxBudget && offer.maxBudget <= request.consumer.budgetCeiling;
+    const federationPass = provider.federationId === request.federationId && provider.runtimeId !== request.consumer.runtimeId;
+    const providerSupportsConsent = provider.consentPolicyRefs.includes(request.requireConsentRef);
+    const consumerAcceptsConsent = request.consumer.acceptedPolicyRefs.includes(request.requireConsentRef);
+    const consentPass = providerSupportsConsent && consumerAcceptsConsent;
+    const allowed = missingScopes.length === 0 && budgetPass && federationPass && consentPass;
+
+    return {
+      decisionId: `${request.requestId}:${offer.offerId}`,
+      requestId: request.requestId,
+      selectedProviderId: allowed ? provider.providerId : undefined,
+      selectedOfferId: allowed ? offer.offerId : undefined,
+      allowed,
+      reasons: allowed
+        ? ['Provider satisfies consent, scope, trust, federation, and budget constraints.']
+        : ['Provider rejected due to one or more constraint failures.'],
+      trustPath: [...request.lineage, provider.providerId],
+      budgetEvaluation: { requested: request.maxBudget, offered: offer.maxBudget, consumerCeiling: request.consumer.budgetCeiling, pass: budgetPass },
+      federationCompatibility: { pass: federationPass, reason: federationPass ? 'Compatible federation boundary.' : 'Cross-federation boundary disallowed.' },
+      consentEvaluation: {
+        pass: consentPass,
+        requiredRef: request.requireConsentRef,
+        providerSupportsRef: providerSupportsConsent,
+        consumerAcceptsRef: consumerAcceptsConsent,
+      },
+      constraintEvaluation: { pass: missingScopes.length === 0, missingScopes, violatedConstraints: allowed ? [] : offer.constraints },
+    };
+  }
+
+  private reputationScore(providerId: string): number {
+    return this.market.reputations.find((item) => item.providerId === providerId)?.trustScore.score ?? 0;
+  }
+
+  private computeTrustScore(profile: MachineReputationProfile) {
+    const total = profile.records.length;
+    if (!total) return { ...profile.trustScore, score: 0, asOf: new Date().toISOString() };
+    const fulfilled = profile.records.filter((record) => record.fulfilled).length;
+    const obligationRatio = profile.records.reduce((acc, record) => acc + record.obligationsMet / Math.max(1, record.obligationsTotal), 0) / total;
+    const avgAudit = profile.records.reduce((acc, record) => acc + record.auditIntegrityScore, 0) / total;
+    const score = Math.round((fulfilled / total) * 40 + obligationRatio * 30 + (avgAudit / 100) * 30);
+    return { ...profile.trustScore, score: Math.max(0, Math.min(100, score)), asOf: new Date().toISOString() };
+  }
+}

--- a/runtime/marketplace/index.ts
+++ b/runtime/marketplace/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './brokerageRuntime';

--- a/runtime/marketplace/types.ts
+++ b/runtime/marketplace/types.ts
@@ -1,0 +1,129 @@
+export type CapabilityLeaseStatus = 'pending' | 'active' | 'revoked' | 'expired' | 'frozen';
+
+export interface CapabilityProvider {
+  providerId: string;
+  runtimeId: string;
+  federationId: string;
+  capabilityIds: string[];
+  consentPolicyRefs: string[];
+  executionRegions: string[];
+  sovereignOptOut?: boolean;
+}
+
+export interface CapabilityConsumer {
+  consumerId: string;
+  runtimeId: string;
+  federationId: string;
+  budgetCeiling: number;
+  acceptedPolicyRefs: string[];
+}
+
+export interface CapabilityOffer {
+  offerId: string;
+  providerId: string;
+  capabilityId: string;
+  scope: string[];
+  maxBudget: number;
+  obligations: string[];
+  constraints: string[];
+  expiresAt: string;
+  revocable: true;
+}
+
+export interface CapabilityExecutionAgreement {
+  agreementId: string;
+  offerId: string;
+  providerId: string;
+  consumerId: string;
+  capabilityId: string;
+  scope: string[];
+  budgetLimit: number;
+  federationBoundary: string;
+  delegationLineage: string[];
+  obligations: string[];
+  behavioralConstraints: string[];
+  expiresAt: string;
+  createdAt: string;
+  revocable: true;
+}
+
+export interface CapabilityLease {
+  leaseId: string;
+  agreementId: string;
+  status: CapabilityLeaseStatus;
+  startedAt: string;
+  expiresAt: string;
+  revokedAt?: string;
+  revocationReason?: string;
+}
+
+export interface ExecutionReputationRecord {
+  recordId: string;
+  providerId: string;
+  consumerId: string;
+  capabilityId: string;
+  fulfilled: boolean;
+  obligationsMet: number;
+  obligationsTotal: number;
+  escalationResolved: boolean;
+  auditIntegrityScore: number;
+  recordedAt: string;
+}
+
+export interface CapabilityTrustScore {
+  providerId: string;
+  score: number;
+  asOf: string;
+  evidenceRefs: string[];
+}
+
+export interface MachineReputationProfile {
+  profileId: string;
+  providerId: string;
+  records: ExecutionReputationRecord[];
+  trustScore: CapabilityTrustScore;
+  portabilityRef: string;
+  exposure: 'private' | 'federated' | 'public';
+}
+
+export interface BrokerageRequest {
+  requestId: string;
+  consumer: CapabilityConsumer;
+  capabilityId: string;
+  requiredScope: string[];
+  maxBudget: number;
+  federationId: string;
+  requireConsentRef: string;
+  lineage: string[];
+}
+
+export interface ExplainableBrokerageDecision {
+  decisionId: string;
+  requestId: string;
+  selectedProviderId?: string;
+  selectedOfferId?: string;
+  allowed: boolean;
+  reasons: string[];
+  trustPath: string[];
+  budgetEvaluation: { requested: number; offered: number; consumerCeiling: number; pass: boolean };
+  federationCompatibility: { pass: boolean; reason: string };
+  consentEvaluation: { pass: boolean; requiredRef: string; providerSupportsRef: boolean; consumerAcceptsRef: boolean };
+  constraintEvaluation: { pass: boolean; missingScopes: string[]; violatedConstraints: string[] };
+}
+
+export interface PortableMarketContinuityExport {
+  exportedAt: string;
+  providerId: string;
+  reputationProfile: MachineReputationProfile;
+  agreements: CapabilityExecutionAgreement[];
+  leases: CapabilityLease[];
+  trustRelationships: string[];
+}
+
+export interface CapabilityMarketplace {
+  providers: CapabilityProvider[];
+  offers: CapabilityOffer[];
+  agreements: CapabilityExecutionAgreement[];
+  leases: CapabilityLease[];
+  reputations: MachineReputationProfile[];
+}


### PR DESCRIPTION
### Motivation
- Introduce a lightweight, non-tokenized capability exchange layer to enable sovereign capability publication, consent-governed leasing, cross-runtime brokerage, and portable machine reputation. 
- Provide deterministic, explainable provider routing and revocable execution leasing while preserving human sovereignty and federation boundaries.

### Description
- Add a new `runtime/marketplace` module with contract types including `CapabilityProvider`, `CapabilityConsumer`, `CapabilityOffer`, `CapabilityLease`, `CapabilityExecutionAgreement`, `CapabilityMarketplace`, `MachineReputationProfile`, `ExecutionReputationRecord`, and `ExplainableBrokerageDecision` (files: `types.ts`).
- Implement `CapabilityBrokerageRuntime` with publishing, explainable routing (consent/federation/budget/scope checks), agreement creation, lease activation/revocation, reputation record appends, trust-score recomputation, and portable continuity export (file: `brokerageRuntime.ts`).
- Add an end-to-end unit test that exercises route → agreement → lease activation → revocation → reputation update → portability export (file: `__tests__/brokerageRuntime.test.ts`).
- Export the marketplace public surface from `runtime/index.ts` so the module is available through the runtime package.

### Testing
- Ran `npm run typecheck`, which failed due to pre-existing TypeScript deprecation errors in repository tsconfig settings (deprecations for `baseUrl` and `moduleResolution=node10`), not introduced by these changes. 
- Added a Jest unit test at `runtime/marketplace/__tests__/brokerageRuntime.test.ts`, which is present but was not executed as part of the failing typecheck step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02402b59688325b7513c9ba63033ca)