### PR TITLE
Define canonical AOC runtime contracts and versioning guidance

### DIFF
--- a/docs/architecture/canonical-contracts.md
+++ b/docs/architecture/canonical-contracts.md
@@ -1,0 +1,74 @@
+# AOC Canonical Runtime Contracts (v1)
+
+## Design principles
+- Implementation-neutral and strongly typed contracts.
+- Additive extensibility through `extensions` records.
+- Immutable-oriented payloads using readonly semantics.
+- Zero-trust runtime posture: explicit subject, scope, constraints, issuer, and traceability.
+- AI-agent compatibility with deterministic IDs, explainability metadata, and machine-evaluable conditions.
+
+## 1) Identity Contract
+Defined in `packages/identity/src/contracts.ts`.
+
+The canonical principal model supports `human`, `service`, `agent`, and `workload` identities with tenant and federation metadata for sovereign multi-tenant execution.
+
+Validation expectations:
+- `id` MUST be globally unique within the trust domain.
+- `createdAt` and `updatedAt` MUST be RFC 3339 UTC timestamps.
+- Claims SHOULD include issuer provenance and lifecycle timestamps.
+- `tenant.tenantId` and `tenant.organizationId` MUST be present for isolation-safe enforcement.
+
+## 2) Capability Token Schema
+Defined in `packages/capability-tokens/src/contracts.ts`.
+
+Capability tokens carry subject/resource/scope with bounded constraints, delegation metadata, attenuation lineage, and proof metadata.
+
+Validation expectations:
+- `expiresAt` MUST be in the future at issuance.
+- Delegation chain depth MUST NOT exceed `maxDepth`.
+- Child tokens MUST be equal or stricter than `attenuationOf` parent scope.
+- `revocationRefs` SHOULD reference revocation list identifiers or event streams.
+
+## 3) Consent Grant + Policy Decision Contracts
+Defined in `packages/consent-engine/src/contracts.ts`.
+
+Consent grant is the legal/purpose constraint layer. Policy decision is the runtime evaluation result layer.
+
+Validation expectations:
+- Consent `allowedOperations` MUST map to enforceable scope operations.
+- Revoked grants MUST NOT be used for new decisions after `revokedAt`.
+- Conditional decisions SHOULD include obligations.
+- `policyRevisionIds` MUST be immutable references to evaluated policy snapshots.
+
+## 4) Audit Event Envelope
+Defined in `packages/audit-sdk/src/contracts.ts`.
+
+Audit envelope provides causal, tenant-isolated traceability across policy, consent, and capability enforcement.
+
+Validation expectations:
+- `eventId` MUST be unique and immutable.
+- `timestamp` MUST be authoritative event time.
+- `tenantIsolation` MUST always be present.
+- Correlation IDs SHOULD be propagated end-to-end across distributed calls.
+
+## 5) Scope Grammar Model
+Defined in `packages/scoped-access/src/contracts.ts`.
+
+Canonical grammar defines namespace/wildcards/attenuation semantics and deny precedence.
+
+Validation expectations:
+- Deny MUST override allow in merged scope sets.
+- Recursive wildcard `**` MUST only apply where explicitly permitted by the grammar.
+- Attenuation MUST never remove inherited deny conditions.
+
+## Security considerations
+- Default deny when contracts are missing, malformed, expired, or unverifiable.
+- Enforce monotonic attenuation for delegated capability chains.
+- Keep trust and federation metadata separate from authorization outcome to avoid conflation.
+- Log decisions with consent/capability/policy references for explainable governance.
+
+## Interoperability guidance
+- Map contracts to OIDC/SAML/SCIM identity providers through `federation` metadata.
+- Keep external protocol evidence in `proofRef`, `policyRefs`, and trace references.
+- Use versioned schema IDs in every serialized artifact.
+- Adopt deterministic identifiers (e.g., canonical hash over stable fields) for replay-safe dedupe and provenance.

--- a/docs/architecture/versioning-strategy.md
+++ b/docs/architecture/versioning-strategy.md
@@ -1,0 +1,39 @@
+# AOC Canonical Contract Versioning Strategy
+
+## Semantic versioning model
+Each contract uses `schemaVersion` with `MAJOR.MINOR.PATCH` semantics.
+
+- MAJOR: breaking structure or meaning changes.
+- MINOR: additive, backward-compatible fields and enum members.
+- PATCH: documentation clarifications and non-semantic corrections.
+
+## Compatibility rules
+- Producers MUST emit a concrete `schemaVersion`.
+- Consumers SHOULD accept the same MAJOR with newer MINOR when unknown fields are ignorable.
+- Consumers MUST reject unsupported MAJOR versions.
+- Additive evolution SHOULD use optional fields, never field repurposing.
+
+## Deprecation process
+1. Mark field or enum value as deprecated in docs and SDK types.
+2. Maintain behavior through at least one MINOR cycle.
+3. Remove only in next MAJOR release.
+
+## Identifier and trace stability
+- `id`, `tokenId`, `grantId`, `decisionId`, and `eventId` are immutable once issued.
+- Policy and consent references MUST point to immutable revisioned artifacts.
+- Causality and correlation identifiers SHOULD be preserved across hops.
+
+## Validation and governance
+- Publish JSON Schemas at stable URIs with explicit version paths.
+- Maintain machine-readable changelog entries per schema.
+- Require conformance tests for every MINOR/MAJOR release.
+
+## Extensibility guardrails
+- Extension data MUST live under `extensions` maps.
+- Extension keys SHOULD be namespaced (e.g., `vendor.feature`).
+- Extensions MUST NOT alter core field semantics.
+
+## Interoperability roadmap
+- Define profile documents for regulated sectors (health, finance, public sector) without changing core contracts.
+- Provide translation adapters for OPA/Rego, Cedar, and XACML ecosystems at policy edges.
+- Support signed envelopes as optional profile layers, not required base semantics.

--- a/packages/audit-sdk/src/contracts.ts
+++ b/packages/audit-sdk/src/contracts.ts
@@ -1,0 +1,46 @@
+export type CanonicalId = string;
+export type UtcDateTime = string;
+
+export interface CausalityLink {
+  readonly eventId: CanonicalId;
+  readonly relationship: 'triggered-by' | 'caused-by' | 'correlated-with';
+}
+
+export interface TenantIsolationMetadata {
+  readonly tenantId: CanonicalId;
+  readonly organizationId: CanonicalId;
+  readonly dataBoundary: string;
+  readonly isolationMode: 'logical' | 'physical' | 'hybrid';
+}
+
+export interface AuditEventEnvelope {
+  readonly schemaVersion: '1.0.0';
+  readonly eventId: CanonicalId;
+  readonly actor: {
+    readonly principalId: CanonicalId;
+    readonly principalType: 'human' | 'service' | 'agent' | 'workload';
+  };
+  readonly action: string;
+  readonly resource: {
+    readonly kind: string;
+    readonly id: CanonicalId;
+  };
+  readonly timestamp: UtcDateTime;
+  readonly correlationIds?: readonly CanonicalId[];
+  readonly causalityChain?: readonly CausalityLink[];
+  readonly policyRefs?: readonly CanonicalId[];
+  readonly consentRefs?: readonly CanonicalId[];
+  readonly capabilityRefs?: readonly CanonicalId[];
+  readonly tenantIsolation: TenantIsolationMetadata;
+  readonly integrity?: {
+    readonly hashAlgorithm: 'sha256' | 'sha512' | 'custom';
+    readonly digest: string;
+  };
+  readonly extensions?: Readonly<Record<string, unknown>>;
+}
+
+export const auditEventSchemaExample = {
+  $id: 'https://aoc.protocol/schemas/audit-event-envelope/1-0-0',
+  type: 'object',
+  required: ['schemaVersion', 'eventId', 'actor', 'action', 'resource', 'timestamp', 'tenantIsolation'],
+} as const;

--- a/packages/capability-tokens/src/contracts.ts
+++ b/packages/capability-tokens/src/contracts.ts
@@ -1,0 +1,60 @@
+export type CanonicalId = string;
+export type UtcDateTime = string;
+
+export interface ResourceRef {
+  readonly kind: string;
+  readonly id: CanonicalId;
+  readonly tenantId?: CanonicalId;
+  readonly attributes?: Readonly<Record<string, string>>;
+}
+
+export interface DelegationMetadata {
+  readonly delegator: CanonicalId;
+  readonly chainDepth: number;
+  readonly maxDepth: number;
+  readonly allowedReDelegation: boolean;
+}
+
+export interface Constraint {
+  readonly name: string;
+  readonly operator: 'eq' | 'in' | 'lt' | 'lte' | 'gt' | 'gte' | 'regex';
+  readonly value: string | number | boolean | readonly string[];
+}
+
+export interface ProofMetadata {
+  readonly proofType: 'jwt' | 'mTLS' | 'detached-signature' | 'custom';
+  readonly proofRef?: string;
+  readonly issuedAt: UtcDateTime;
+}
+
+export interface CapabilityToken {
+  readonly schemaVersion: '1.0.0';
+  readonly tokenId: CanonicalId;
+  readonly issuer: CanonicalId;
+  readonly subject: CanonicalId;
+  readonly resource: ResourceRef;
+  readonly scope: readonly string[];
+  readonly constraints?: readonly Constraint[];
+  readonly delegation?: DelegationMetadata;
+  readonly expiresAt: UtcDateTime;
+  readonly notBefore?: UtcDateTime;
+  readonly revocationRefs?: readonly string[];
+  readonly proof: ProofMetadata;
+  readonly attenuationOf?: CanonicalId;
+  readonly attenuationPath?: readonly CanonicalId[];
+  readonly extensions?: Readonly<Record<string, unknown>>;
+}
+
+export const capabilityTokenSchemaExample = {
+  $id: 'https://aoc.protocol/schemas/capability-token/1-0-0',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schemaVersion', 'tokenId', 'issuer', 'subject', 'resource', 'scope', 'expiresAt', 'proof'],
+  properties: {
+    schemaVersion: { const: '1.0.0' },
+    tokenId: { type: 'string' },
+    scope: { type: 'array', items: { type: 'string', minLength: 3 } },
+    constraints: { type: 'array', items: { type: 'object' } },
+    attenuationOf: { type: 'string' },
+  },
+} as const;

--- a/packages/consent-engine/src/contracts.ts
+++ b/packages/consent-engine/src/contracts.ts
@@ -1,0 +1,64 @@
+export type CanonicalId = string;
+export type UtcDateTime = string;
+
+export interface ContextCondition {
+  readonly key: string;
+  readonly operator: 'eq' | 'neq' | 'in' | 'contains' | 'exists';
+  readonly value?: string | number | boolean | readonly string[];
+}
+
+export interface ConsentGrant {
+  readonly schemaVersion: '1.0.0';
+  readonly grantId: CanonicalId;
+  readonly grantor: CanonicalId;
+  readonly grantee: CanonicalId;
+  readonly purpose: string;
+  readonly allowedOperations: readonly string[];
+  readonly legalBasis: {
+    readonly basisType: 'contract' | 'legitimate-interest' | 'consent' | 'public-task' | 'custom';
+    readonly jurisdiction?: string;
+    readonly reference?: string;
+  };
+  readonly contextualConditions?: readonly ContextCondition[];
+  readonly policyRefs?: readonly CanonicalId[];
+  readonly issuedAt: UtcDateTime;
+  readonly expiresAt?: UtcDateTime;
+  readonly revokedAt?: UtcDateTime;
+  readonly revocationReason?: string;
+  readonly extensions?: Readonly<Record<string, unknown>>;
+}
+
+export type PolicyDecisionOutcome = 'allow' | 'deny' | 'conditional';
+
+export interface DecisionObligation {
+  readonly type: string;
+  readonly parameters?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export interface PolicyDecisionContract {
+  readonly schemaVersion: '1.0.0';
+  readonly decisionId: CanonicalId;
+  readonly outcome: PolicyDecisionOutcome;
+  readonly obligations?: readonly DecisionObligation[];
+  readonly reasoningMetadata: Readonly<Record<string, string | number | boolean>>;
+  readonly policyRevisionIds: readonly CanonicalId[];
+  readonly evaluationTraceRefs?: readonly string[];
+  readonly riskScore?: {
+    readonly value: number;
+    readonly band: 'low' | 'medium' | 'high' | 'critical';
+    readonly modelVersion?: string;
+  };
+  readonly evaluatedAt: UtcDateTime;
+}
+
+export const consentGrantSchemaExample = {
+  $id: 'https://aoc.protocol/schemas/consent-grant/1-0-0',
+  type: 'object',
+  required: ['schemaVersion', 'grantId', 'grantor', 'grantee', 'purpose', 'allowedOperations', 'legalBasis', 'issuedAt'],
+} as const;
+
+export const policyDecisionSchemaExample = {
+  $id: 'https://aoc.protocol/schemas/policy-decision/1-0-0',
+  type: 'object',
+  required: ['schemaVersion', 'decisionId', 'outcome', 'reasoningMetadata', 'policyRevisionIds', 'evaluatedAt'],
+} as const;

--- a/packages/identity/src/contracts.ts
+++ b/packages/identity/src/contracts.ts
@@ -1,0 +1,79 @@
+export type CanonicalId = string;
+export type UtcDateTime = string;
+
+export type PrincipalType = 'human' | 'service' | 'agent' | 'workload';
+
+export type ClaimValue = string | number | boolean | string[] | Record<string, unknown>;
+
+export interface Claim {
+  readonly name: string;
+  readonly value: ClaimValue;
+  readonly issuer: CanonicalId;
+  readonly issuedAt: UtcDateTime;
+  readonly expiresAt?: UtcDateTime;
+  readonly confidence?: 'low' | 'medium' | 'high';
+}
+
+export interface TrustMetadata {
+  readonly assuranceLevel: 'aal1' | 'aal2' | 'aal3' | 'custom';
+  readonly verificationMethods: readonly string[];
+  readonly trustFrameworks?: readonly string[];
+  readonly attestedAt?: UtcDateTime;
+  readonly attestedBy?: CanonicalId;
+  readonly riskFlags?: readonly string[];
+}
+
+export interface TenantMetadata {
+  readonly tenantId: CanonicalId;
+  readonly organizationId: CanonicalId;
+  readonly orgPath?: readonly CanonicalId[];
+  readonly environment?: 'prod' | 'staging' | 'dev' | 'sandbox';
+  readonly residencyRegion?: string;
+}
+
+export interface FederationMetadata {
+  readonly federationId: CanonicalId;
+  readonly homeRealm: string;
+  readonly protocol: 'oidc' | 'saml' | 'scim' | 'custom';
+  readonly externalSubject: string;
+  readonly synchronizedAt?: UtcDateTime;
+  readonly sourceOfTruth?: string;
+}
+
+export interface IdentityContract {
+  readonly schemaVersion: '1.0.0';
+  readonly id: CanonicalId;
+  readonly deterministicKey?: string;
+  readonly principalType: PrincipalType;
+  readonly displayName?: string;
+  readonly status: 'active' | 'suspended' | 'revoked';
+  readonly createdAt: UtcDateTime;
+  readonly updatedAt: UtcDateTime;
+  readonly claims: readonly Claim[];
+  readonly trust: TrustMetadata;
+  readonly tenant: TenantMetadata;
+  readonly federation?: FederationMetadata;
+  readonly tags?: Readonly<Record<string, string>>;
+  readonly extensions?: Readonly<Record<string, unknown>>;
+}
+
+export const identityContractSchemaExample = {
+  $id: 'https://aoc.protocol/schemas/identity-contract/1-0-0',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schemaVersion', 'id', 'principalType', 'status', 'createdAt', 'updatedAt', 'claims', 'trust', 'tenant'],
+  properties: {
+    schemaVersion: { const: '1.0.0' },
+    id: { type: 'string', minLength: 3 },
+    deterministicKey: { type: 'string' },
+    principalType: { enum: ['human', 'service', 'agent', 'workload'] },
+    status: { enum: ['active', 'suspended', 'revoked'] },
+    claims: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'value', 'issuer', 'issuedAt'],
+      },
+    },
+  },
+} as const;

--- a/packages/scoped-access/src/contracts.ts
+++ b/packages/scoped-access/src/contracts.ts
@@ -1,0 +1,43 @@
+export type ScopeEffect = 'allow' | 'deny';
+
+export interface ScopeSegmentRule {
+  readonly segment: string;
+  readonly wildcard: '*' | '**' | null;
+}
+
+export interface ScopeExpression {
+  readonly namespace: string;
+  readonly path: readonly ScopeSegmentRule[];
+  readonly operation: string;
+  readonly effect: ScopeEffect;
+}
+
+export interface ScopeGrammarModel {
+  readonly schemaVersion: '1.0.0';
+  readonly grammarId: string;
+  readonly namespacePattern: 'domain:resource:action' | 'custom';
+  readonly wildcardRules: {
+    readonly singleSegment: '*';
+    readonly recursive: '**';
+  };
+  readonly attenuationSemantics: {
+    readonly canReduceNamespace: boolean;
+    readonly canReduceOperations: boolean;
+    readonly canAddConstraints: boolean;
+    readonly canRemoveDenies: false;
+  };
+  readonly hierarchicalInheritance: {
+    readonly enabled: true;
+    readonly parentSeparator: ':' | '/';
+  };
+  readonly precedence: {
+    readonly denyOverridesAllow: true;
+    readonly moreSpecificOverridesBroad: true;
+  };
+}
+
+export const scopeGrammarSchemaExample = {
+  $id: 'https://aoc.protocol/schemas/scope-grammar-model/1-0-0',
+  type: 'object',
+  required: ['schemaVersion', 'grammarId', 'namespacePattern', 'wildcardRules', 'attenuationSemantics', 'hierarchicalInheritance', 'precedence'],
+} as const;


### PR DESCRIPTION
### Motivation
- Establish a first, canonical set of implementation‑neutral runtime contracts to serve as the foundation of the AOC Protocol trust layer. 
- Provide enterprise-grade, strongly-typed, composable schemas that support humans, AI agents, workloads, services, federated tenants, delegated and temporary access. 
- Enforce a zero-trust, explainable, and extensible design surface with deterministic identifiers and machine-evaluable metadata for provenance and auditability. 

### Description
- Added TypeScript readonly interfaces for Identity, Capability Tokens, Consent Grants, Policy Decisions, Audit Event Envelope, and Scope Grammar in `packages/*/src/contracts.ts`. 
- Included compact JSON Schema example constants alongside each contract to support implementation-neutral validation and schema publishing. 
- Adopted immutable-oriented design (`readonly` types, explicit `schemaVersion` fields), additive extensibility via `extensions` maps, and deterministic identifier expectations in docs. 
- Added architecture guidance and a `versioning-strategy.md` describing `schemaVersion` SemVer rules, compatibility/deprecation guardrails, validation expectations, and interoperability recommendations. 

### Testing
- Ran `git diff --check` to validate whitespace and indexable diff issues and it reported no problems. 
- Inspected changes with `git status --short` to verify the intended files were added and staged successfully. 
- No unit or runtime conformance tests were added in this change; the versioning doc requires conformance tests for future MINOR/MAJOR releases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a054fd77aa48325a3495c75125bc5c6)