### PR TITLE
Introduce storage repository boundaries, startup safety checks, and repository parity tests

### DIFF
--- a/ADAPTER_COMPATIBILITY_GUIDANCE.md
+++ b/ADAPTER_COMPATIBILITY_GUIDANCE.md
@@ -1,0 +1,8 @@
+# Adapter Compatibility Guidance
+
+Future durable adapters must:
+1. Implement `runtime/storage.ts` interfaces exactly.
+2. Preserve ordering/filtering semantics under all query paths.
+3. Preserve idempotency semantics for payout lookups.
+4. Preserve append-only visibility for audit/usage streams.
+5. Pass repository parity tests unchanged.

--- a/DETERMINISTIC_RUNTIME_SEMANTICS.md
+++ b/DETERMINISTIC_RUNTIME_SEMANTICS.md
@@ -1,0 +1,9 @@
+# Deterministic Runtime Semantics
+
+Determinism expectations across adapters:
+- same writes + same reads => same observable outputs;
+- same audit query => same sorted/filter result set;
+- same payout withdrawal id => same cached idempotent decision;
+- same usage record set => same summary counts/fees/reason tallies.
+
+Any adapter that changes these outcomes is non-compliant.

--- a/DURABILITY_AND_RUNTIME_STATE.md
+++ b/DURABILITY_AND_RUNTIME_STATE.md
@@ -1,0 +1,16 @@
+# Durability and Runtime State
+
+## What improved
+- Runtime state boundaries are now explicit and adapter-ready.
+- In-memory coupling in core services is reduced.
+
+## What remains in-memory
+- Default repositories are still process-local.
+- Multi-instance deployments still require external durable adapters to avoid divergence.
+
+## Operational implications
+- Single-instance/local operation unchanged.
+- Enterprise/multi-instance readiness improved by contract seams, not infra rollout.
+
+## Next hardening step
+- Add a contract test suite that runs against every repository implementation (in-memory + future durable adapters) to verify behavior parity.

--- a/ENVIRONMENT_CLASSIFICATION.md
+++ b/ENVIRONMENT_CLASSIFICATION.md
@@ -1,0 +1,17 @@
+# Environment Classification
+
+Runtime classifies environment from:
+1. `AOC_RUNTIME_ENV` (preferred)
+2. `NODE_ENV` (fallback)
+
+## Mapping
+- `production`, `prod` -> `production`
+- `staging`, `stage` -> `staging`
+- `development`, `dev`, `local` -> `development`
+- `test`, `ci` -> `test`
+- anything else -> `unknown`
+
+## Posture
+- `production`/`staging`: strict safety gates, fail-fast.
+- `development`/`test`: warn on soft-mode and defaults; do not block startup.
+- `unknown`: treated like development for usability, but warning emitted.

--- a/PERSISTENCE_ABSTRACTION_GUIDANCE.md
+++ b/PERSISTENCE_ABSTRACTION_GUIDANCE.md
@@ -1,0 +1,17 @@
+# Persistence Abstraction Guidance
+
+## Principles
+- Keep persistence vendor-neutral.
+- Keep business invariants in service layer, not in storage adapters.
+- Avoid API changes when introducing durable backends.
+
+## Adapter rules
+1. Implement repository interfaces from `runtime/storage.ts`.
+2. Preserve deterministic behaviors (sorting/filtering semantics where relevant).
+3. Preserve idempotency semantics (`withdrawal_id` in payout execution).
+4. Preserve audit append-only assumptions.
+
+## Non-goals
+- No ORM introduction.
+- No mandatory distributed storage assumptions.
+- No topology-specific runtime branching in core logic.

--- a/REPOSITORY_PARITY_MODEL.md
+++ b/REPOSITORY_PARITY_MODEL.md
@@ -1,0 +1,9 @@
+# Repository Parity Model
+
+All repository implementations MUST preserve canonical runtime semantics:
+- key uniqueness is key-based (latest write wins per key);
+- append-only event streams preserve insertion order when listed raw;
+- query APIs return deterministic filtered/sorted views;
+- retention behavior must match configured bounds.
+
+Parity is validated by shared repository contract tests in `runtime/__tests__/repositoryParity.test.ts`.

--- a/RUNTIME_BEHAVIORAL_INVARIANTS.md
+++ b/RUNTIME_BEHAVIORAL_INVARIANTS.md
@@ -1,0 +1,8 @@
+# Runtime Behavioral Invariants
+
+## Invariants
+- Trust verification uses latest credential by `issued_at` ordering.
+- Payout idempotency is keyed by `withdrawal_id`.
+- Usage summaries are derived from append history and endpoint-sorted output.
+- Protocol audit query outputs are sorted by `occurred_at` ascending.
+- Protocol audit retention trims oldest events first.

--- a/RUNTIME_SAFETY_GUARDRAILS.md
+++ b/RUNTIME_SAFETY_GUARDRAILS.md
@@ -1,0 +1,14 @@
+# Runtime Safety Guardrails
+
+## Guardrails added
+- Startup assertion layer in `runtime/startupSafety.ts`.
+- Constructor-time validation in `createRuntimeServer`.
+- Startup posture logging with deterministic reason code format:
+  - `SAFETY_POSTURE_<ENV>_<MODE>`
+- Warning log emissions for non-fatal unsafe posture in non-strict environments.
+
+## Unsafe fallback visibility
+Soft enforcement is now explicitly logged as a warning in non-strict environments.
+
+## Developer usability
+Local development remains compatible with seeded API keys and default secret, but warnings make risk visible.

--- a/RUNTIME_STATE_MODEL.md
+++ b/RUNTIME_STATE_MODEL.md
@@ -1,0 +1,17 @@
+# Runtime State Model
+
+## Current state domains
+- API key state
+- Trust state (issuers, credentials, consents, trust audit)
+- Data access state (tokens + access audit)
+- Payout state (idempotency results + payout audit)
+- Usage state (usage records)
+- Protocol audit stream
+
+## State ownership
+- Each service owns semantics, but state read/write passes through repository contracts.
+- This decouples storage mechanics from runtime behavior.
+
+## Durability posture
+- Default implementations are in-memory.
+- The runtime is now durability-ready at interface boundaries but not yet durable in default configuration.

--- a/SECURITY_STARTUP_ASSERTIONS.md
+++ b/SECURITY_STARTUP_ASSERTIONS.md
@@ -1,0 +1,18 @@
+# Security Startup Assertions
+
+## Hard assertions (fail startup in production/staging)
+1. `ENFORCEMENT_MODE` must equal `strict`.
+2. `AOC_CAPABILITY_SECRET` must not be the built-in default.
+3. `AOC_CAPABILITY_SECRET` length must be at least 24 chars.
+4. Default development API keys must not be present.
+
+## Soft assertions (warn only outside strict mode)
+1. Runtime environment cannot be classified (`unknown`).
+2. Enforcement mode is `soft`.
+
+## Automated checks
+- `runtime/__tests__/startupSafety.test.ts` validates:
+  - strict-mode fail-fast
+  - default-secret detection
+  - default API key detection in production
+  - safe production startup with explicit secret/key/mode

--- a/STARTUP_SAFETY_MODEL.md
+++ b/STARTUP_SAFETY_MODEL.md
@@ -1,0 +1,20 @@
+# Startup Safety Model
+
+## Objective
+Runtime startup now enforces an explicit safety posture before the HTTP server accepts requests.
+
+## Assertions
+- Environment is classified (`production`, `staging`, `development`, `test`, `unknown`).
+- `production`/`staging` are **strict-mode environments**.
+- Strict-mode requires:
+  - `ENFORCEMENT_MODE=strict`
+  - non-default `AOC_CAPABILITY_SECRET`
+  - capability secret length >= 24
+  - no seeded/default dev API keys
+
+## Behavior
+- Strict-mode violations throw at startup (fail-fast).
+- Development/test/unknown modes remain usable and emit warnings for risky posture (e.g., soft enforcement).
+
+## Operational Result
+Unsafe states become explicit and observable instead of silently accepted.

--- a/STORAGE_BOUNDARY_ARCHITECTURE.md
+++ b/STORAGE_BOUNDARY_ARCHITECTURE.md
@@ -1,0 +1,18 @@
+# Storage Boundary Architecture
+
+This runtime now uses storage boundary contracts for stateful domains without selecting a persistence vendor.
+
+## Boundary contracts
+- `ApiKeyRepository`
+- `TrustStateRepository`
+- `DataAccessRepository`
+- `PayoutStateRepository`
+- `UsageRepository`
+- `ProtocolAuditRepository`
+
+Defined in: `runtime/storage.ts`.
+
+## Design
+- Business services depend on repository contracts.
+- Default in-memory repositories remain first-class for local/dev and tests.
+- Durable implementations can be added later by implementing these interfaces, without changing API routes or protocol logic.

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "lint": "npm run typecheck && npm run lint:semantic-ownership",
     "validate:publishability": "node scripts/validate-publishability.mjs",
     "lint:semantic-ownership": "node scripts/lint-semantic-ownership.mjs",
-    "validate:release": "npm run typecheck && npm run build && npm run lint && npm test && npm run lint:semantic-ownership && npm run validate:publishability && npm pack ./packages/protocol"
     "check:runtime-boundaries": "node scripts/check-runtime-boundaries.mjs",
     "check:identity-vocabulary": "node scripts/check-identity-vocabulary.mjs",
     "check:contract-drift": "node scripts/check-contract-drift.mjs",
-    "validate:release": "npm run typecheck && npm run build && npm run lint:semantic-ownership && npm test && npm run validate:publishability"
+    "validate:release": "npm run typecheck && npm run build && npm run lint:semantic-ownership && npm test && npm run validate:publishability",
+    "check:persistence-boundaries": "node scripts/check-persistence-boundaries.mjs",
+    "test:repository-parity": "jest runtime/__tests__/repositoryParity.test.ts"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/runtime/__tests__/repositoryParity.test.ts
+++ b/runtime/__tests__/repositoryParity.test.ts
@@ -1,0 +1,66 @@
+import type { ProtocolAuditEvent } from '../../protocol/audit';
+import {
+  createInMemoryDataAccessRepository,
+  createInMemoryPayoutStateRepository,
+  createInMemoryProtocolAuditRepository,
+  createInMemoryTrustStateRepository,
+  createInMemoryUsageRepository,
+} from '../storage';
+
+describe('repository contract parity invariants', () => {
+  it('TrustStateRepository preserves latest-write wins and append-order audit visibility', () => {
+    const repo = createInMemoryTrustStateRepository();
+    repo.setIssuer({ issuer_id: 'i1', display_name: 'Issuer 1', active: true, supported_kyc_levels: ['basic'] });
+    repo.setIssuer({ issuer_id: 'i1', display_name: 'Issuer 1 updated', active: true, supported_kyc_levels: ['basic', 'enhanced'] });
+    expect(repo.getIssuer('i1')?.display_name).toBe('Issuer 1 updated');
+
+    repo.appendAuditEvent({ event_type: 'VERIFICATION_PERFORMED', at: '2026-01-01T00:00:00Z', subject_hash: 's', reason_code: 'VERIFIED' });
+    repo.appendAuditEvent({ event_type: 'CONSENT_GRANTED', at: '2026-01-01T00:00:01Z', subject_hash: 's', consumer_id: 'c', issuer_id: 'i1' });
+    expect(repo.listAuditEvents().map((e) => e.event_type)).toEqual(['VERIFICATION_PERFORMED', 'CONSENT_GRANTED']);
+  });
+
+  it('DataAccessRepository enforces token uniqueness by key and append-only audit order', () => {
+    const repo = createInMemoryDataAccessRepository();
+    repo.setToken('t1', { token: 't1', audit_ref: 'a1', subject_hash: 's', consumer_id: 'c', dataset_id: 'd', purpose: 'p', requested_scope: [], issued_at: 'x', expires_at: 'y' });
+    repo.setToken('t1', { token: 't1', audit_ref: 'a2', subject_hash: 's2', consumer_id: 'c2', dataset_id: 'd2', purpose: 'p2', requested_scope: [], issued_at: 'x2', expires_at: 'y2' });
+    expect(repo.getToken('t1')?.audit_ref).toBe('a2');
+
+    repo.appendAuditEvent({ event_type: 'DATA_ACCESS_REQUESTED', at: '2026-01-01T00:00:00Z', subject_hash: 's', consumer_id: 'c', dataset_id: 'd', reason_code: 'ACCESS_REQUEST_RECEIVED', audit_ref: 'r1' });
+    repo.appendAuditEvent({ event_type: 'DATA_ACCESS_DENIED', at: '2026-01-01T00:00:01Z', subject_hash: 's', consumer_id: 'c', dataset_id: 'd', reason_code: 'ACCESS_DENIED_NOT_FOUND', audit_ref: 'r2' });
+    expect(repo.listAuditEvents().map((e) => e.audit_ref)).toEqual(['r1', 'r2']);
+  });
+
+  it('PayoutStateRepository preserves idempotent key overwrite and append-only audit ordering', () => {
+    const repo = createInMemoryPayoutStateRepository();
+    repo.setIdempotentResult('w1', { allowed: false, reason_code: 'PAYOUT_BLOCKED_NOT_FOUND' });
+    repo.setIdempotentResult('w1', { allowed: true, reason_code: 'PAYOUT_ALLOWED', payout_id: 'p1', provider_status: 'submitted' });
+    expect(repo.getIdempotentResult('w1')?.allowed).toBe(true);
+
+    repo.appendAuditEvent({ event_type: 'PAYOUT_EXECUTION_REQUESTED', at: '2026-01-01T00:00:00Z', withdrawal_id: 'w1', reason_code: 'PAYOUT_REQUEST_RECEIVED' });
+    repo.appendAuditEvent({ event_type: 'PAYOUT_EXECUTION_RESULT', at: '2026-01-01T00:00:01Z', withdrawal_id: 'w1', reason_code: 'PAYOUT_ALLOWED', provider_status: 'submitted' });
+    expect(repo.listAuditEvents().map((e) => e.event_type)).toEqual(['PAYOUT_EXECUTION_REQUESTED', 'PAYOUT_EXECUTION_RESULT']);
+  });
+
+  it('UsageRepository preserves append visibility for summary reducers', () => {
+    const repo = createInMemoryUsageRepository();
+    repo.appendUsageRecord({ consumer_id: 'c', endpoint: '/data/access', decision: 'allow', reason_code: 'OK', used_at: '2026-01-01T00:00:00Z' });
+    repo.appendUsageRecord({ consumer_id: 'c', endpoint: '/data/access', decision: 'deny', reason_code: 'DENY', used_at: '2026-01-01T00:00:01Z' });
+    const records = repo.listUsageRecords();
+    expect(records).toHaveLength(2);
+    expect(records[1].reason_code).toBe('DENY');
+  });
+
+  it('ProtocolAuditRepository enforces retention and sorted query results deterministically', () => {
+    const repo = createInMemoryProtocolAuditRepository(2);
+    const events: ProtocolAuditEvent[] = [
+      { event_id: 'e1', event_type: 'access.granted', occurred_at: '2026-01-01T00:00:03Z', subject_id: 's', requester_id: 'r' },
+      { event_id: 'e2', event_type: 'access.denied', occurred_at: '2026-01-01T00:00:01Z', subject_id: 's', requester_id: 'r' },
+      { event_id: 'e3', event_type: 'access.granted', occurred_at: '2026-01-01T00:00:02Z', subject_id: 's', requester_id: 'r' },
+    ];
+    events.forEach((event) => repo.appendEvent(event));
+
+    const listed = repo.listEvents();
+    expect(listed.map((e) => e.event_id)).toEqual(['e2', 'e3']);
+    expect(repo.listEvents({ event_type: 'access.granted' }).map((e) => e.event_id)).toEqual(['e3']);
+  });
+});

--- a/runtime/__tests__/startupSafety.test.ts
+++ b/runtime/__tests__/startupSafety.test.ts
@@ -1,0 +1,73 @@
+import { InMemoryApiKeyStore } from '../auth/apiKeys';
+import { createRuntimeServer } from '../api/server';
+import { assertRuntimeStartupSafety } from '../startupSafety';
+
+describe('runtime startup safety assertions', () => {
+  it('fails fast when production uses soft enforcement', () => {
+    expect(() =>
+      assertRuntimeStartupSafety({
+        nodeEnv: 'production',
+        capabilitySecret: 'super_secure_production_secret_value_123',
+        enforcementMode: 'soft',
+        apiKeySeededWithDefaults: false,
+        apiKeys: [],
+      })
+    ).toThrow(/ENFORCEMENT_MODE must be strict/);
+  });
+
+  it('fails fast when production uses default capability secret', () => {
+    expect(() =>
+      assertRuntimeStartupSafety({
+        nodeEnv: 'production',
+        capabilitySecret: 'aoc_runtime_capability_secret',
+        enforcementMode: 'strict',
+        apiKeySeededWithDefaults: false,
+        apiKeys: [],
+      })
+    ).toThrow(/default value/);
+  });
+
+  it('allows local startup with warnings in soft mode', () => {
+    const result = assertRuntimeStartupSafety({
+      nodeEnv: 'development',
+      capabilitySecret: 'aoc_runtime_capability_secret',
+      enforcementMode: 'soft',
+      apiKeySeededWithDefaults: true,
+      apiKeys: [],
+    });
+
+    expect(result.environment).toBe('development');
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('server constructor fails in production with default api keys', () => {
+    const oldEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      expect(() => createRuntimeServer()).toThrow(/Default development API keys are forbidden/);
+    } finally {
+      process.env.NODE_ENV = oldEnv;
+    }
+  });
+
+  it('server constructor allows production startup with explicit keys + strict mode', () => {
+    const oldEnv = process.env.NODE_ENV;
+    const oldMode = process.env.ENFORCEMENT_MODE;
+    const oldSecret = process.env.AOC_CAPABILITY_SECRET;
+
+    process.env.NODE_ENV = 'production';
+    process.env.ENFORCEMENT_MODE = 'strict';
+    process.env.AOC_CAPABILITY_SECRET = 'super_secure_production_secret_value_123';
+
+    try {
+      const apiKeyStore = new InMemoryApiKeyStore([{ apiKey: 'prod_key_1', owner: 'prod', tier: 'pro' }]);
+      const server = createRuntimeServer({ apiKeyStore });
+      server.close();
+    } finally {
+      process.env.NODE_ENV = oldEnv;
+      process.env.ENFORCEMENT_MODE = oldMode;
+      process.env.AOC_CAPABILITY_SECRET = oldSecret;
+    }
+  });
+});

--- a/runtime/access/service.ts
+++ b/runtime/access/service.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'crypto';
 import type { InMemoryTrustService } from '../trust/service';
 import type { DataAccessAuditEvent, DataAccessDecision, DataAccessRequestInput, AccessTokenRecord } from './types';
+import { createInMemoryDataAccessRepository, type DataAccessRepository } from '../storage';
 
 const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
 
@@ -14,20 +15,20 @@ const TRUST_REASON_TO_ACCESS_REASON: Record<string, DataAccessDecision['reason_c
 };
 
 export class DataAccessService {
-  private readonly auditEvents: DataAccessAuditEvent[] = [];
-  private readonly tokens = new Map<string, AccessTokenRecord>();
+  private readonly repo: DataAccessRepository;
 
   constructor(
     private readonly trustService: InMemoryTrustService,
-    private readonly tokenTtlMs: number = DEFAULT_TOKEN_TTL_MS
-  ) {}
+    private readonly tokenTtlMs: number = DEFAULT_TOKEN_TTL_MS,
+    repo?: DataAccessRepository
+  ) { this.repo = repo ?? createInMemoryDataAccessRepository(); }
 
   requestAccess(input: DataAccessRequestInput): DataAccessDecision {
     const now = input.now ?? new Date();
     const requestedAt = now.toISOString();
     const requestRef = randomUUID();
 
-    this.auditEvents.push({
+    this.repo.appendAuditEvent({
       event_type: 'DATA_ACCESS_REQUESTED',
       at: requestedAt,
       subject_hash: input.subject_hash,
@@ -47,7 +48,7 @@ export class DataAccessService {
 
     if (!verification.valid) {
       const deniedRef = randomUUID();
-      this.auditEvents.push({
+      this.repo.appendAuditEvent({
         event_type: 'DATA_ACCESS_DENIED',
         at: requestedAt,
         subject_hash: input.subject_hash,
@@ -67,7 +68,7 @@ export class DataAccessService {
     const expiresAt = new Date(now.getTime() + this.tokenTtlMs).toISOString();
     const token = this.generateToken(auditRef, input, requestedAt, expiresAt);
 
-    this.tokens.set(token, {
+    this.repo.setToken(token, {
       token,
       audit_ref: auditRef,
       subject_hash: input.subject_hash,
@@ -79,7 +80,7 @@ export class DataAccessService {
       expires_at: expiresAt,
     });
 
-    this.auditEvents.push({
+    this.repo.appendAuditEvent({
       event_type: 'DATA_ACCESS_ALLOWED',
       at: requestedAt,
       subject_hash: input.subject_hash,
@@ -99,7 +100,7 @@ export class DataAccessService {
   }
 
   getAuditEvents(): readonly DataAccessAuditEvent[] {
-    return [...this.auditEvents];
+    return this.repo.listAuditEvents();
   }
 
   private generateToken(auditRef: string, input: DataAccessRequestInput, issuedAt: string, expiresAt: string): string {
@@ -110,3 +111,5 @@ export class DataAccessService {
     return `aoc_access_${digest}`;
   }
 }
+
+

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -8,6 +8,7 @@ import { authAndLimit } from './middleware';
 import { DEFAULT_RUNTIME_CORE, deriveDecision, executeRoute, maybeResolveUsageConsumerId, type RuntimeCore } from './routes';
 import { isMeteredEndpoint } from '../usage';
 import { enforceCapabilityAccess, type EnforcementMode } from '../enforcement';
+import { assertRuntimeStartupSafety } from '../startupSafety';
 
 const POST_ENDPOINTS: RuntimeEndpoint[] = [
   '/enforcement/evaluate',
@@ -70,6 +71,31 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
   const core = deps.core ?? DEFAULT_RUNTIME_CORE;
   const capabilitySecret = deps.capabilitySecret ?? process.env.AOC_CAPABILITY_SECRET ?? 'aoc_runtime_capability_secret';
   const enforcementMode = deps.enforcementMode ?? (process.env.ENFORCEMENT_MODE === 'strict' ? 'strict' : 'soft');
+
+  const startupSafety = assertRuntimeStartupSafety({
+    nodeEnv: process.env.NODE_ENV,
+    runtimeEnvironment: process.env.AOC_RUNTIME_ENV,
+    capabilitySecret,
+    enforcementMode,
+    apiKeySeededWithDefaults: deps.apiKeyStore === undefined,
+    apiKeys: apiKeyStore.list(),
+  });
+
+  logger.log({
+    requestId: 'startup',
+    endpoint: '/runtime/startup',
+    decision: startupSafety.strictMode ? 'allow' : 'deny',
+    reason_code: `SAFETY_POSTURE_${startupSafety.environment.toUpperCase()}_${enforcementMode.toUpperCase()}`,
+  });
+
+  startupSafety.warnings.forEach((warning, index) => {
+    logger.log({
+      requestId: `startup-warning-${index + 1}`,
+      endpoint: '/runtime/startup',
+      decision: 'deny',
+      reason_code: warning,
+    });
+  });
 
   return createServer(async (request, response) => {
     if (request.url === undefined) {

--- a/runtime/audit/service.ts
+++ b/runtime/audit/service.ts
@@ -5,6 +5,7 @@ import type { RlusdPayoutExecutorService } from '../payout/rlusdPayoutExecutor.s
 import type { PayoutAuditEvent } from '../payout/types';
 import type { InMemoryTrustService } from '../trust/service';
 import type { TrustAuditEvent } from '../trust/types';
+import { createInMemoryProtocolAuditRepository, type ProtocolAuditRepository } from '../storage';
 
 const DEFAULT_MAX_AUDIT_EVENTS = 10_000;
 
@@ -19,68 +20,25 @@ export type ListAuditEventsInput = {
 };
 
 export class InMemoryAuditService {
-  private readonly events: ProtocolAuditEvent[] = [];
+  private readonly repo: ProtocolAuditRepository;
   private readonly maxEvents: number;
 
-  constructor(maxEvents: number = DEFAULT_MAX_AUDIT_EVENTS) {
+  constructor(maxEvents: number = DEFAULT_MAX_AUDIT_EVENTS, repo?: ProtocolAuditRepository) {
     this.maxEvents = Number.isFinite(maxEvents) && maxEvents > 0 ? Math.floor(maxEvents) : DEFAULT_MAX_AUDIT_EVENTS;
+    this.repo = repo ?? createInMemoryProtocolAuditRepository(this.maxEvents);
   }
 
   recordEvent(event: ProtocolAuditEvent): void {
-    this.events.push({
-      ...event,
-      metadata: event.metadata === undefined ? undefined : { ...event.metadata },
-    });
-
-    while (this.events.length > this.maxEvents) {
-      this.events.shift();
-    }
+    this.repo.appendEvent(event);
   }
 
   listEvents(query: AuditEventQuery = {}): ProtocolAuditEvent[] {
-    return this.events
-      .filter((event) => this.matchesQuery(event, query))
-      .slice()
-      .sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at))
-      .map((event) => ({
-        ...event,
-        metadata: event.metadata === undefined ? undefined : { ...event.metadata },
-      }));
+    return this.repo.listEvents(query);
   }
 
-  private matchesQuery(event: ProtocolAuditEvent, query: AuditEventQuery): boolean {
-    if (query.event_type !== undefined && event.event_type !== query.event_type) {
-      return false;
-    }
-
-    if (query.subject_id !== undefined && event.subject_id !== query.subject_id) {
-      return false;
-    }
-
-    if (query.requester_id !== undefined && event.requester_id !== query.requester_id) {
-      return false;
-    }
-
-    if (query.consent_id !== undefined && event.consent_id !== query.consent_id) {
-      return false;
-    }
-
-    if (query.capability_id !== undefined && event.capability_id !== query.capability_id) {
-      return false;
-    }
-
-    const occurredAt = Date.parse(event.occurred_at);
-    if (query.from !== undefined && occurredAt < query.from.getTime()) {
-      return false;
-    }
-
-    if (query.to !== undefined && occurredAt > query.to.getTime()) {
-      return false;
-    }
-
-    return true;
-  }
 }
+
+
 
 export class RuntimeAuditService {
   constructor(

--- a/runtime/auth/apiKeys.ts
+++ b/runtime/auth/apiKeys.ts
@@ -20,6 +20,10 @@ export class InMemoryApiKeyStore {
   add(record: ApiKeyRecord): void {
     this.keys.set(record.apiKey, record);
   }
+
+  list(): ApiKeyRecord[] {
+    return [...this.keys.values()];
+  }
 }
 
 export const DEFAULT_API_KEYS: ApiKeyRecord[] = [

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -55,3 +55,7 @@ export * from './sovereign-runtime';
 // Compatibility note: runtime negotiation module is not yet stabilized for npm export.
 // Compatibility note: governance treaties module pending extraction; keep internal-only for now.
 export * from './marketplace';
+
+export type { ApiKeyRepository, TrustStateRepository, DataAccessRepository, PayoutStateRepository, UsageRepository, ProtocolAuditRepository } from './storage';
+
+export { createInMemoryTrustStateRepository, createInMemoryDataAccessRepository, createInMemoryPayoutStateRepository, createInMemoryUsageRepository, createInMemoryProtocolAuditRepository } from './storage';

--- a/runtime/payout/rlusdPayoutExecutor.service.ts
+++ b/runtime/payout/rlusdPayoutExecutor.service.ts
@@ -2,27 +2,28 @@ import type { InMemoryTrustService } from '../trust/service';
 import type { PayoutAdapter } from './types';
 import type { PayoutAuditEvent, PayoutCallbackInput, PayoutExecuteResult } from './types';
 import type { RlusdWithdrawalRequest } from '../trust/types';
+import { createInMemoryPayoutStateRepository, type PayoutStateRepository } from '../storage';
 
 export class RlusdPayoutExecutorService {
-  private readonly auditEvents: PayoutAuditEvent[] = [];
-  private readonly idempotentResults = new Map<string, PayoutExecuteResult>();
+  private readonly repo: PayoutStateRepository;
 
   constructor(
     private readonly trustService: InMemoryTrustService,
-    private readonly adapter: PayoutAdapter
-  ) {}
+    private readonly adapter: PayoutAdapter,
+    repo?: PayoutStateRepository
+  ) { this.repo = repo ?? createInMemoryPayoutStateRepository(); }
 
   getAuditEvents(): readonly PayoutAuditEvent[] {
-    return [...this.auditEvents];
+    return this.repo.listAuditEvents();
   }
 
   execute(request: RlusdWithdrawalRequest, now: Date = new Date()): PayoutExecuteResult {
-    const cached = this.idempotentResults.get(request.withdrawal_id);
+    const cached = this.repo.getIdempotentResult(request.withdrawal_id);
     if (cached !== undefined) {
       return cached;
     }
 
-    this.auditEvents.push({
+    this.repo.appendAuditEvent({
       event_type: 'PAYOUT_EXECUTION_REQUESTED',
       at: now.toISOString(),
       withdrawal_id: request.withdrawal_id,
@@ -35,8 +36,8 @@ export class RlusdPayoutExecutorService {
         allowed: false,
         reason_code: kycDecision.reason_code,
       };
-      this.idempotentResults.set(request.withdrawal_id, blocked);
-      this.auditEvents.push({
+      this.repo.setIdempotentResult(request.withdrawal_id, blocked);
+      this.repo.appendAuditEvent({
         event_type: 'PAYOUT_EXECUTION_RESULT',
         at: now.toISOString(),
         withdrawal_id: request.withdrawal_id,
@@ -53,8 +54,8 @@ export class RlusdPayoutExecutorService {
       payout_id: adapterResult.payout_id,
       provider_status: adapterResult.provider_status,
     };
-    this.idempotentResults.set(request.withdrawal_id, allowed);
-    this.auditEvents.push({
+    this.repo.setIdempotentResult(request.withdrawal_id, allowed);
+    this.repo.appendAuditEvent({
       event_type: 'PAYOUT_EXECUTION_RESULT',
       at: now.toISOString(),
       withdrawal_id: request.withdrawal_id,
@@ -67,7 +68,7 @@ export class RlusdPayoutExecutorService {
   }
 
   callback(input: PayoutCallbackInput, now: Date = new Date()): { received: true; reason_code: string } {
-    this.auditEvents.push({
+    this.repo.appendAuditEvent({
       event_type: 'PAYOUT_CALLBACK_RECEIVED',
       at: input.occurred_at ?? now.toISOString(),
       payout_id: input.payout_id,
@@ -81,3 +82,5 @@ export class RlusdPayoutExecutorService {
     };
   }
 }
+
+

--- a/runtime/startupSafety.ts
+++ b/runtime/startupSafety.ts
@@ -1,0 +1,82 @@
+import { DEFAULT_API_KEYS, type ApiKeyRecord } from './auth/apiKeys';
+import type { EnforcementMode } from './enforcement';
+
+export type RuntimeEnvironment = 'production' | 'staging' | 'development' | 'test' | 'unknown';
+
+export type StartupSafetyInput = {
+  nodeEnv?: string;
+  runtimeEnvironment?: string;
+  capabilitySecret?: string;
+  enforcementMode: EnforcementMode;
+  apiKeySeededWithDefaults: boolean;
+  apiKeys: ReadonlyArray<ApiKeyRecord>;
+};
+
+export type StartupSafetyResult = {
+  environment: RuntimeEnvironment;
+  strictMode: boolean;
+  warnings: string[];
+};
+
+const DEFAULT_CAPABILITY_SECRET = 'aoc_runtime_capability_secret';
+const DEFAULT_API_KEY_VALUES = new Set(DEFAULT_API_KEYS.map((record) => record.apiKey));
+
+function classifyEnvironment(nodeEnv?: string, runtimeEnvironment?: string): RuntimeEnvironment {
+  const value = (runtimeEnvironment ?? nodeEnv ?? '').trim().toLowerCase();
+  if (value === 'production' || value === 'prod') return 'production';
+  if (value === 'staging' || value === 'stage') return 'staging';
+  if (value === 'development' || value === 'dev' || value === 'local') return 'development';
+  if (value === 'test' || value === 'ci') return 'test';
+  return 'unknown';
+}
+
+function validateCapabilitySecret(environment: RuntimeEnvironment, capabilitySecret: string): string[] {
+  const errors: string[] = [];
+  if (environment === 'production' || environment === 'staging') {
+    if (capabilitySecret === DEFAULT_CAPABILITY_SECRET) {
+      errors.push('AOC_CAPABILITY_SECRET cannot use the default value in production/staging.');
+    }
+    if (capabilitySecret.length < 24) {
+      errors.push('AOC_CAPABILITY_SECRET must be at least 24 characters in production/staging.');
+    }
+  }
+  return errors;
+}
+
+function validateApiKeys(environment: RuntimeEnvironment, input: StartupSafetyInput): string[] {
+  const errors: string[] = [];
+  const usesDefaultValue = input.apiKeys.some((record) => DEFAULT_API_KEY_VALUES.has(record.apiKey));
+  if ((environment === 'production' || environment === 'staging') && (input.apiKeySeededWithDefaults || usesDefaultValue)) {
+    errors.push('Default development API keys are forbidden in production/staging runtime startup.');
+  }
+  return errors;
+}
+
+export function assertRuntimeStartupSafety(input: StartupSafetyInput): StartupSafetyResult {
+  const environment = classifyEnvironment(input.nodeEnv, input.runtimeEnvironment);
+  const strictMode = environment === 'production' || environment === 'staging';
+  const warnings: string[] = [];
+
+  if (environment === 'unknown') {
+    warnings.push('Runtime environment is unknown; defaulting to development safety posture.');
+  }
+
+  if (!strictMode && input.enforcementMode === 'soft') {
+    warnings.push('Capability enforcement is running in soft mode; authorization denials may not block requests.');
+  }
+
+  const errors = [
+    ...validateCapabilitySecret(environment, input.capabilitySecret ?? DEFAULT_CAPABILITY_SECRET),
+    ...validateApiKeys(environment, input),
+  ];
+
+  if (strictMode && input.enforcementMode !== 'strict') {
+    errors.push('ENFORCEMENT_MODE must be strict in production/staging.');
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Runtime startup safety assertion failed: ${errors.join(' ')}`);
+  }
+
+  return { environment, strictMode, warnings };
+}

--- a/runtime/storage.ts
+++ b/runtime/storage.ts
@@ -1,0 +1,120 @@
+import type { ProtocolAuditEvent, AuditEventQuery } from '../protocol/audit';
+import type { ApiKeyRecord } from './auth/apiKeys';
+import type { AccessTokenRecord, DataAccessAuditEvent } from './access/types';
+import type { AocIdentityConsentRecord, AocIdentityCredentialRecord, AocIdentityIssuerRecord, TrustAuditEvent } from './trust/types';
+import type { PayoutAuditEvent, PayoutExecuteResult } from './payout/types';
+import type { UsageRecord } from './usage';
+
+export interface ApiKeyRepository {
+  get(apiKey: string): ApiKeyRecord | undefined;
+  add(record: ApiKeyRecord): void;
+  list(): ApiKeyRecord[];
+}
+
+export interface TrustStateRepository {
+  getIssuer(issuerId: string): AocIdentityIssuerRecord | undefined;
+  setIssuer(record: AocIdentityIssuerRecord): void;
+  listCredentials(): AocIdentityCredentialRecord[];
+  setCredential(record: AocIdentityCredentialRecord): void;
+  listConsents(): AocIdentityConsentRecord[];
+  setConsent(record: AocIdentityConsentRecord): void;
+  appendAuditEvent(event: TrustAuditEvent): void;
+  listAuditEvents(): TrustAuditEvent[];
+}
+
+export interface DataAccessRepository {
+  setToken(token: string, record: AccessTokenRecord): void;
+  getToken(token: string): AccessTokenRecord | undefined;
+  appendAuditEvent(event: DataAccessAuditEvent): void;
+  listAuditEvents(): DataAccessAuditEvent[];
+}
+
+export interface PayoutStateRepository {
+  getIdempotentResult(withdrawalId: string): PayoutExecuteResult | undefined;
+  setIdempotentResult(withdrawalId: string, result: PayoutExecuteResult): void;
+  appendAuditEvent(event: PayoutAuditEvent): void;
+  listAuditEvents(): PayoutAuditEvent[];
+}
+
+export interface UsageRepository {
+  appendUsageRecord(record: UsageRecord): void;
+  listUsageRecords(): UsageRecord[];
+}
+
+export interface ProtocolAuditRepository {
+  appendEvent(event: ProtocolAuditEvent): void;
+  listEvents(query?: AuditEventQuery): ProtocolAuditEvent[];
+}
+
+export function createInMemoryTrustStateRepository(): TrustStateRepository {
+  const issuers = new Map<string, AocIdentityIssuerRecord>();
+  const credentials = new Map<string, AocIdentityCredentialRecord>();
+  const consents = new Map<string, AocIdentityConsentRecord>();
+  const auditEvents: TrustAuditEvent[] = [];
+  return {
+    getIssuer: (issuerId) => issuers.get(issuerId),
+    setIssuer: (record) => { issuers.set(record.issuer_id, record); },
+    listCredentials: () => [...credentials.values()],
+    setCredential: (record) => { credentials.set(record.credential_ref, record); },
+    listConsents: () => [...consents.values()],
+    setConsent: (record) => { consents.set(record.consent_id, record); },
+    appendAuditEvent: (event) => { auditEvents.push(event); },
+    listAuditEvents: () => [...auditEvents],
+  };
+}
+
+export function createInMemoryDataAccessRepository(): DataAccessRepository {
+  const tokens = new Map<string, AccessTokenRecord>();
+  const auditEvents: DataAccessAuditEvent[] = [];
+  return {
+    setToken: (token, record) => { tokens.set(token, record); },
+    getToken: (token) => tokens.get(token),
+    appendAuditEvent: (event) => { auditEvents.push(event); },
+    listAuditEvents: () => [...auditEvents],
+  };
+}
+
+export function createInMemoryPayoutStateRepository(): PayoutStateRepository {
+  const idempotentResults = new Map<string, PayoutExecuteResult>();
+  const auditEvents: PayoutAuditEvent[] = [];
+  return {
+    getIdempotentResult: (withdrawalId) => idempotentResults.get(withdrawalId),
+    setIdempotentResult: (withdrawalId, result) => { idempotentResults.set(withdrawalId, result); },
+    appendAuditEvent: (event) => { auditEvents.push(event); },
+    listAuditEvents: () => [...auditEvents],
+  };
+}
+
+export function createInMemoryUsageRepository(): UsageRepository {
+  const records: UsageRecord[] = [];
+  return {
+    appendUsageRecord: (record) => { records.push(record); },
+    listUsageRecords: () => [...records],
+  };
+}
+
+export function createInMemoryProtocolAuditRepository(maxEvents: number): ProtocolAuditRepository {
+  const events: ProtocolAuditEvent[] = [];
+  return {
+    appendEvent: (event) => {
+      events.push({ ...event, metadata: event.metadata === undefined ? undefined : { ...event.metadata } });
+      while (events.length > maxEvents) events.shift();
+    },
+    listEvents: (query = {}) =>
+      events
+        .filter((event) => {
+          if (query.event_type !== undefined && event.event_type !== query.event_type) return false;
+          if (query.subject_id !== undefined && event.subject_id !== query.subject_id) return false;
+          if (query.requester_id !== undefined && event.requester_id !== query.requester_id) return false;
+          if (query.consent_id !== undefined && event.consent_id !== query.consent_id) return false;
+          if (query.capability_id !== undefined && event.capability_id !== query.capability_id) return false;
+          const occurredAt = Date.parse(event.occurred_at);
+          if (query.from !== undefined && occurredAt < query.from.getTime()) return false;
+          if (query.to !== undefined && occurredAt > query.to.getTime()) return false;
+          return true;
+        })
+        .slice()
+        .sort((a, b) => Date.parse(a.occurred_at) - Date.parse(b.occurred_at))
+        .map((event) => ({ ...event, metadata: event.metadata === undefined ? undefined : { ...event.metadata } })),
+  };
+}

--- a/runtime/trust/service.ts
+++ b/runtime/trust/service.ts
@@ -6,6 +6,7 @@ import {
   type RlusdWithdrawalRequest,
   type TrustAuditEvent,
 } from './types';
+import { createInMemoryTrustStateRepository, type TrustStateRepository } from '../storage';
 
 export type RegisterCredentialInput = {
   credential_ref: string;
@@ -35,23 +36,21 @@ export type VerifyIdentityInput = {
 };
 
 export class InMemoryTrustService {
-  private readonly issuers = new Map<string, AocIdentityIssuerRecord>();
-  private readonly credentials = new Map<string, AocIdentityCredentialRecord>();
-  private readonly consents = new Map<string, AocIdentityConsentRecord>();
-  private readonly auditEvents: TrustAuditEvent[] = [];
+  private readonly repo: TrustStateRepository;
 
-  constructor(initialIssuers: readonly AocIdentityIssuerRecord[] = []) {
+  constructor(initialIssuers: readonly AocIdentityIssuerRecord[] = [], repo?: TrustStateRepository) {
+    this.repo = repo ?? createInMemoryTrustStateRepository();
     for (const issuer of initialIssuers) {
-      this.issuers.set(issuer.issuer_id, issuer);
+      this.repo.setIssuer(issuer);
     }
   }
 
   getAuditEvents(): readonly TrustAuditEvent[] {
-    return [...this.auditEvents];
+    return this.repo.listAuditEvents();
   }
 
   registerCredential(input: RegisterCredentialInput): AocIdentityCredentialRecord {
-    const issuer = this.issuers.get(input.issuer_id);
+    const issuer = this.repo.getIssuer(input.issuer_id);
     if (issuer === undefined || !issuer.active) {
       throw new Error(`Issuer is invalid or inactive: ${input.issuer_id}`);
     }
@@ -70,8 +69,8 @@ export class InMemoryTrustService {
       issued_at: input.issued_at,
       expires_at: input.expires_at,
     };
-    this.credentials.set(record.credential_ref, record);
-    this.auditEvents.push({
+    this.repo.setCredential(record);
+    this.repo.appendAuditEvent({
       event_type: 'CREDENTIAL_REGISTERED',
       at: input.issued_at,
       subject_hash: input.subject_hash,
@@ -79,7 +78,7 @@ export class InMemoryTrustService {
       credential_ref: input.credential_ref,
     });
     if (input.wallet_address !== undefined) {
-      this.auditEvents.push({
+      this.repo.appendAuditEvent({
         event_type: 'WALLET_LINKED',
         at: input.issued_at,
         subject_hash: input.subject_hash,
@@ -91,7 +90,7 @@ export class InMemoryTrustService {
   }
 
   grantConsent(input: GrantConsentInput): AocIdentityConsentRecord {
-    const issuer = this.issuers.get(input.issuer_id);
+    const issuer = this.repo.getIssuer(input.issuer_id);
     if (issuer === undefined || !issuer.active) {
       throw new Error(`Issuer is invalid or inactive: ${input.issuer_id}`);
     }
@@ -102,8 +101,8 @@ export class InMemoryTrustService {
       issuer_id: input.issuer_id,
       granted_at: input.granted_at,
     };
-    this.consents.set(input.consent_id, consent);
-    this.auditEvents.push({
+    this.repo.setConsent(consent);
+    this.repo.appendAuditEvent({
       event_type: 'CONSENT_GRANTED',
       at: input.granted_at,
       subject_hash: input.subject_hash,
@@ -115,7 +114,7 @@ export class InMemoryTrustService {
 
   verifyIdentity(input: VerifyIdentityInput): IdentityVerificationResult {
     const now = input.now ?? new Date();
-    const candidates = [...this.credentials.values()].filter(
+    const candidates = this.repo.listCredentials().filter(
       (credential) =>
         credential.subject_hash === input.subject_hash &&
         (input.issuer_id === undefined || credential.issuer_id === input.issuer_id)
@@ -126,7 +125,7 @@ export class InMemoryTrustService {
       return result;
     }
     const latest = candidates.sort((a, b) => Date.parse(b.issued_at) - Date.parse(a.issued_at))[0];
-    const issuer = this.issuers.get(latest.issuer_id);
+    const issuer = this.repo.getIssuer(latest.issuer_id);
     if (issuer === undefined || !issuer.active) {
       const result: IdentityVerificationResult = { valid: false, reason_code: 'ISSUER_INACTIVE' };
       this.pushVerificationAudit(input, result, latest);
@@ -143,7 +142,7 @@ export class InMemoryTrustService {
       return result;
     }
     if (input.consumer_id !== undefined) {
-      const consentExists = [...this.consents.values()].some(
+      const consentExists = this.repo.listConsents().some(
         (consent) =>
           consent.subject_hash === input.subject_hash &&
           consent.consumer_id === input.consumer_id &&
@@ -175,7 +174,7 @@ export class InMemoryTrustService {
       now,
     });
     if (!verification.valid) {
-      this.auditEvents.push({
+      this.repo.appendAuditEvent({
         event_type: 'PAYOUT_BLOCKED',
         at: now.toISOString(),
         subject_hash: request.subject_hash,
@@ -186,7 +185,7 @@ export class InMemoryTrustService {
       });
       return { allowed: false, reason_code: `PAYOUT_BLOCKED_${verification.reason_code}` };
     }
-    this.auditEvents.push({
+    this.repo.appendAuditEvent({
       event_type: 'PAYOUT_ALLOWED',
       at: now.toISOString(),
       subject_hash: request.subject_hash,
@@ -203,7 +202,7 @@ export class InMemoryTrustService {
     result: IdentityVerificationResult,
     credential?: AocIdentityCredentialRecord
   ): void {
-    this.auditEvents.push({
+    this.repo.appendAuditEvent({
       event_type: 'VERIFICATION_PERFORMED',
       at: (input.now ?? new Date()).toISOString(),
       subject_hash: input.subject_hash,
@@ -214,6 +213,8 @@ export class InMemoryTrustService {
     });
   }
 }
+
+
 
 export const DEFAULT_TRUST_ISSUERS: readonly AocIdentityIssuerRecord[] = [
   {

--- a/runtime/usage/service.ts
+++ b/runtime/usage/service.ts
@@ -6,6 +6,7 @@ import type {
   UsageSummaryQuery,
   UsageSummaryResult,
 } from './types';
+import { createInMemoryUsageRepository, type UsageRepository } from '../storage';
 
 const UNIT_PRICES: Record<MeteredRuntimeEndpoint, number> = {
   '/data/access': 0.05,
@@ -22,10 +23,10 @@ type RecordUsageInput = {
 };
 
 export class InMemoryUsageService {
-  private readonly records: UsageRecord[] = [];
+  constructor(private readonly repo: UsageRepository = createInMemoryUsageRepository()) {}
 
   recordUsage(input: RecordUsageInput): void {
-    this.records.push({
+    this.repo.appendUsageRecord({
       consumer_id: input.consumer_id,
       endpoint: input.endpoint,
       decision: input.decision,
@@ -35,7 +36,7 @@ export class InMemoryUsageService {
   }
 
   getSummary(query: UsageSummaryQuery): UsageSummaryResult {
-    const filtered = this.records.filter((record) => {
+    const filtered = this.repo.listUsageRecords().filter((record) => {
       if (record.consumer_id !== query.consumer_id) {
         return false;
       }
@@ -90,3 +91,5 @@ export class InMemoryUsageService {
 }
 
 export { UNIT_PRICES };
+
+

--- a/scripts/check-persistence-boundaries.mjs
+++ b/scripts/check-persistence-boundaries.mjs
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+
+const files = [
+  'runtime/trust/service.ts',
+  'runtime/access/service.ts',
+  'runtime/payout/rlusdPayoutExecutor.service.ts',
+  'runtime/usage/service.ts',
+  'runtime/audit/service.ts'
+];
+
+const violations = [];
+for (const file of files) {
+  const src = readFileSync(file, 'utf8');
+  if (!src.includes('Repository')) {
+    violations.push(`${file}: missing repository boundary usage`);
+  }
+}
+
+if (violations.length) {
+  console.error('Persistence boundary check failed:');
+  for (const v of violations) console.error(`- ${v}`);
+  process.exit(1);
+}
+
+console.log('Persistence boundary check passed.');


### PR DESCRIPTION
### Motivation
- Introduce explicit persistence boundaries so the runtime can support durable adapters without changing service logic.
- Make startup safety posture explicit and fail-fast in strict environments to avoid insecure production startups.
- Capture and document runtime invariants and adapter compatibility requirements to guide future durable adapter implementations.

### Description
- Add `runtime/storage.ts` which defines repository interfaces (`ApiKeyRepository`, `TrustStateRepository`, `DataAccessRepository`, `PayoutStateRepository`, `UsageRepository`, `ProtocolAuditRepository`) and in-memory implementations (factory functions like `createInMemory*`), and export those from `runtime/index.ts`.
- Refactor core services (`trust`, `access`, `payout`, `usage`, `audit`) to depend on repository interfaces instead of local in-memory arrays and maps, wiring default in-memory repositories where not provided.
- Add `runtime/startupSafety.ts` and integrate it into `createRuntimeServer` to classify environment, validate capability secret and API key seeding, and emit/log startup warnings or throw on strict-mode violations.
- Add repository parity and startup safety unit tests (`runtime/__tests__/repositoryParity.test.ts`, `runtime/__tests__/startupSafety.test.ts`) and helper script `scripts/check-persistence-boundaries.mjs` to assert services reference repositories.
- Add numerous documentation/architecture files (e.g. `STORAGE_BOUNDARY_ARCHITECTURE.md`, `REPOSITORY_PARITY_MODEL.md`, `STARTUP_SAFETY_MODEL.md`, `RUNTIME_SAFETY_GUARDRAILS.md`, etc.) describing invariants, durability posture, and adapter guidance.
- Update `package.json` to include `check:persistence-boundaries` and `test:repository-parity` scripts and expose repository parity test command.

### Testing
- Added unit tests `runtime/__tests__/repositoryParity.test.ts` and `runtime/__tests__/startupSafety.test.ts` that exercise repository parity invariants and startup safety assertions.
- Ran the test suite with `npm test` and the repository parity check with `npm run test:repository-parity`, and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07aa3d24c4832582fba71ebd0bb1ea)