### PR TITLE
docs: formalize repository governance and layering boundaries

### DIFF
--- a/docs/governance/extraction-policy.md
+++ b/docs/governance/extraction-policy.md
@@ -1,0 +1,91 @@
+# Extraction Policy and Migration Governance
+
+## Purpose
+This policy defines when and how functionality is extracted from `Architects_of_Change_Protocol` into `AOC-Enterprise`, with explicit risk handling, migration sequencing, and compatibility discipline.
+
+---
+
+## Extraction Criteria
+
+Extraction to `AOC-Enterprise` is required when one or more conditions are true:
+- behavior is tenant-aware or organization-aware
+- logic coordinates multiple runtimes/environments
+- lifecycle includes governance process orchestration
+- behavior requires control-plane state and operational scheduling
+- implementation depends on enterprise integrations not required for deterministic protocol execution
+
+Functionality must remain in core when:
+- it defines canonical protocol semantics
+- it is deterministic and invariant-preserving
+- it is required as a stable primitive across all adopters
+
+---
+
+## Candidate Risk Classification
+
+## Low-Risk Extraction Candidates
+Typically safe to extract:
+- orchestration workflows that call core APIs without redefining semantics
+- operational rollout coordinators
+- tenant/runtime negotiation policies and sequencing logic
+- treaty/governance lifecycle orchestrators
+- monitoring/control loops that consume core events
+
+## High-Risk Extraction Candidates
+Require deeper design and staged rollout:
+- modules co-mingling deterministic engines with orchestration glue
+- components that currently expose mixed public APIs consumed by products
+- flows where product code imports core internals through orchestration pathways
+- stateful services whose data model encodes protocol invariants
+- modules with transitive dependency cycles across core and orchestration boundaries
+
+---
+
+## Migration Sequencing Philosophy
+1. **Contract first**: define stable core-facing contract and enterprise-facing orchestrator contract.
+2. **Semantics lock**: document and freeze deterministic behavior expected from core.
+3. **Strangler path**: route new orchestration flows to `AOC-Enterprise` while preserving old entry points temporarily.
+4. **Parity validation**: verify enterprise path produces operational parity without semantic drift.
+5. **Traffic cutover**: move consumers in controlled cohorts.
+6. **Deprecation and removal**: remove legacy core orchestration code after deprecation window closes.
+
+Rule: Do not extract by copy-and-fork; extract by contract and ownership transfer with explicit compatibility plan.
+
+---
+
+## Compatibility Shim Strategy
+- Use thin compatibility shims at old call sites during migration.
+- Shims may translate interfaces, not redefine semantics.
+- Shims must have explicit expiry dates and owners.
+- Shims are temporary and tracked in a deprecation registry.
+- New consumers must target canonical destination APIs directly (no new dependencies on shim surfaces).
+
+---
+
+## Deprecation Guidance
+- Every extracted surface must publish:
+  - deprecation notice date
+  - replacement API path
+  - minimum overlap window
+  - removal target release
+- Deprecation windows should align with SDK/release cadence and enterprise upgrade constraints.
+- Breaking removals require migration evidence for critical consumers.
+
+---
+
+## Anti-Spaghetti Migration Rules
+- No bidirectional dependency creation during extraction.
+- No temporary hacks that introduce hidden protocol/orchestration coupling.
+- No consumer-specific branches in core for enterprise cutovers.
+- No runtime behavior forks by environment flags inside deterministic kernel.
+
+---
+
+## Review and Approval Gates
+Extraction PRs must include:
+- boundary classification (core vs enterprise)
+- dependency direction impact
+- compatibility shim plan (if needed)
+- deprecation timeline
+- rollback strategy
+- owner sign-off from both core and enterprise maintainers

--- a/docs/governance/layering-model.md
+++ b/docs/governance/layering-model.md
@@ -1,0 +1,84 @@
+# Layering Model Governance
+
+## Purpose
+This model defines mandatory layering for the sovereign infrastructure ecosystem and enforces allowed dependency flow to prevent upward leakage and architecture erosion.
+
+---
+
+## Canonical Layer Stack
+
+- **L0 = Canonical contracts/specs**
+  - Schemas, invariants, protocol contracts, formal semantics.
+
+- **L1 = Deterministic engines**
+  - Deterministic evaluators, validators, enforcement and transition kernels.
+
+- **L2 = Runtime foundation services**
+  - Core runtime services supporting deterministic execution (state services, runtime utilities, foundational service abstractions).
+
+- **L3 = Adapters/provider interfaces**
+  - Provider-neutral adapter interfaces and integration seams; infrastructure bindings through governed contracts.
+
+- **L4 = Enterprise orchestration**
+  - Control plane orchestration, runtime negotiation, governance treaty lifecycle coordination, operational governance.
+
+- **L5 = Products/apps/UI**
+  - User-facing products, application workflows, UX, channel/API composition.
+
+---
+
+## Dependency Direction Rules
+
+### General Rule
+Dependencies may flow **downward only toward lower canonical layers**.
+
+Allowed directional examples:
+- L5 -> L4/L3/L2/L1/L0
+- L4 -> L3/L2/L1/L0
+- L3 -> L2/L1/L0 (and platform/provider SDKs as implementation detail outside core contracts)
+- L2 -> L1/L0
+- L1 -> L0
+- L0 -> none
+
+### Forbidden Upward Dependencies
+- L0/L1/L2/L3 importing L4 orchestration logic is forbidden.
+- L0/L1/L2/L3/L4 importing L5 product/UI code is forbidden.
+- L1 deterministic kernels depending on tenant orchestration policy is forbidden.
+
+---
+
+## Leakage Prohibitions
+
+## Forbidden Product Leakage into Protocol
+- No L5 business-domain entities in L0-L2 contracts.
+- No product roadmap features as protocol flags in L0/L1.
+- No UI-driven state model decisions embedded in deterministic engines.
+
+## Forbidden Orchestration Leakage into Protocol
+- No control-plane lifecycle state in deterministic protocol contracts.
+- No treaty orchestration state machines in L0-L2.
+- No tenant rollout logic in deterministic runtime kernel.
+
+---
+
+## Adapter Boundary Model (L3)
+- L3 defines stable abstraction boundaries between runtime foundation and external systems.
+- Core defines adapter contracts; enterprise/product layers provide binding implementations.
+- Adapter contracts must be coarse enough to prevent infrastructure-specific leakage upward.
+- Provider-specific behavior must be normalized before crossing into L2/L1 pathways.
+
+---
+
+## Anti-Spaghetti Structural Rules
+- No cyclic dependencies across layers.
+- No cross-layer “shortcut imports” that bypass public boundaries.
+- No “god modules” combining L1 deterministic logic with L4 orchestration concerns.
+- No mixed ownership modules spanning core and enterprise responsibilities.
+
+---
+
+## Enforcement Practices
+- Each module must declare its layer (`L0`-`L5`) in architecture metadata/readme.
+- CI/static checks should enforce dependency direction.
+- PR reviews must reject ambiguous layer ownership.
+- Exception requests require architecture board approval and time-bounded remediation plan.

--- a/docs/governance/public-api-policy.md
+++ b/docs/governance/public-api-policy.md
@@ -1,0 +1,79 @@
+# Public API Policy and Export Surface Governance
+
+## Purpose
+This policy governs how core protocol and runtime capabilities are exposed to consumers, preserving stable integration surfaces and preventing internal coupling.
+
+---
+
+## Canonical Export Surface Philosophy
+- Public APIs must represent intentional, stable platform contracts.
+- Export surfaces prioritize deterministic semantics over convenience aggregation.
+- Internal refactors must not force unnecessary consumer churn.
+- API design must preserve clear separation between protocol primitives and orchestration workflows.
+
+---
+
+## Public vs Internal Modules
+
+## Public (Supported) Surface
+Public modules are:
+- explicitly documented
+- versioned under compatibility policy
+- safe for cross-repository consumption
+
+## Internal-Only Surface
+Internal modules are:
+- implementation details
+- not covered by compatibility guarantees
+- inaccessible through public barrels/package roots
+
+Rule: Consumers in `AOC-Enterprise` and products/apps must use only documented public surfaces.
+
+---
+
+## Stable Package Boundary Rules
+- Each package/module must have explicit boundary designation: `public` or `internal`.
+- Public boundaries must avoid exposing transitive internal types where possible.
+- Breaking shape changes at public boundaries require version and migration treatment.
+- Internal symbols should use namespace/layout conventions to discourage accidental import.
+
+---
+
+## Barrel Governance
+- Barrel files are allowed only for curated stable surfaces.
+- “Export everything” barrels are forbidden.
+- Barrels must not re-export internal or experimental modules.
+- Barrel changes require API review when they alter consumer-visible surface.
+
+---
+
+## SDK Versioning Philosophy
+- Semantic versioning governs public SDKs.
+- Patch: fixes without public contract change.
+- Minor: backward-compatible additions.
+- Major: breaking public API changes or behavioral contract shifts.
+- Deterministic semantic changes must be treated as contract-impacting, even if type signatures remain unchanged.
+
+---
+
+## Import Discipline
+- Consumers must import from canonical package roots/public entrypoints only.
+- Deep imports into internal paths are forbidden.
+- Cross-layer imports that bypass designated APIs are forbidden.
+- Enterprise and product repositories must not depend on undocumented core internals.
+
+---
+
+## Migration Governance for Public API Changes
+- Every public breaking change requires:
+  - architecture decision record (ADR) or equivalent rationale
+  - migration notes and examples
+  - deprecation period (unless emergency/security override)
+  - compatibility test coverage for key consumer paths
+
+---
+
+## Examples and UI Isolation Rules
+- Examples/reference apps may demonstrate API usage but never define API policy.
+- UI helpers must remain outside core public API contracts unless explicitly promoted via governance process.
+- No promotion of app-specific utilities into canonical public exports without multi-consumer justification.

--- a/docs/governance/repo-boundaries.md
+++ b/docs/governance/repo-boundaries.md
@@ -1,0 +1,132 @@
+# Repository Boundaries Governance
+
+## Purpose
+This document formalizes canonical ownership boundaries between:
+- `Architects_of_Change_Protocol` (core repository)
+- `AOC-Enterprise` (enterprise orchestration repository)
+- product/application repositories (solution-specific delivery)
+
+Its goal is to prevent architectural drift, preserve deterministic behavior in core runtime surfaces, and avoid orchestration/product coupling contaminating protocol primitives.
+
+---
+
+## Canonical Ownership Model
+
+### 1) `Architects_of_Change_Protocol` (Core)
+This repository is the canonical home for:
+- protocol primitive layer
+- foundation runtime layer
+- deterministic enforcement/runtime kernel
+
+Core owns **portable, deterministic, sovereignty-grade primitives** that are reusable across enterprises and products without tenant-specific behavior.
+
+### 2) `AOC-Enterprise` (Enterprise)
+This repository is the canonical home for:
+- control plane orchestration
+- tenant/runtime negotiation
+- governance treaty orchestration
+- enterprise operational governance
+- runtime coordination concerns
+
+This includes extracted orchestration runtimes previously removed from core:
+- `runtime/controlPlane`
+- `runtime/runtime-negotiation`
+- `runtime/governance-treaties`
+
+### 3) Products / Apps (Delivery)
+Product and application repositories own:
+- UI/UX flows
+- business vertical logic
+- customer-specific workflows
+- deployment composition and operational packaging
+
+Products consume core and enterprise capabilities; they do not define protocol primitives or enterprise governance contracts.
+
+---
+
+## Boundary Definitions
+
+## What Belongs in Core Protocol Repository
+Allowed in core:
+- canonical schemas, contracts, and invariants
+- deterministic validation/enforcement engines
+- runtime foundation abstractions needed by deterministic execution
+- provider-neutral adapter interfaces
+- cryptographic, policy-evaluation, and state-transition mechanisms that are deterministic
+- test fixtures proving deterministic protocol behavior
+
+Not allowed in core:
+- tenant orchestration logic
+- control plane coordination workflows
+- governance treaty lifecycle orchestration
+- environment-specific policy override stacks
+- customer/product feature toggles
+- UI/API gateway composition for app delivery
+
+## What Belongs in `AOC-Enterprise`
+Allowed in enterprise:
+- tenant-aware orchestration
+- runtime coordination plans and operational control loops
+- treaty/governance process orchestration and lifecycle management
+- enterprise integration workflows and topology-aware controllers
+- policy rollout sequencing and fleet-level change control
+
+Not allowed in enterprise:
+- redefining protocol primitives already canonicalized in core
+- embedding product UI/business domain logic
+- bypassing core deterministic enforcement semantics
+
+## What Belongs in Products/Apps
+Allowed in products/apps:
+- end-user journey implementation
+- feature-specific orchestration using enterprise and core APIs
+- presentation layer contracts and API composition for channels
+
+Not allowed in products/apps:
+- direct mutation of core canonical contracts
+- ad-hoc orchestration embedded into protocol runtime internals
+- bypasses around enterprise governance workflows where required by platform policy
+
+---
+
+## Runtime vs Orchestration Distinction
+
+## Runtime (Core)
+Runtime concerns are execution-time deterministic functions with invariant outcomes for equivalent inputs and protocol state.
+
+## Orchestration (Enterprise)
+Orchestration concerns are coordination-time decisions across tenants, environments, schedules, governance lifecycles, and operational state.
+
+Rule: If behavior depends on tenant identity, rollout window, operational topology, or enterprise governance process, it belongs in `AOC-Enterprise`, not core.
+
+---
+
+## Forbidden Coupling Patterns
+- Core importing orchestration modules from `AOC-Enterprise`
+- Core importing UI/product code
+- Core embedding tenant identifiers, enterprise policy routing, or environment rollout logic
+- Enterprise rewriting core deterministic transitions inline instead of invoking canonical core APIs
+- Products reaching into non-public internals of core or enterprise repositories
+
+---
+
+## Adapter Boundary Rules
+- Adapters are declared as interfaces/contracts in core; concrete provider integrations may live in enterprise or product repos depending on scope.
+- Core must not depend on provider SDK specifics.
+- Enterprise can bind adapter interfaces to infrastructure/provider implementations.
+- Product repos can add channel-facing adapters, but must not alter canonical adapter contracts without governance approval.
+
+---
+
+## Examples and UI Isolation Rules
+- `examples/`, demo apps, and reference UIs are non-canonical and must not become dependency roots for core.
+- UI artifacts must depend outward on public APIs only.
+- No imports from UI or demo code into any deterministic core module.
+- Example code may illustrate integration patterns but cannot define normative protocol behavior.
+
+---
+
+## Governance Enforcement
+- Boundary violations block merge.
+- Architectural review is required when introducing new top-level modules touching runtime/orchestration seams.
+- Any new module must declare its layer and dependency intent in its local README or architecture note.


### PR DESCRIPTION
### Motivation
- Establish clear, long-term governance to prevent architectural drift between the core protocol runtime and enterprise orchestration layers.
- Protect deterministic runtime primitives and enforce separation of concerns so protocol invariants remain portable and tenant-agnostic.
- Provide a repeatable extraction and migration discipline for functionality moved into `AOC-Enterprise` to reduce risk and ambiguity.
- Define public API expectations and package/barrel discipline to ensure stable cross-repo integrations.

### Description
- Added `docs/governance/repo-boundaries.md` which codifies canonical ownership (core vs enterprise vs products), runtime vs orchestration distinctions, forbidden coupling patterns, adapter boundary rules, and UI/example isolation constraints.
- Added `docs/governance/extraction-policy.md` which defines extraction criteria, low/high-risk candidate classifications, migration sequencing (contract-first/strangler path), compatibility shim strategy, deprecation guidance, and anti-spaghetti migration rules.
- Added `docs/governance/layering-model.md` which formalizes the L0–L5 layering model (L0 contracts through L5 products), allowed dependency directions, forbidden upward dependencies, adapter model (L3), and enforcement practices.
- Added `docs/governance/public-api-policy.md` which documents the public export-surface philosophy, public vs internal boundaries, stable package boundary rules, barrel governance, SDK versioning semantics, and import discipline.

### Testing
- Ran repository validation check with `git diff --check` and observed no reported whitespace or diff-check issues; it passed.
- Ran workspace status inspection with `git status --short` to confirm the new files are present in the working tree; it showed the four new documentation files.
- All automated checks executed for this change completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055a76345883258861df24d79e378a)