### PR TITLE
Harden runtime export surface and add explicit public/internal/experimental entrypoints

### DIFF
--- a/EXPERIMENTAL_RUNTIME_MODULES.md
+++ b/EXPERIMENTAL_RUNTIME_MODULES.md
@@ -1,0 +1,11 @@
+# Experimental Runtime Modules
+
+Experimental runtime entrypoint: `runtime/experimental.ts`.
+
+## Experimental Modules
+- `runtime/sovereign-runtime`
+- `runtime/marketplace`
+
+## Compatibility Notes
+- Experimental APIs may change without semver guarantees.
+- Downstream consumers should pin versions and avoid production hard dependencies until promoted to stable.

--- a/FUTURE_PACKAGE_EXTRACTION_MAP.md
+++ b/FUTURE_PACKAGE_EXTRACTION_MAP.md
@@ -1,0 +1,18 @@
+# Future Package Extraction Map
+
+This map defines likely extraction boundaries without performing a split now.
+
+## Candidate Packages
+- `@aoc/runtime-governance` ← `runtime/governance/*`
+- `@aoc/runtime-distributed` ← `runtime/distributed/*`
+- `@aoc/runtime-capabilities` ← `runtime/capabilities/*`
+- `@aoc/runtime-attestations` ← `runtime/attestations/*`
+- `@aoc/runtime-execution-fabric` ← `runtime/execution-fabric/*`
+- `@aoc/runtime-sovereign` (experimental) ← `runtime/sovereign-runtime/*`
+- `@aoc/runtime-marketplace` (experimental) ← `runtime/marketplace/*`
+
+## Promotion Criteria
+- API contract docs complete.
+- Semver ownership defined.
+- Export leakage checks green.
+- External-consumer fixture import tests green.

--- a/INTERNAL_RUNTIME_SURFACE.md
+++ b/INTERNAL_RUNTIME_SURFACE.md
@@ -1,0 +1,12 @@
+# Internal Runtime Surface
+
+Internal runtime entrypoint: `runtime/internal.ts`.
+
+## Internal-only Modules
+- `runtime/governance`
+- `runtime/distributed`
+- `runtime/capabilities`
+- `runtime/attestations`
+- `runtime/execution-fabric`
+
+These modules are for platform composition and should not be treated as stable SDK contracts.

--- a/PACKAGE_SURFACE_GOVERNANCE.md
+++ b/PACKAGE_SURFACE_GOVERNANCE.md
@@ -1,0 +1,27 @@
+# Package Surface Governance
+
+## Objective
+Formalize export governance so only intended runtime surfaces are visible to SDK/public consumers.
+
+## Entrypoint Classes
+- **Stable public:** `./runtime` (`runtime/index.ts`)
+- **Internal-only:** `./runtime/internal` (`runtime/internal.ts`)
+- **Experimental:** `./runtime/experimental` (`runtime/experimental.ts`)
+- **Compatibility-only:** legacy root `index.ts` remains, but runtime-internal modules are no longer re-exported through `runtime/index.ts`.
+
+## Package Export Map Governance
+`package.json` now declares explicit `exports` keys for:
+- `.`
+- `./runtime`
+- `./runtime/internal`
+- `./runtime/experimental`
+
+No additional subpath exports should be added without governance review.
+
+## Guardrails
+- Automated check: `npm run check:runtime-exports`
+- Rule: stable `runtime/index.ts` must not re-export internal/experimental modules.
+- Rule: `package.json` must preserve required runtime export keys.
+
+## Change Control
+Any new runtime module must be classified as stable/internal/experimental before export.

--- a/PUBLIC_RUNTIME_SURFACE.md
+++ b/PUBLIC_RUNTIME_SURFACE.md
@@ -1,0 +1,16 @@
+# Public Runtime Surface
+
+Stable public runtime entrypoint: `runtime/index.ts`.
+
+## Stable Exports
+- Runtime server/client bootstrap and SDK-facing client types.
+- Auth/rate limiting/logging/trust services.
+- Identity normalization/types.
+- Usage and monetization stable service/types.
+- Audit service/types.
+- Enforcement API.
+
+## Stability Contract
+- Public runtime exports are semver-governed.
+- No wildcard re-exports of internal control-plane/distributed/governance domains.
+- Experimental and internal modules are isolated into dedicated entrypoints.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "check:contract-drift": "node scripts/check-contract-drift.mjs",
     "validate:publishability": "node scripts/validate-publishability.mjs",
     "lint:semantic-ownership": "node scripts/lint-semantic-ownership.mjs",
-    "validate:release": "npm run typecheck && npm run build && npm run lint && npm test && npm run lint:semantic-ownership && npm run check:version-graph && npm run validate:publishability && npm pack ./packages/protocol"
+    "validate:release": "npm run typecheck && npm run build && npm run lint && npm test && npm run lint:semantic-ownership && npm run check:version-graph && npm run validate:publishability && npm pack ./packages/protocol",
+    "check:runtime-exports": "node scripts/check-runtime-export-governance.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.28.1",
@@ -34,5 +35,26 @@
   "packageManager": "npm@11.4.2",
   "engines": {
     "node": ">=20"
+  },
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./runtime": {
+      "types": "./runtime/index.d.ts",
+      "default": "./runtime/index.js"
+    },
+    "./runtime/internal": {
+      "types": "./runtime/internal.d.ts",
+      "default": "./runtime/internal.js"
+    },
+    "./runtime/experimental": {
+      "types": "./runtime/experimental.d.ts",
+      "default": "./runtime/experimental.js"
+    },
+    "./package.json": "./package.json"
   }
 }

--- a/runtime/experimental.ts
+++ b/runtime/experimental.ts
@@ -1,0 +1,9 @@
+/**
+ * Experimental Runtime Surface
+ *
+ * Experimental modules may change without semver guarantees and are isolated
+ * from the stable public runtime entrypoint.
+ */
+
+export * from './sovereign-runtime';
+export * from './marketplace';

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Public Runtime Surface (stable)
+ *
+ * This module is the stable entrypoint intended for SDK/application consumers.
+ * Internal and experimental runtime modules are intentionally excluded and are
+ * available only through dedicated entrypoints.
+ */
+
 export { createRuntimeServer } from './api/server';
 export { HostedRuntimeClient } from './sdk/client';
 export type { HostedRuntimeSdk, HostedRuntimeClientOptions, PayoutCallbackResult } from './sdk/client';
@@ -5,6 +13,7 @@ export { InMemoryApiKeyStore, DEFAULT_API_KEYS } from './auth/apiKeys';
 export { InMemoryRateLimiter } from './limits/rateLimiter';
 export { RuntimeLogger } from './logging/logger';
 export { InMemoryTrustService, DEFAULT_TRUST_ISSUERS } from './trust/service';
+
 export type {
   AocIdentityConsentRecord,
   AocIdentityCredentialRecord,
@@ -13,16 +22,18 @@ export type {
   RlusdWithdrawalRequest,
   TrustAuditEvent,
 } from './trust/types';
+
 export type { ApiRequest, ApiResponse, ErrorResponse, RuntimeEndpoint } from './types/api-types';
 export type { PrincipalId, TenantId, ActorKind, RuntimeIdentity, CanonicalPrincipalContext, LegacyPrincipalAliases } from './identity';
 export { normalizePrincipalContext } from './identity';
 
 export type { PayoutCallbackInput, PayoutExecuteResult, PayoutAuditEvent } from './payout/types';
-
 export type { DataAccessAuditEvent, DataAccessDecision, DataAccessRequestInput, AccessTokenRecord } from './access/types';
 export type { GetUsageSummaryInput, ListAuditEventsInput } from './sdk/client';
+
 export { InMemoryUsageService, UNIT_PRICES } from './usage';
 export { InMemoryMonetizationService, InMemoryPricingRegistry } from './monetization';
+
 export type {
   PricingRule,
   BillableEvent,
@@ -41,17 +52,4 @@ export type {
 } from './usage';
 
 export * from './audit';
-// Internal control-plane API: intentionally not exported from public runtime surface.
-export * from './governance';
-
-export * from './distributed';
-
-export * from './capabilities';
-
-export * from './attestations';
-export * from './execution-fabric';
-
-export * from './sovereign-runtime';
-// Compatibility note: runtime negotiation module is not yet stabilized for npm export.
-// Compatibility note: governance treaties module pending extraction; keep internal-only for now.
-export * from './marketplace';
+export * from './enforcement';

--- a/runtime/internal.ts
+++ b/runtime/internal.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal Runtime Surface
+ *
+ * These exports are for internal platform/runtime composition only.
+ * They are not part of the semver-stable SDK contract.
+ */
+
+export * from './governance';
+export * from './distributed';
+export * from './capabilities';
+export * from './attestations';
+export * from './execution-fabric';

--- a/scripts/check-runtime-export-governance.mjs
+++ b/scripts/check-runtime-export-governance.mjs
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+
+const runtimeIndex = fs.readFileSync(new URL('../runtime/index.ts', import.meta.url), 'utf8');
+const disallowedPublicExports = [
+  "export * from './governance'",
+  "export * from './distributed'",
+  "export * from './capabilities'",
+  "export * from './attestations'",
+  "export * from './execution-fabric'",
+  "export * from './sovereign-runtime'",
+  "export * from './marketplace'",
+];
+
+const violations = disallowedPublicExports.filter((entry) => runtimeIndex.includes(entry));
+
+const packageJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const requiredExports = ['.', './runtime', './runtime/internal', './runtime/experimental'];
+const missingExports = requiredExports.filter((key) => !packageJson.exports || !(key in packageJson.exports));
+
+if (violations.length || missingExports.length) {
+  console.error('Runtime export governance violations detected.');
+  if (violations.length) {
+    console.error('Disallowed exports present in runtime/index.ts:');
+    for (const violation of violations) console.error(` - ${violation}`);
+  }
+  if (missingExports.length) {
+    console.error('Missing package.json exports keys:');
+    for (const key of missingExports) console.error(` - ${key}`);
+  }
+  process.exit(1);
+}
+
+console.log('Runtime export governance checks passed.');


### PR DESCRIPTION
### Motivation
- Prevent accidental public API exposure by making the runtime surface explicit and minimizing transitive wildcard re-exports. 
- Isolate internal platform composition modules and experimental surfaces so SDK consumers only see semver-stable APIs. 
- Provide automated guardrails and documentation to enable future safe extraction/publishing without performing a repo split now. 

### Description
- Narrowed the stable public runtime entrypoint by updating `runtime/index.ts` to only export SDK-safe runtime primitives such as server/client bootstrap, auth/rate-limiting/logging/trust, identity normalization/types, usage/monetization, audit, and enforcement. 
- Introduced explicit entrypoints `runtime/internal.ts` for internal-only modules (governance, distributed, capabilities, attestations, execution-fabric) and `runtime/experimental.ts` for unstable modules (sovereign-runtime, marketplace). 
- Added package export map entries in `package.json` for `.`, `./runtime`, `./runtime/internal`, and `./runtime/experimental` to control subpath visibility. 
- Added an automated governance check script `scripts/check-runtime-export-governance.mjs` and an npm script `check:runtime-exports` to detect disallowed leaks and missing export-map keys. 
- Added governance documentation files: `PACKAGE_SURFACE_GOVERNANCE.md`, `PUBLIC_RUNTIME_SURFACE.md`, `INTERNAL_RUNTIME_SURFACE.md`, `EXPERIMENTAL_RUNTIME_MODULES.md`, and `FUTURE_PACKAGE_EXTRACTION_MAP.md` describing classification, guardrails, and candidate extraction boundaries. 

### Testing
- Ran `npm run check:runtime-exports` and the governance check passed. 
- Ran `npm run typecheck` and `npm run build` and both succeeded. 
- Attempted `npm test -- --runInBand` but tests could not run due to the `jest` binary not being available in the execution environment. 
- Attempted `npm ci` but it failed in this environment due to registry access (`403 Forbidden`), so dependency installation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fa50abd48325961ae8c7b944477d)