### PR TITLE
Establish vendor-neutral runtime observability governance foundation

### DIFF
--- a/AUDIT_VS_TELEMETRY_BOUNDARY.md
+++ b/AUDIT_VS_TELEMETRY_BOUNDARY.md
@@ -1,0 +1,13 @@
+# Audit vs Telemetry Boundary
+
+## Audit
+Business/security evidence: consent decisions, capability grants/revocations, payout decisions, governance actions.
+
+## Telemetry
+Operational behavior: runtime health, request lifecycle, response emission, latency/availability, metering success/failure.
+
+## Usage/Metering
+Consumption and billability events belong in usage/metering systems and may emit summarized telemetry for operations.
+
+## Must never log
+Raw payloads, access tokens, API keys, secrets, private keys, credentials, or stack traces containing sensitive internals.

--- a/OBSERVABILITY_ADAPTER_GUIDANCE.md
+++ b/OBSERVABILITY_ADAPTER_GUIDANCE.md
@@ -1,0 +1,10 @@
+# Observability Adapter Guidance
+
+Current runtime contracts are vendor-neutral (`TelemetrySink`, `RuntimeMetricsSink`, `RuntimeHealthReporter`, `TraceContextProvider`).
+
+Future adapters can map these contracts to OpenTelemetry, Datadog, SIEM, or enterprise observability systems without runtime semantic drift.
+
+Rules:
+- Preserve taxonomy and severity mapping.
+- Apply redaction before export.
+- Avoid transforming audit records into telemetry events.

--- a/OBSERVABILITY_ARCHITECTURE.md
+++ b/OBSERVABILITY_ARCHITECTURE.md
@@ -1,0 +1,11 @@
+# Observability Architecture
+
+This runtime now separates operational telemetry from business audit. Telemetry events are emitted through `TelemetrySink`, metrics through `RuntimeMetricsSink`, and health through `RuntimeHealthReporter`.
+
+## Core model
+- Canonical primitives live in `runtime/observability.ts`.
+- Runtime request lifecycle emits compact event taxonomy.
+- `/runtime/health` exposes posture without secrets.
+
+## Sensitive-data guardrails
+Forbidden telemetry fields include secrets, tokens, API keys, passwords, raw payloads, and private keys.

--- a/OPERATIONAL_METRICS_GOVERNANCE.md
+++ b/OPERATIONAL_METRICS_GOVERNANCE.md
@@ -1,0 +1,11 @@
+# Operational Metrics Governance
+
+## Canonical runtime metrics
+- `runtime.metering.success`
+- `runtime.metering.failure`
+
+## Governance rules
+- Metrics represent operational posture, not domain truth.
+- Emit bounded-cardinality tags only (e.g., endpoint, status).
+- Never include identifiers that are secrets or personal payload bodies.
+- Keep metric families stable across versions unless versioned explicitly.

--- a/RUNTIME_HEALTH_MODEL.md
+++ b/RUNTIME_HEALTH_MODEL.md
@@ -1,0 +1,14 @@
+# Runtime Health Model
+
+`RuntimeHealthSnapshot` contains:
+- status: healthy|degraded|unhealthy|unknown
+- startupPosture
+- environment classification
+- transport/contracts/sdk compatibility versions
+- storage mode
+- enforcement mode
+- warning count
+- degraded and strict flags
+- generated timestamp
+
+Endpoint: `GET /runtime/health` returns an envelope-compatible snapshot and correlation metadata.

--- a/TELEMETRY_EVENT_TAXONOMY.md
+++ b/TELEMETRY_EVENT_TAXONOMY.md
@@ -1,0 +1,18 @@
+# Telemetry Event Taxonomy
+
+## Event types
+- `startup.completed`
+- `request.received`
+- `request.auth.allowed|denied`
+- `request.payload_validation.failed`
+- `request.capability.denied`
+- `request.route.allowed|denied`
+- `transport.response.emitted`
+- `metering.recorded|failed`
+- `compatibility.warning|failure`
+
+## Categories
+startup, request, transport, auth, capability, consent, audit, usage, metering, compatibility, storage, sdk, system.
+
+## Severity
+debug, info, warn, error, critical.

--- a/TRACE_CONTEXT_MODEL.md
+++ b/TRACE_CONTEXT_MODEL.md
@@ -1,0 +1,12 @@
+# Trace Context Model
+
+`RuntimeTraceContext` fields:
+- requestId
+- correlationId
+- traceId
+- endpoint
+- runtimeVersion
+- transportVersion
+- timestamp
+
+Request lifecycle telemetry uses this trace context for all runtime operational events.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "check:sdk-exports": "node scripts/check-sdk-exports.mjs",
     "check:sdk-examples": "node scripts/check-sdk-examples-compile.mjs",
     "check:persistence-boundaries": "node scripts/check-runtime-boundaries.mjs",
-    "check:release-governance": "node scripts/check-release-governance.mjs"
+    "check:release-governance": "node scripts/check-release-governance.mjs",
+    "check:observability-governance": "node scripts/check-observability-governance.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/runtime/api/server.ts
+++ b/runtime/api/server.ts
@@ -3,6 +3,7 @@ import { URL } from 'url';
 import { DEFAULT_API_KEYS, InMemoryApiKeyStore } from '../auth/apiKeys';
 import { InMemoryRateLimiter } from '../limits/rateLimiter';
 import { RuntimeLogger } from '../logging/logger';
+import { DefaultRuntimeHealthReporter, DefaultTraceContextProvider, NoopRuntimeMetricsSink, NoopTelemetrySink, type RuntimeMetricsSink, type RuntimeHealthReporter, type TelemetrySink, type TraceContextProvider } from '../observability';
 import type { ApiResponse, RuntimeEndpoint } from '../types/api-types';
 import { RUNTIME_HANDSHAKE_PATH, buildMetadata, toErrorEnvelope, type RuntimeResponseEnvelope, type RuntimeHandshakeEnvelope } from '../types/transport';
 import { CONTRACTS_VERSION, MINIMUM_SUPPORTED_TRANSPORT_VERSION, PLATFORM_VERSION, RUNTIME_TRANSPORT_VERSION, SDK_COMPATIBILITY_VERSION } from '../versioning';
@@ -27,6 +28,7 @@ const POST_ENDPOINTS: RuntimeEndpoint[] = [
 ];
 
 const GET_ENDPOINTS: RuntimeEndpoint[] = ['/access/requests', '/access/grants/active', '/audit/events', '/usage/summary'];
+const RUNTIME_HEALTH_PATH = '/runtime/health' as const;
 
 export type RuntimeServerDeps = {
   apiKeyStore?: InMemoryApiKeyStore;
@@ -35,6 +37,10 @@ export type RuntimeServerDeps = {
   core?: RuntimeCore;
   capabilitySecret?: string;
   enforcementMode?: EnforcementMode;
+  telemetrySink?: TelemetrySink;
+  metricsSink?: RuntimeMetricsSink;
+  healthReporter?: RuntimeHealthReporter;
+  traceContextProvider?: TraceContextProvider;
 };
 
 function sendJson(response: ServerResponse, statusCode: number, body: RuntimeResponseEnvelope<unknown>): void {
@@ -78,6 +84,10 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
   const core = deps.core ?? DEFAULT_RUNTIME_CORE;
   const capabilitySecret = deps.capabilitySecret ?? process.env.AOC_CAPABILITY_SECRET ?? 'aoc_runtime_capability_secret';
   const enforcementMode = deps.enforcementMode ?? (process.env.ENFORCEMENT_MODE === 'strict' ? 'strict' : 'soft');
+  const telemetrySink = deps.telemetrySink ?? new NoopTelemetrySink();
+  const metricsSink = deps.metricsSink ?? new NoopRuntimeMetricsSink();
+  const traceContextProvider = deps.traceContextProvider ?? new DefaultTraceContextProvider();
+  const healthReporter = deps.healthReporter ?? new DefaultRuntimeHealthReporter(enforcementMode);
 
   return createServer(async (request, response) => {
     if (request.url === undefined) {
@@ -104,6 +114,13 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
       return sendJson(response, 200, envelope);
     }
 
+    if (method === 'GET' && pathname === RUNTIME_HEALTH_PATH) {
+      const requestId = 'runtime_health';
+      const correlationId = typeof request.headers['x-correlation-id'] === 'string' ? request.headers['x-correlation-id'] : requestId;
+      const health = healthReporter.snapshot();
+      return sendJson(response, 200, asEnvelope(requestId, correlationId, 'remote', RUNTIME_HEALTH_PATH, { success: true, data: health }));
+    }
+
     const isPost = method === 'POST' && POST_ENDPOINTS.includes(pathname);
     const isGet = method === 'GET' && GET_ENDPOINTS.includes(pathname);
     if (!isPost && !isGet) {
@@ -122,6 +139,9 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
     }
 
     const { requestId } = authResult.data;
+    const correlationId = typeof request.headers['x-correlation-id'] === 'string' ? request.headers['x-correlation-id'] : requestId;
+    const trace = traceContextProvider.create({ requestId, correlationId, endpoint: pathname });
+    telemetrySink.emit({ eventType: 'request.received', category: 'request', severity: 'info', message: 'Runtime request received.', trace, metadata: { method, endpoint: pathname } });
 
     let payload: unknown;
     if (method === 'GET') {
@@ -131,6 +151,7 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
         payload = await parseJson(request);
       } catch (error) {
         logger.log({ requestId, endpoint: pathname, decision: 'deny', reason_code: 'REQUEST_PARSE_ERROR' });
+        telemetrySink.emit({ eventType: 'request.payload_validation.failed', category: 'request', severity: 'warn', message: 'Request payload parsing failed.', trace, metadata: { endpoint: pathname } });
         return sendJson(response, 400, asEnvelope(requestId, requestId, 'remote', pathname, { success: false, error: { code: 'REQUEST_PARSE_ERROR', message: error instanceof Error ? error.message : 'Invalid JSON payload.' } }));
       }
     }
@@ -167,7 +188,8 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
             decision: 'deny',
             reason_code: capabilityResult.authorization?.reason_code ?? capabilityResult.reason_code,
           });
-          return sendJson(response, 403, asEnvelope(requestId, requestId, 'remote', pathname, { success: false, error: { code: 'CAPABILITY_ACCESS_DENIED', message: `Capability enforcement denied access (${capabilityResult.reason_code}).` } }));
+          telemetrySink.emit({ eventType: 'request.capability.denied', category: 'capability', severity: 'warn', message: 'Capability access denied.', trace, metadata: { reason_code: capabilityResult.reason_code } });
+          return sendJson(response, 403, asEnvelope(requestId, correlationId, 'remote', pathname, { success: false, error: { code: 'CAPABILITY_ACCESS_DENIED', message: `Capability enforcement denied access (${capabilityResult.reason_code}).` } }));
         }
       }
     }
@@ -180,7 +202,8 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
         decision: 'deny',
         reason_code: routeResult.error?.code ?? 'PROTOCOL_ERROR',
       });
-      return sendJson(response, 400, asEnvelope(requestId, requestId, 'remote', pathname, routeResult));
+      telemetrySink.emit({ eventType: 'request.route.denied', category: 'request', severity: 'warn', message: 'Route execution denied or failed validation.', trace, metadata: { code: routeResult.error?.code ?? 'PROTOCOL_ERROR' } });
+      return sendJson(response, 400, asEnvelope(requestId, correlationId, 'remote', pathname, routeResult));
     }
 
     const decisionInfo = deriveDecision(pathname, routeResult.data);
@@ -190,6 +213,8 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
       decision: decisionInfo.decision,
       reason_code: decisionInfo.reasonCode,
     });
+
+    telemetrySink.emit({ eventType: 'request.route.allowed', category: 'request', severity: 'info', message: 'Route execution succeeded.', trace, metadata: { decision: decisionInfo.decision, reason_code: decisionInfo.reasonCode } });
 
     if (isMeteredEndpoint(pathname)) {
       const consumerId = maybeResolveUsageConsumerId(pathname, payload);
@@ -213,6 +238,10 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
               occurred_at: occurredAt,
             });
           })
+          .then(() => {
+            telemetrySink.emit({ eventType: 'metering.recorded', category: 'metering', severity: 'info', message: 'Usage metering recorded.', trace, metadata: { endpoint: pathname } });
+            metricsSink.emitMetric({ metric: 'runtime.metering.success', value: 1, unit: 'count', category: 'metering', trace, tags: { endpoint: pathname } });
+          })
           .catch(() => {
             logger.log({
               requestId,
@@ -220,10 +249,13 @@ export function createRuntimeServer(deps: RuntimeServerDeps = {}) {
               decision: 'deny',
               reason_code: 'USAGE_METERING_ERROR',
             });
+            telemetrySink.emit({ eventType: 'metering.failed', category: 'metering', severity: 'error', message: 'Usage metering failed.', trace, metadata: { endpoint: pathname } });
+            metricsSink.emitMetric({ metric: 'runtime.metering.failure', value: 1, unit: 'count', category: 'metering', trace, tags: { endpoint: pathname } });
           });
       }
     }
 
-    return sendJson(response, 200, asEnvelope(requestId, requestId, 'remote', pathname, routeResult));
+    telemetrySink.emit({ eventType: 'transport.response.emitted', category: 'transport', severity: 'info', message: 'Response envelope emitted.', trace, metadata: { statusCode: 200 } });
+    return sendJson(response, 200, asEnvelope(requestId, correlationId, 'remote', pathname, routeResult));
   });
 }

--- a/runtime/index.ts
+++ b/runtime/index.ts
@@ -56,3 +56,5 @@ export * from './enforcement';
 
 export { RUNTIME_TRANSPORT_VERSION, RUNTIME_HANDSHAKE_PATH, buildMetadata, toErrorEnvelope } from './types/transport';
 export type { RuntimeTransportMetadata, RuntimeRequestEnvelope, RuntimeResponseEnvelope, RuntimeErrorEnvelope, RuntimeHandshakeEnvelope, RuntimeErrorCode } from './types/transport';
+
+export * from './observability';

--- a/runtime/observability.ts
+++ b/runtime/observability.ts
@@ -1,0 +1,141 @@
+import type { RuntimeEndpoint } from './types/api-types';
+import { CONTRACTS_VERSION, PLATFORM_VERSION, RUNTIME_TRANSPORT_VERSION, SDK_COMPATIBILITY_VERSION } from './versioning';
+
+export type RuntimeTelemetrySeverity = 'debug' | 'info' | 'warn' | 'error' | 'critical';
+export type RuntimeTelemetryCategory =
+  | 'startup'
+  | 'request'
+  | 'transport'
+  | 'auth'
+  | 'capability'
+  | 'consent'
+  | 'audit'
+  | 'usage'
+  | 'metering'
+  | 'compatibility'
+  | 'storage'
+  | 'sdk'
+  | 'system';
+
+export type RuntimeTelemetryEventType =
+  | 'startup.completed'
+  | 'request.received'
+  | 'request.auth.allowed'
+  | 'request.auth.denied'
+  | 'request.payload_validation.failed'
+  | 'request.capability.denied'
+  | 'request.route.allowed'
+  | 'request.route.denied'
+  | 'transport.response.emitted'
+  | 'metering.recorded'
+  | 'metering.failed'
+  | 'compatibility.warning'
+  | 'compatibility.failure';
+
+export type RuntimeTelemetryMetadata = Record<string, string | number | boolean | null | undefined>;
+
+export type RuntimeTraceContext = {
+  requestId: string;
+  correlationId: string;
+  traceId: string;
+  endpoint: RuntimeEndpoint | '/runtime/handshake' | '/runtime/health' | 'unknown';
+  runtimeVersion: string;
+  transportVersion: string;
+  timestamp: string;
+};
+
+export type RuntimeTelemetryEvent = {
+  eventType: RuntimeTelemetryEventType;
+  category: RuntimeTelemetryCategory;
+  severity: RuntimeTelemetrySeverity;
+  message: string;
+  trace: RuntimeTraceContext;
+  metadata?: RuntimeTelemetryMetadata;
+};
+
+export type RuntimeMetricEvent = {
+  metric: string;
+  value: number;
+  unit: 'count' | 'ms';
+  category: RuntimeTelemetryCategory;
+  trace?: RuntimeTraceContext;
+  tags?: Record<string, string>;
+};
+
+export type RuntimeHealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+export type RuntimeHealthSnapshot = {
+  status: RuntimeHealthStatus;
+  startupPosture: 'ready' | 'degraded' | 'failed';
+  environment: 'development' | 'test' | 'production' | 'unknown';
+  transportVersion: string;
+  contractsVersion: string;
+  sdkCompatibilityVersion: string;
+  storageMode: 'memory' | 'external' | 'unknown';
+  enforcementMode: 'soft' | 'strict';
+  warningCount: number;
+  degraded: boolean;
+  strictMode: boolean;
+  generatedAt: string;
+};
+
+export interface TelemetrySink { emit(event: RuntimeTelemetryEvent): void; }
+export interface RuntimeMetricsSink { emitMetric(event: RuntimeMetricEvent): void; }
+export interface RuntimeHealthReporter { snapshot(): RuntimeHealthSnapshot; }
+export interface TraceContextProvider {
+  create(input: { requestId: string; correlationId?: string; endpoint: RuntimeTraceContext['endpoint'] }): RuntimeTraceContext;
+}
+
+export class NoopTelemetrySink implements TelemetrySink { emit(): void {} }
+export class NoopRuntimeMetricsSink implements RuntimeMetricsSink { emitMetric(): void {} }
+
+export class InMemoryTelemetrySink implements TelemetrySink {
+  readonly events: RuntimeTelemetryEvent[] = [];
+  emit(event: RuntimeTelemetryEvent): void { this.events.push(event); }
+}
+
+export class InMemoryRuntimeMetricsSink implements RuntimeMetricsSink {
+  readonly events: RuntimeMetricEvent[] = [];
+  emitMetric(event: RuntimeMetricEvent): void { this.events.push(event); }
+}
+
+export class DefaultTraceContextProvider implements TraceContextProvider {
+  create(input: { requestId: string; correlationId?: string; endpoint: RuntimeTraceContext['endpoint'] }): RuntimeTraceContext {
+    const correlationId = input.correlationId && input.correlationId.trim() !== '' ? input.correlationId : input.requestId;
+    return {
+      requestId: input.requestId,
+      correlationId,
+      traceId: `${input.requestId}:${Date.now()}`,
+      endpoint: input.endpoint,
+      runtimeVersion: PLATFORM_VERSION,
+      transportVersion: RUNTIME_TRANSPORT_VERSION,
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
+
+export class DefaultRuntimeHealthReporter implements RuntimeHealthReporter {
+  constructor(private readonly enforcementMode: 'soft' | 'strict', private readonly warningCount = 0) {}
+  snapshot(): RuntimeHealthSnapshot {
+    const env = process.env.NODE_ENV;
+    const environment = env === 'development' || env === 'test' || env === 'production' ? env : 'unknown';
+    const status: RuntimeHealthStatus = this.warningCount > 0 ? 'degraded' : 'healthy';
+    return {
+      status,
+      startupPosture: status === 'healthy' ? 'ready' : 'degraded',
+      environment,
+      transportVersion: RUNTIME_TRANSPORT_VERSION,
+      contractsVersion: CONTRACTS_VERSION,
+      sdkCompatibilityVersion: SDK_COMPATIBILITY_VERSION,
+      storageMode: 'memory',
+      enforcementMode: this.enforcementMode,
+      warningCount: this.warningCount,
+      degraded: status !== 'healthy',
+      strictMode: this.enforcementMode === 'strict',
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}
+
+export const FORBIDDEN_TELEMETRY_FIELDS = [
+  'apiKey', 'authorization', 'token', 'secret', 'capabilityToken', 'privateKey', 'seedPhrase', 'password', 'rawPayload'
+] as const;

--- a/scripts/check-observability-governance.mjs
+++ b/scripts/check-observability-governance.mjs
@@ -1,0 +1,50 @@
+import fs from 'fs';
+
+const docs = [
+  'OBSERVABILITY_ARCHITECTURE.md',
+  'TELEMETRY_EVENT_TAXONOMY.md',
+  'AUDIT_VS_TELEMETRY_BOUNDARY.md',
+  'RUNTIME_HEALTH_MODEL.md',
+  'TRACE_CONTEXT_MODEL.md',
+  'OBSERVABILITY_ADAPTER_GUIDANCE.md',
+  'OPERATIONAL_METRICS_GOVERNANCE.md'
+];
+
+const requiredTelemetryTypes = [
+  'RuntimeTelemetryEvent',
+  'RuntimeTelemetryEventType',
+  'RuntimeTelemetrySeverity',
+  'RuntimeTelemetryCategory',
+  'RuntimeMetricEvent',
+  'RuntimeHealthSnapshot',
+  'RuntimeTraceContext',
+  'TelemetrySink',
+  'RuntimeMetricsSink'
+];
+
+let failed = false;
+for (const doc of docs) {
+  if (!fs.existsSync(doc)) {
+    console.error(`Missing observability governance doc: ${doc}`);
+    failed = true;
+  }
+}
+
+const source = fs.readFileSync('runtime/observability.ts', 'utf8');
+for (const symbol of requiredTelemetryTypes) {
+  if (!source.includes(symbol)) {
+    console.error(`Missing observability symbol: ${symbol}`);
+    failed = true;
+  }
+}
+
+const forbiddenFields = ['apiKey', 'token', 'secret', 'privateKey', 'password'];
+for (const field of forbiddenFields) {
+  if (!source.includes(field)) {
+    console.error(`Forbidden telemetry field policy missing entry: ${field}`);
+    failed = true;
+  }
+}
+
+if (failed) process.exit(1);
+console.log('Observability governance checks passed.');


### PR DESCRIPTION
### Motivation
- Provide a canonical, vendor-neutral observability foundation so runtime operational behavior is observable without mixing business audit evidence. 
- Define compact telemetry primitives, trace context, and a lightweight health posture model to enable consistent runtime visibility and future adapterization. 
- Enforce redaction-safe telemetry semantics and a clear audit vs telemetry boundary to avoid leaking sensitive data. 
- Deliver governance docs and a validation hook so observability requirements are verifiable in CI before adding adapters.

### Description
- Added a canonical telemetry model and contracts in `runtime/observability.ts` including `RuntimeTelemetryEvent`, `RuntimeTelemetryEventType`, `RuntimeTelemetrySeverity`, `RuntimeTelemetryCategory`, `RuntimeTelemetryMetadata`, `RuntimeMetricEvent`, `RuntimeHealthSnapshot`, `RuntimeTraceContext`, `TelemetrySink`, `RuntimeMetricsSink`, `RuntimeHealthReporter`, and `TraceContextProvider`, plus noop and in-memory implementations and a `FORBIDDEN_TELEMETRY_FIELDS` policy constant. 
- Integrated vendor-neutral observability into request lifecycle in `runtime/api/server.ts` by wiring `telemetrySink`, `metricsSink`, and `traceContextProvider`, emitting telemetry for `request.received`, `request.payload_validation.failed`, `request.capability.denied`, `request.route.allowed|denied`, `transport.response.emitted`, and metering `metering.recorded|failed`, and adding a correlation-aware `GET /runtime/health` endpoint that returns an envelope-compatible `RuntimeHealthSnapshot`. 
- Exported observability contracts on the stable runtime surface via `runtime/index.ts` and added a governance validation script `scripts/check-observability-governance.mjs` with a `check:observability-governance` npm script. 
- Added governance documentation files: `OBSERVABILITY_ARCHITECTURE.md`, `TELEMETRY_EVENT_TAXONOMY.md`, `AUDIT_VS_TELEMETRY_BOUNDARY.md`, `RUNTIME_HEALTH_MODEL.md`, `TRACE_CONTEXT_MODEL.md`, `OBSERVABILITY_ADAPTER_GUIDANCE.md`, and `OPERATIONAL_METRICS_GOVERNANCE.md`. 
- Preserved constraints: no vendor-specific telemetry dependencies were added and telemetry remains separated from business audit pathways.

### Testing
- Ran `npm run check:observability-governance` which succeeded and verified presence of docs and required observability symbols. 
- Ran the repository build/typecheck sweep (`npm run build` / `npm run typecheck`) which failed due to pre-existing TypeScript deprecation/configuration issues in multiple workspace `tsconfig.json` files (errors about `baseUrl` and `moduleResolution=node10`), which are unrelated to the observability changes. 
- All other repository validation checks were left intact and the new observability check was added to `package.json` as `check:observability-governance`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08921036148325bb33b822b7865dbf)