### PR TITLE
Stabilize canonical package entrypoints and export boundaries

### DIFF
--- a/docs/governance/export-surface-map.md
+++ b/docs/governance/export-surface-map.md
@@ -1,0 +1,30 @@
+# Export Surface Map (Canonical)
+
+## Canonical public packages
+
+| Package | Stable entrypoint | Surface class | Notes |
+|---|---|---|---|
+| `@aoc/capability-tokens` | `@aoc/capability-tokens` | contracts, shared types | Exposes only capability token contract types and schema examples. |
+| `@aoc/consent-engine` | `@aoc/consent-engine` | contracts | Exposes consent grant and policy decision contracts only. |
+| `@aoc/identity` | `@aoc/identity` | contracts | Exposes identity contract types and schema example only. |
+| `@aoc/scoped-access` | `@aoc/scoped-access` | contracts | Exposes scope grammar and scope expression contract types only. |
+| `@aoc/audit-sdk` | `@aoc/audit-sdk` | contracts, shared types | Exposes audit envelope contracts only. |
+
+## Export policy
+
+- Public imports MUST resolve through package root entrypoints only.
+- Deep imports into `/src/*`, `/dist/*`, or individual contract files are not stable.
+- Barrels (`src/index.ts`) export stable API only; no internal runtime implementation modules.
+
+## Deprecated/ambiguous surfaces
+
+- Any import path that bypasses package root (e.g. `@aoc/identity/src/contracts`) is **deprecated**.
+- Legacy `@aoc-runtime/*` naming is tolerated for existing consumers but not canonical for new SDK integrations.
+
+## Stable import examples
+
+```ts
+import { CapabilityToken } from '@aoc/capability-tokens';
+import { ConsentGrant } from '@aoc/consent-engine';
+import { IdentityContract } from '@aoc/identity';
+```

--- a/docs/governance/package-boundaries.md
+++ b/docs/governance/package-boundaries.md
@@ -1,0 +1,39 @@
+# Package Boundaries and Consumption Rules
+
+## Boundary intent
+
+This repository is the canonical protocol primitive and deterministic runtime foundation. Package boundaries are designed to keep consumer imports stable without exposing implementation detail.
+
+## Boundary rules
+
+1. **Contracts packages** publish schema and type contracts only.
+2. **Runtime packages** publish runtime interfaces and deterministic execution primitives only.
+3. **Provider interfaces** publish adapter/provider abstractions only.
+4. **Shared types** publish cross-package, implementation-neutral type aliases/interfaces only.
+5. Internal wiring modules remain non-exported and non-importable from package roots.
+
+## Consumer policy
+
+- AOC-Enterprise, PMFreak, HRKey, and external SDKs MUST consume root entrypoints only.
+- Consumers MUST NOT deep import contract internals, runtime internals, or generated output folders.
+- New public API requires explicit root barrel export and package-level `exports` declaration.
+
+## Canonical import philosophy
+
+- Prefer semantic package names over folder-oriented import paths.
+- Keep import paths stable while allowing internal refactors.
+- Treat package root exports as API contracts under governance.
+
+### Good
+
+```ts
+import { ConsentGrant } from '@aoc/consent-engine';
+import { AuditEventEnvelope } from '@aoc/audit-sdk';
+```
+
+### Avoid
+
+```ts
+import { ConsentGrant } from '@aoc/consent-engine/src/contracts';
+import { AuditEventEnvelope } from '../../packages/audit-sdk/src/contracts';
+```

--- a/packages/audit-sdk/package.json
+++ b/packages/audit-sdk/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aoc/audit-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  }
+}

--- a/packages/audit-sdk/src/index.ts
+++ b/packages/audit-sdk/src/index.ts
@@ -1,0 +1,3 @@
+export type { AuditEventEnvelope, CausalityLink, TenantIsolationMetadata } from './contracts';
+
+export { auditEventSchemaExample } from './contracts';

--- a/packages/audit-sdk/tsconfig.json
+++ b/packages/audit-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/capability-tokens/package.json
+++ b/packages/capability-tokens/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aoc/capability-tokens",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  }
+}

--- a/packages/capability-tokens/src/index.ts
+++ b/packages/capability-tokens/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+  CapabilityToken,
+  Constraint,
+  DelegationMetadata,
+  ProofMetadata,
+  ResourceRef,
+} from './contracts';
+
+export { capabilityTokenSchemaExample } from './contracts';

--- a/packages/capability-tokens/tsconfig.json
+++ b/packages/capability-tokens/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/consent-engine/package.json
+++ b/packages/consent-engine/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aoc/consent-engine",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  }
+}

--- a/packages/consent-engine/src/index.ts
+++ b/packages/consent-engine/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+  ConsentGrant,
+  ContextCondition,
+  DecisionObligation,
+  PolicyDecisionContract,
+  PolicyDecisionOutcome,
+} from './contracts';
+
+export { consentGrantSchemaExample, policyDecisionSchemaExample } from './contracts';

--- a/packages/consent-engine/tsconfig.json
+++ b/packages/consent-engine/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aoc/identity",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  }
+}

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -1,0 +1,11 @@
+export type {
+  Claim,
+  ClaimValue,
+  FederationMetadata,
+  IdentityContract,
+  PrincipalType,
+  TenantMetadata,
+  TrustMetadata,
+} from './contracts';
+
+export { identityContractSchemaExample } from './contracts';

--- a/packages/identity/tsconfig.json
+++ b/packages/identity/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/scoped-access/package.json
+++ b/packages/scoped-access/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aoc/scoped-access",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  }
+}

--- a/packages/scoped-access/src/index.ts
+++ b/packages/scoped-access/src/index.ts
@@ -1,0 +1,3 @@
+export type { ScopeEffect, ScopeExpression, ScopeGrammarModel, ScopeSegmentRule } from './contracts';
+
+export { scopeGrammarSchemaExample } from './contracts';

--- a/packages/scoped-access/tsconfig.json
+++ b/packages/scoped-access/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -40,6 +40,21 @@
       ],
       "@aoc-runtime/trust-registry-runtime": [
         "packages/trust-registry-runtime/src"
+      ],
+      "@aoc/capability-tokens": [
+        "packages/capability-tokens/src"
+      ],
+      "@aoc/consent-engine": [
+        "packages/consent-engine/src"
+      ],
+      "@aoc/identity": [
+        "packages/identity/src"
+      ],
+      "@aoc/scoped-access": [
+        "packages/scoped-access/src"
+      ],
+      "@aoc/audit-sdk": [
+        "packages/audit-sdk/src"
       ]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,21 @@
     },
     {
       "path": "examples/pmfreak-adapter"
+    },
+    {
+      "path": "packages/capability-tokens"
+    },
+    {
+      "path": "packages/consent-engine"
+    },
+    {
+      "path": "packages/identity"
+    },
+    {
+      "path": "packages/scoped-access"
+    },
+    {
+      "path": "packages/audit-sdk"
     }
   ]
 }


### PR DESCRIPTION
### Motivation

- Establish stable, canonical public package roots to prevent deep-imports and ambiguous SDK surfaces for downstream consumers (AOC-Enterprise, PMFreak, HRKey, and future SDKs). 
- Limit exported surfaces to implementation-neutral contracts and shared types so runtime internals remain non-consumable and refactorable. 
- Provide explicit package-level `exports` and TypeScript path aliases to formalize import semantics and preserve deterministic-runtime boundaries.

### Description

- Added new contract-focused packages with package-level `package.json`, `tsconfig.json`, and `src/index.ts` barrels: `@aoc/capability-tokens`, `@aoc/consent-engine`, `@aoc/identity`, `@aoc/scoped-access`, and `@aoc/audit-sdk`. 
- Each package `package.json` includes an `exports` entry mapping the canonical root to `dist` outputs and exposes only stable contract types and schema examples via the barrel files. 
- Wired new packages into the workspace by adding project references in `tsconfig.json` and path aliases in `tsconfig.base.json` for stable `@aoc/*` import paths. 
- Added governance documentation `docs/governance/export-surface-map.md` and `docs/governance/package-boundaries.md` to codify export policy, canonical import examples, and deprecation guidance for deep imports.

### Testing

- Ran `npm run typecheck` which exercised the workspace TypeScript build and resulted in failures due to existing TypeScript deprecation errors (`baseUrl` and `moduleResolution=node10`) across pre-existing package tsconfigs, which were not introduced by this change and must be addressed separately. Failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055bd3d674832588c8b95c827b78c5)