### PR TITLE
Formalize and normalize AOC protocol contract surface

### DIFF
--- a/src/adapters/interfaces.ts
+++ b/src/adapters/interfaces.ts
@@ -24,7 +24,7 @@ export interface AuditSinkAdapter {
 }
 
 export interface IdentityResolverAdapter {
-  resolveUser(userId: string): Promise<{ id: string; workspace_id: string } | null>;
+  resolveUser(userId: string): Promise<{ id: string; workspaceId: string } | null>;
   resolveAgent(agentId: string): Promise<Agent | null>;
 }
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -2,23 +2,31 @@ import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from "
 
 export type AgentId = string;
 
+export type AgentRiskLevel = "low" | "medium" | "high" | "critical";
+
 export type Agent = {
   id: AgentId;
-  workspace_id: WorkspaceId;
+  workspaceId: WorkspaceId;
   name: string;
   status: "active" | "disabled" | "revoked";
-  agent_type: string;
-  risk_level: "low" | "medium" | "high";
-  created_at?: string;
+  agentType: "autonomous" | "assistive" | "system" | "external";
+  riskLevel: AgentRiskLevel;
+  parentAgentId?: AgentId | null;
+  delegationAuthority?: "none" | "limited" | "full";
+  createdAt?: string;
+  metadata?: Record<string, unknown> | null;
 };
 
 export type AgentScope = {
   id: string;
-  agent_id: AgentId;
-  workspace_id: WorkspaceId;
-  resource_type: CapabilityResourceType;
-  resource_id: string;
+  agentId: AgentId;
+  workspaceId: WorkspaceId;
+  resourceType: CapabilityResourceType;
+  resourceId: string;
   permission: CapabilityPermission;
+  executionBoundary?: Record<string, unknown> | null;
+  delegationDepthLimit?: number | null;
   status: "active" | "expired" | "revoked";
-  expires_at: string | null;
+  expiresAt: string | null;
+  grantedByPrincipalId?: string | null;
 };

--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -1,11 +1,48 @@
+export type AuditEventCategory =
+  | "capability"
+  | "delegation"
+  | "policy"
+  | "consent"
+  | "agent"
+  | "authorization"
+  | "audit"
+  | "identity";
+
+export type AuditSeverity = "debug" | "info" | "notice" | "warning" | "error" | "critical";
+
+export type AuditEventType =
+  | "capability.requested"
+  | "capability.granted"
+  | "capability.revoked"
+  | "delegation.created"
+  | "delegation.revoked"
+  | "policy.evaluated"
+  | "consent.updated"
+  | "agent.action"
+  | "authorization.failed"
+  | "audit.exported"
+  | "scope.violation";
+
+export type AuditActor = {
+  principalId: string;
+  principalType: "human" | "agent" | "service" | "system";
+};
+
+export type AuditSubject = {
+  subjectType: string;
+  subjectId: string;
+};
+
 export type AuditTimelineItem = {
   id?: string;
-  created_at: string;
-  event_type: string;
-  severity?: string | null;
-  workspace_id?: string | null;
-  actor_user_id?: string | null;
-  actor_agent_id?: string | null;
-  event_detail?: Record<string, unknown> | null;
+  createdAt: string;
+  eventType: AuditEventType;
+  category: AuditEventCategory;
+  severity: AuditSeverity;
+  workspaceId?: string | null;
+  actor?: AuditActor | null;
+  subject?: AuditSubject | null;
+  details?: Record<string, unknown> | null;
+  correlationId?: string | null;
   [key: string]: unknown;
 };

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -1,52 +1,83 @@
 export type WorkspaceId = string;
 export type ProjectId = string;
 
+/**
+ * Protocol-scoped capability actions grouped by semantic domain.
+ * These are protocol contracts, not implementation rules.
+ */
 export type CapabilityPermission =
-  | "read"
-  | "write"
-  | "approve"
-  | "manage"
-  | "execute"
-  | "delegate"
-  | "delete"
-  | "write_memory"
-  | "delete_memory"
-  | "manage_members"
-  | "manage_projects"
-  | "manage_workspace"
-  | "manage_ai"
-  | "manage_billing"
-  | "execute_ai_action"
-  | "view_executive"
-  | "upload_documents";
+  | "resource:read"
+  | "resource:create"
+  | "resource:update"
+  | "resource:delete"
+  | "resource:execute"
+  | "governance:approve"
+  | "governance:manage"
+  | "identity:delegate"
+  | "workspace:manage"
+  | "project:manage"
+  | "membership:manage"
+  | "billing:manage"
+  | "agent:manage"
+  | "agent:execute"
+  | "document:upload"
+  | "memory:read"
+  | "memory:write"
+  | "memory:delete"
+  | "audit:read"
+  | "audit:export";
 
 export type CapabilityResourceType =
   | "workspace"
   | "project"
-  | "operational_memory"
-  | "governance_object"
-  | "ai_coprocess"
-  | "copilot";
+  | "document"
+  | "dataset"
+  | "policy"
+  | "consent"
+  | "delegation"
+  | "audit_log"
+  | "agent"
+  | "memory"
+  | "execution"
+  | "integration";
+
+export type CapabilityRequestStatus =
+  | "pending"
+  | "approved"
+  | "denied"
+  | "revoked"
+  | "expired"
+  | "consumed";
+
+export type CapabilityGrantStatus = "active" | "revoked" | "expired" | "consumed";
 
 export type CapabilityRequest = {
   id: string;
-  workspace_id: WorkspaceId;
-  target_resource_type: CapabilityResourceType;
-  target_resource_id: string;
-  requested_permission: CapabilityPermission;
-  status: "pending" | "approved" | "denied" | "revoked";
-  requester_user_id: string;
+  workspaceId: WorkspaceId;
+  resourceType: CapabilityResourceType;
+  resourceId: string;
+  permission: CapabilityPermission;
+  status: CapabilityRequestStatus;
+  requesterPrincipalId: string;
   justification: string | null;
-  created_at: string;
+  createdAt: string;
+  expiresAt?: string | null;
+  metadata?: Record<string, unknown> | null;
 };
 
 export type CapabilityGrant = {
   id: string;
-  workspace_id: WorkspaceId;
-  capability_request_id: string;
+  workspaceId: WorkspaceId;
+  capabilityRequestId: string;
+  resourceType: CapabilityResourceType;
+  resourceId: string;
   permission: CapabilityPermission;
-  target_resource_type: CapabilityResourceType;
-  target_resource_id: string;
-  status: "active" | "revoked" | "expired";
-  expires_at: string | null;
+  status: CapabilityGrantStatus;
+  grantedByPrincipalId?: string | null;
+  activatedAt?: string | null;
+  expiresAt: string | null;
+  revokedAt?: string | null;
+  revokedReason?: string | null;
+  consumedAt?: string | null;
+  metadata?: Record<string, unknown> | null;
 };

--- a/src/consent/types.ts
+++ b/src/consent/types.ts
@@ -1,9 +1,17 @@
+export type ConsentStatus = "active" | "revoked" | "expired" | "superseded";
+
 export type ConsentGrant = {
   id: string;
-  subject_id: string;
+  workspaceId?: string | null;
+  subjectPrincipalId: string;
+  controllerPrincipalId?: string | null;
+  delegatedByPrincipalId?: string | null;
   scope: string;
-  status: "active" | "revoked" | "expired";
-  granted_at: string;
-  expires_at: string | null;
+  boundaries?: Record<string, unknown> | null;
+  status: ConsentStatus;
+  grantedAt: string;
+  expiresAt: string | null;
+  revokedAt?: string | null;
+  revocationReason?: string | null;
   metadata?: Record<string, unknown> | null;
 };

--- a/src/decisions/types.ts
+++ b/src/decisions/types.ts
@@ -1,8 +1,31 @@
-export type PolicyDecision = "allow" | "deny" | "require_approval" | "expired" | "no_match";
+export type PolicyDecision =
+  | "allow"
+  | "deny"
+  | "conditional_allow"
+  | "require_approval"
+  | "expired"
+  | "delegated"
+  | "inherited"
+  | "unresolved";
+
+export type PolicyReference = {
+  policyId: string;
+  policyVersion?: string | null;
+  ruleId?: string | null;
+};
+
+export type EvaluationSource = {
+  sourceType: "policy_engine" | "delegation_engine" | "consent_engine" | "manual_review" | "system";
+  sourceId?: string | null;
+  sourceVersion?: string | null;
+};
 
 export type DecisionContext = {
-  request_id: string;
-  evaluated_at: string;
+  requestId: string;
+  evaluatedAt: string;
   rationale?: string;
-  metadata?: Record<string, unknown>;
+  conditions?: string[];
+  policyReferences?: PolicyReference[];
+  evaluationSources?: EvaluationSource[];
+  evaluationMetadata?: Record<string, unknown>;
 };

--- a/src/delegations/types.ts
+++ b/src/delegations/types.ts
@@ -1,25 +1,43 @@
 import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from "../capabilities/types";
 
+export type PrincipalType = "human" | "agent" | "service";
+
+export type DelegationStatus = "active" | "expired" | "revoked" | "consumed";
+
+export type DelegationPrincipal = {
+  principalType: PrincipalType;
+  principalId: string;
+};
+
+export type DelegationLineage = {
+  rootDelegationId: string;
+  parentDelegationId: string | null;
+  ancestorDelegationIds: string[];
+  depth: number;
+};
+
+export type DelegationRevocation = {
+  revokedAt: string;
+  revokedByPrincipalId: string;
+  reason?: string | null;
+  propagationMode?: "none" | "downstream" | "chain";
+  propagatedFromDelegationId?: string | null;
+};
+
 export type Delegation = {
   id: string;
-  workspace_id: WorkspaceId;
-  delegator_actor_type: "human" | "ai_agent";
-  delegator_user_id: string | null;
-  delegator_agent_id: string | null;
-  delegate_actor_type: "human" | "ai_agent";
-  delegatee_user_id: string | null;
-  delegatee_agent_id: string | null;
-  source_capability_grant_id: string | null;
-  parent_delegation_id?: string | null;
-  resource_type: CapabilityResourceType | null;
-  resource_id: string | null;
+  workspaceId: WorkspaceId;
+  delegator: DelegationPrincipal;
+  delegatee: DelegationPrincipal;
+  sourceCapabilityGrantId: string | null;
+  lineage: DelegationLineage;
+  resourceType: CapabilityResourceType | null;
+  resourceId: string | null;
   permission: CapabilityPermission;
-  delegated_scope: Record<string, unknown>;
-  status: "active" | "expired" | "revoked" | "consumed";
-  delegation_depth: number;
-  expires_at: string;
-  created_at: string;
-  revoked_at: string | null;
-  revoked_reason?: string | null;
+  scope: Record<string, unknown>;
+  status: DelegationStatus;
+  createdAt: string;
+  expiresAt: string | null;
+  revocation?: DelegationRevocation | null;
   metadata?: Record<string, unknown> | null;
 };

--- a/src/errors/contracts.ts
+++ b/src/errors/contracts.ts
@@ -1,14 +1,37 @@
 export type ProtocolErrorCode =
-  | "invalid_request"
-  | "forbidden"
-  | "not_found"
+  | "validation.invalid_request"
+  | "validation.invalid_state"
+  | "authorization.forbidden"
+  | "authorization.scope_violation"
+  | "policy.evaluation_failed"
+  | "policy.not_applicable"
+  | "delegation.invalid_chain"
+  | "delegation.revoked"
+  | "consent.missing"
+  | "consent.revoked"
+  | "audit.write_failed"
+  | "audit.export_failed"
+  | "identity.not_found"
+  | "identity.ambiguous"
   | "conflict"
   | "unavailable"
   | "internal";
 
+export type ProtocolErrorCategory =
+  | "validation"
+  | "authorization"
+  | "policy"
+  | "delegation"
+  | "consent"
+  | "audit"
+  | "identity"
+  | "platform";
+
 export type ProtocolErrorContract = {
   code: ProtocolErrorCode;
+  category: ProtocolErrorCategory;
   message: string;
   recoverable: boolean;
   details?: unknown;
+  causeCode?: string;
 };

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -1,16 +1,17 @@
 import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from "../capabilities/types";
 
-export type PolicyEffect = "allow" | "deny" | "require_approval";
+export type PolicyEffect = "allow" | "deny" | "require_approval" | "conditional_allow";
 
 export type Policy = {
   id: string;
-  workspace_id: WorkspaceId;
+  workspaceId: WorkspaceId;
   name: string;
   description: string | null;
-  resource_type: CapabilityResourceType;
+  resourceType: CapabilityResourceType;
   permission: CapabilityPermission;
   effect: PolicyEffect;
   enabled: boolean;
   priority: number;
   conditions: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
 };

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -1,49 +1,18 @@
-export type WorkspaceId = string;
-export type ProjectId = string;
-export type AgentId = string;
-
-export type CapabilityPermission =
-  | "read"
-  | "write"
-  | "approve"
-  | "manage"
-  | "execute"
-  | "delegate"
-  | "delete"
-  | "write_memory"
-  | "delete_memory"
-  | "manage_members"
-  | "manage_projects"
-  | "manage_workspace"
-  | "manage_ai"
-  | "manage_billing"
-  | "execute_ai_action"
-  | "view_executive"
-  | "upload_documents";
-
-export type CapabilityResourceType = "workspace" | "project" | "operational_memory" | "governance_object" | "ai_coprocess" | "copilot";
-
-export type CapabilityRequest = { id: string; workspace_id: WorkspaceId; target_resource_type: CapabilityResourceType; target_resource_id: string; requested_permission: CapabilityPermission; status: "pending" | "approved" | "denied" | "revoked"; requester_user_id: string; justification: string | null; created_at: string; };
-export type CapabilityGrant = { id: string; workspace_id: WorkspaceId; capability_request_id: string; permission: CapabilityPermission; target_resource_type: CapabilityResourceType; target_resource_id: string; status: "active" | "revoked" | "expired"; expires_at: string | null; };
-
-export type Policy = { id: string; workspace_id: WorkspaceId; name: string; description: string | null; resource_type: CapabilityResourceType; permission: CapabilityPermission; effect: "allow" | "deny" | "require_approval"; enabled: boolean; priority: number; conditions: Record<string, unknown> | null; };
-export type PolicyDecision = "allow" | "deny" | "require_approval" | "expired" | "no_match";
-
-export type Agent = { id: AgentId; workspace_id: WorkspaceId; name: string; status: "active" | "disabled" | "revoked"; agent_type: string; risk_level: "low" | "medium" | "high"; created_at?: string; };
-export type AgentScope = { id: string; agent_id: AgentId; workspace_id: WorkspaceId; resource_type: CapabilityResourceType; resource_id: string; permission: CapabilityPermission; status: "active" | "expired" | "revoked"; expires_at: string | null; };
-
-export type AuditTimelineItem = { id?: string; created_at: string; event_type: string; severity?: string | null; workspace_id?: string | null; actor_user_id?: string | null; actor_agent_id?: string | null; event_detail?: Record<string, unknown> | null; [key: string]: unknown; };
+export type { WorkspaceId, ProjectId, CapabilityPermission, CapabilityResourceType, CapabilityRequestStatus, CapabilityGrantStatus, CapabilityRequest, CapabilityGrant } from "../capabilities/types";
+export type { AgentId, AgentRiskLevel, Agent, AgentScope } from "../agents/types";
+export type { Policy, PolicyEffect } from "../policies/types";
+export type { PolicyDecision, DecisionContext, PolicyReference, EvaluationSource } from "../decisions/types";
+export type { Delegation, DelegationStatus, DelegationPrincipal, DelegationLineage, DelegationRevocation, PrincipalType } from "../delegations/types";
+export type { AuditTimelineItem, AuditActor, AuditSubject, AuditEventCategory, AuditEventType, AuditSeverity } from "../audit/types";
 
 export type AocClientConfig = {
   baseUrl: string;
   token?: string;
   apiKey?: string;
-  workspaceId?: WorkspaceId;
-  agentId?: AgentId;
+  workspaceId?: string;
+  agentId?: string;
   delegationToken?: string;
   executionGrant?: string;
   agentToken?: string;
   fetch?: typeof globalThis.fetch;
 };
-
-export type Delegation = { id: string; workspace_id: WorkspaceId; delegator_actor_type: "human" | "ai_agent"; delegator_user_id: string | null; delegator_agent_id: string | null; delegate_actor_type: "human" | "ai_agent"; delegatee_user_id: string | null; delegatee_agent_id: string | null; source_capability_grant_id: string | null; parent_delegation_id?: string | null; resource_type: CapabilityResourceType | null; resource_id: string | null; permission: CapabilityPermission; delegated_scope: Record<string, unknown>; status: "active" | "expired" | "revoked" | "consumed"; delegation_depth: number; expires_at: string; created_at: string; revoked_at: string | null; revoked_reason?: string | null; metadata?: Record<string, unknown> | null; };


### PR DESCRIPTION
### Motivation
- Converge protocol semantics and naming into a single canonical contract surface to remove mixed terminology and accidental implementation coupling.
- Formalize capability, delegation, decision, consent, audit, agent scope, and error contracts so the repository is a stable, enterprise-grade protocol definition package.
- Ensure protocol types are framework- and runtime-agnostic while enabling future tracing, auditing, and policy-engine interoperability.
- Provide a clean SDK export surface that re-uses canonical contracts rather than duplicating legacy shapes.

### Description
- Normalized field naming to `camelCase`, unified actor semantics to `principal` vocabulary, and standardized resource targeting to `resourceType` + `resourceId` across capability, delegation, consent, audit, decision, agent, and policy contracts (key files: `src/capabilities/types.ts`, `src/delegations/types.ts`, `src/consent/types.ts`, `src/audit/types.ts`, `src/decisions/types.ts`, `src/agents/types.ts`, `src/policies/types.ts`).
- Formalized capability semantics by introducing a grouped domain-qualified permission taxonomy (`domain:action`), expanded resource taxonomy, and explicit lifecycle enums for requests and grants (`CapabilityRequestStatus`, `CapabilityGrantStatus`).
- Strengthened delegation lineage with explicit `delegator`/`delegatee` principal objects, `DelegationLineage` (root/parent/ancestors/depth), and `DelegationRevocation` metadata including propagation modes to support downstream tracing without runtime assumptions.
- Expanded decision, audit, consent, agent scope, and error models with richer metadata and structured enums: decisions include `conditional_allow`, `delegated`, and source attribution; audit adds categories/severity/dotted event types and actor/subject models; consent and agent scopes support delegation/expiration/authorities; errors use domain-qualified codes and categories.
- Cleaned SDK surface to re-export canonical types from `src` so downstream consumers import a single canonical contract set (`src/sdk/types.ts`) and adapters were updated to the new field names (e.g., `resolveUser` returns `{ id, workspaceId }`).
- This change is intentionally breaking at the type level: snake_case→camelCase migrations, permission/resource taxonomy replacements, and expanded/renamed fields across contracts.

### Testing
- Ran `npm run typecheck` which failed due to pre-existing TypeScript deprecation warnings in workspace `packages/*/tsconfig.json` (deprecated `baseUrl` and `moduleResolution=node10`) and therefore did not produce a clean build.
- Ran `npm run build` which failed for the same tsconfig deprecation issues across workspace packages and did not complete.
- Ran `npm test` which failed in this environment because `jest` is not available on PATH, so test execution did not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07350b25608325beed7e20e50fec9a)