### PR TITLE
Establish canonical policy semantics and deterministic evaluation foundations

### DIFF
--- a/docs/governance/POLICY_ADAPTER_GUIDANCE.md
+++ b/docs/governance/POLICY_ADAPTER_GUIDANCE.md
@@ -1,0 +1,4 @@
+# Policy Adapter Guidance
+Adapters (future OPA/Cedar/custom engines) must map into canonical primitives and produce canonical decisions/traces. They must preserve deny precedence, fail-closed semantics for protected operations, and trace visibility redaction tiers.
+
+Example future enterprise adapter: external PDP returns permit/deny -> mapped to allow/deny + canonical reason code taxonomy and trace summary.

--- a/docs/governance/POLICY_CONFLICT_RESOLUTION.md
+++ b/docs/governance/POLICY_CONFLICT_RESOLUTION.md
@@ -1,0 +1,8 @@
+# Policy Conflict Resolution
+- allow + deny = deny.
+- deny + abstain = deny.
+- allow + abstain = allow only if all required categories pass.
+- indeterminate + protected operation = deny.
+- condition evaluation failure = indeterminate.
+
+Example conflicting rules: capability allow plus runtime deny produces denied with conflict `allow_vs_deny`.

--- a/docs/governance/POLICY_ENGINE_ARCHITECTURE.md
+++ b/docs/governance/POLICY_ENGINE_ARCHITECTURE.md
@@ -1,0 +1,2 @@
+# Policy Engine Architecture
+This pass introduces a lightweight, deterministic policy semantics layer that normalizes governance decisions without replacing existing capability/consent/trust engines. It uses internal types (`runtime/policy/types.ts`) and deterministic evaluators (`runtime/policy/evaluation.ts`) with compatibility shims at route decision derivation.

--- a/docs/governance/POLICY_EVALUATION_ORDER.md
+++ b/docs/governance/POLICY_EVALUATION_ORDER.md
@@ -1,0 +1,9 @@
+# Policy Evaluation Order
+1. Sort rules by priority descending then rule id.
+2. Evaluate all conditions deterministically.
+3. Condition failure returns abstain; condition exception returns indeterminate.
+4. Merge effects with deny precedence.
+5. Protected operations fail closed on indeterminate.
+6. Required categories must have allow match; abstain alone never grants.
+7. Aggregate obligations in evaluated rule order.
+8. Build ordered trace.

--- a/docs/governance/POLICY_EVOLUTION_ROADMAP.md
+++ b/docs/governance/POLICY_EVOLUTION_ROADMAP.md
@@ -1,0 +1,6 @@
+# Policy Evolution Roadmap
+Near-term: canonical reason-code registry, category requirement profiles, inheritance semantics.
+Mid-term: adapter interface hardening and policy lifecycle states (draft/active/revoked).
+Long-term: enterprise control-plane integration and explainability dashboard contracts.
+
+Remaining risks: incomplete policy-like logic migration across legacy services/routes and partial reason-code duplication across domains.

--- a/docs/governance/POLICY_EXPLAINABILITY_TRACE.md
+++ b/docs/governance/POLICY_EXPLAINABILITY_TRACE.md
@@ -1,0 +1,12 @@
+# Policy Explainability Trace
+Trace fields: traceId, evaluatedRules, matchedRules, skippedRules, conditionsEvaluated, obligations, conflicts, finalDecision, decisionReason, evaluatedAt.
+
+Visibility levels:
+- internal: full rule ids and conflict details.
+- audit-safe: remove sensitive condition payloads.
+- sdk-safe: summary only (finalDecision/decisionReason/high-level obligations).
+- user-facing: minimal plain-language reason.
+
+Redaction guidance: never include secrets, bearer tokens, raw credential artifacts, or internal evaluator source expressions.
+
+Example trace output: `{ traceId, finalDecision: "denied", decisionReason: "POLICY_DENY_OVERRIDES" }`.

--- a/docs/governance/POLICY_PUBLIC_INTERNAL_BOUNDARIES.md
+++ b/docs/governance/POLICY_PUBLIC_INTERNAL_BOUNDARIES.md
@@ -1,0 +1,7 @@
+# Policy Public/Internal Boundaries
+- Stable public contracts: normalized decision outcome + reason code compatible with existing wire responses.
+- Internal runtime contracts: rule-level evaluators, conflicts, traces.
+- Experimental contracts: future policy adapters and inheritance composition.
+- Future enterprise control-plane contracts: policy publication lifecycle and delegated admin governance.
+
+Current placement: `runtime/policy/*` is internal-only via `runtime/internal` export.

--- a/docs/governance/POLICY_SEMANTICS_MODEL.md
+++ b/docs/governance/POLICY_SEMANTICS_MODEL.md
@@ -1,0 +1,10 @@
+# Policy Semantics Model
+Canonical primitives: PolicyId, PolicyVersion, PolicyScope, PolicySubject, PolicyRequester, PolicyResource, PolicyAction, PolicyEffect (allow|deny|abstain), PolicyCondition, PolicyRule, PolicySet, PolicyDecision, PolicyEvaluationContext, PolicyEvaluationTrace, PolicyObligation, PolicyConflict.
+
+Decision outcomes: allowed, denied, conditional, indeterminate.
+
+Policy categories: consent, capability, trust, identity, tenant, runtime, metering, payout, data-access, agent, governance.
+
+Example allow rule: capability rule with effect=allow and reasonCode=CAPABILITY_VALID.
+Example deny rule: trust rule with effect=deny and reasonCode=TRUST_INVALID.
+Example abstain rule: consent rule with effect=abstain when no condition match.

--- a/package.json
+++ b/package.json
@@ -22,23 +22,8 @@
     "check:runtime-boundaries": "node scripts/check-runtime-boundaries.mjs",
     "check:identity-vocabulary": "node scripts/check-identity-vocabulary.mjs",
     "check:contract-drift": "node scripts/check-contract-drift.mjs",
-    "validate:release": "npm run typecheck && npm run build && npm run lint && npm test && npm run lint:semantic-ownership && npm run check:version-graph && npm run validate:publishability && npm pack ./packages/protocol"
-  },
-  "devDependencies": {
-    "@changesets/cli": "^2.28.1",
-    "check:runtime-boundaries": "node scripts/check-runtime-boundaries.mjs",
-    "check:identity-vocabulary": "node scripts/check-identity-vocabulary.mjs",
-    "check:contract-drift": "node scripts/check-contract-drift.mjs",
-    "validate:publishability": "node scripts/validate-publishability.mjs",
-    "lint:semantic-ownership": "node scripts/lint-semantic-ownership.mjs",
     "validate:release": "npm run typecheck && npm run build && npm run lint && npm test && npm run lint:semantic-ownership && npm run check:version-graph && npm run validate:publishability && npm pack ./packages/protocol",
-    "check:runtime-exports": "node scripts/check-runtime-export-governance.mjs",
-    "check:sdk-boundaries": "node scripts/check-sdk-import-boundary.mjs",
-    "check:sdk-exports": "node scripts/check-sdk-exports.mjs",
-    "check:sdk-examples": "node scripts/check-sdk-examples-compile.mjs",
-    "check:persistence-boundaries": "node scripts/check-runtime-boundaries.mjs",
-    "check:release-governance": "node scripts/check-release-governance.mjs",
-    "check:observability-governance": "node scripts/check-observability-governance.mjs"
+    "check:policy-governance": "node scripts/check-policy-governance.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/runtime/api/routes.ts
+++ b/runtime/api/routes.ts
@@ -21,6 +21,7 @@ import { InMemoryUsageService, isMeteredEndpoint } from '../usage';
 import { InMemoryMonetizationService, InMemoryPricingRegistry, type PricingRule } from '../monetization';
 import type { MeteredRuntimeEndpoint, UsageSummaryResult } from '../usage';
 import { ControlPlaneService, type AccessRequest, type ConsentDecision, type GrantedAccess } from '../controlPlane';
+import { normalizePolicyDecision } from '../policy';
 
 export type RuntimeCore = {
   evaluateEnforcement: typeof evaluateEnforcement;
@@ -127,19 +128,23 @@ function parseOptionalMeteredEndpoint(input: unknown): MeteredRuntimeEndpoint | 
   return input;
 }
 
+function fromBooleanDecision(allowed: boolean, reasonCode: string): { decision: 'allow' | 'deny'; reasonCode: string } {
+  return { decision: normalizePolicyDecision(allowed ? 'allowed' : 'denied'), reasonCode };
+}
+
 export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { decision: 'allow' | 'deny'; reasonCode: string } {
   if (endpoint === '/enforcement/evaluate') {
     const enforcement = data as EnforcementDecision;
-    return { decision: enforcement.allowed ? 'allow' : 'deny', reasonCode: enforcement.reason_code };
+    return fromBooleanDecision(enforcement.allowed, enforcement.reason_code);
   }
 
   if (endpoint === '/execution/authorize') {
     const execution = data as ExecutionAuthorizationResult;
-    return { decision: execution.authorized ? 'allow' : 'deny', reasonCode: execution.reason_code };
+    return fromBooleanDecision(execution.authorized, execution.reason_code);
   }
   if (endpoint === '/trust/verify') {
     const verification = data as IdentityVerificationResult;
-    return { decision: verification.valid ? 'allow' : 'deny', reasonCode: verification.reason_code };
+    return fromBooleanDecision(verification.valid, verification.reason_code);
   }
   if (endpoint === '/trust/credential/register') {
     return { decision: 'allow', reasonCode: 'CREDENTIAL_REGISTERED' };
@@ -149,15 +154,15 @@ export function deriveDecision(endpoint: RuntimeEndpoint, data: unknown): { deci
   }
   if (endpoint === '/payout/execute') {
     const payout = data as { allowed: boolean; reason_code: string };
-    return { decision: payout.allowed ? 'allow' : 'deny', reasonCode: payout.reason_code };
+    return fromBooleanDecision(payout.allowed, payout.reason_code);
   }
   if (endpoint === '/payout/callback') {
     const callback = data as { received: true; reason_code: string };
-    return { decision: callback.received ? 'allow' : 'deny', reasonCode: callback.reason_code };
+    return fromBooleanDecision(callback.received, callback.reason_code);
   }
   if (endpoint === '/data/access') {
     const access = data as { allowed: boolean; reason_code: string };
-    return { decision: access.allowed ? 'allow' : 'deny', reasonCode: access.reason_code };
+    return fromBooleanDecision(access.allowed, access.reason_code);
   }
   if (endpoint === '/capability/mint') {
     return { decision: 'allow', reasonCode: 'CAPABILITY_MINTED' };

--- a/runtime/internal.ts
+++ b/runtime/internal.ts
@@ -10,3 +10,5 @@ export * from './distributed';
 export * from './capabilities';
 export * from './attestations';
 export * from './execution-fabric';
+
+export * from './policy';

--- a/runtime/policy/__tests__/evaluation.test.ts
+++ b/runtime/policy/__tests__/evaluation.test.ts
@@ -1,0 +1,57 @@
+import { evaluatePolicySet } from '../evaluation';
+import type { PolicySet } from '../types';
+
+const baseContext = {
+  subject: { id: 'subj-1' },
+  requester: { id: 'req-1' },
+  resource: { id: 'res-1', kind: 'dataset' },
+  action: { verb: 'read', protectedOperation: true },
+  now: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+describe('policy evaluation semantics', () => {
+  test('deny overrides allow', () => {
+    const set: PolicySet = {
+      id: 'p1', version: '1.0.0', scope: 'operation', categories: ['capability'],
+      rules: [
+        { id: 'allow', category: 'capability', effect: 'allow', reasonCode: 'ALLOW' },
+        { id: 'deny', category: 'capability', effect: 'deny', reasonCode: 'DENY' },
+      ],
+    };
+    const result = evaluatePolicySet(set, baseContext);
+    expect(result.decision.outcome).toBe('denied');
+  });
+
+  test('abstain alone does not allow protected operations', () => {
+    const set: PolicySet = {
+      id: 'p2', version: '1.0.0', scope: 'operation', categories: ['consent'],
+      rules: [{ id: 'abstain', category: 'consent', effect: 'abstain', reasonCode: 'NO_MATCH' }],
+    };
+    const result = evaluatePolicySet(set, baseContext);
+    expect(result.decision.outcome).toBe('indeterminate');
+  });
+
+  test('indeterminate fails closed for protected operation', () => {
+    const set: PolicySet = {
+      id: 'p3', version: '1.0.0', scope: 'operation', categories: ['trust'],
+      rules: [{ id: 'trust', category: 'trust', effect: 'allow', reasonCode: 'TRUST_OK', conditions: [{ id: 'boom', evaluate: () => { throw new Error('x'); } }] }],
+    };
+    const result = evaluatePolicySet(set, baseContext);
+    expect(result.decision.outcome).toBe('denied');
+    expect(result.decision.reasonCode).toBe('POLICY_INDETERMINATE_FAIL_CLOSED');
+  });
+
+  test('obligations aggregate deterministically and conflicts recorded', () => {
+    const set: PolicySet = {
+      id: 'p4', version: '1.0.0', scope: 'operation', categories: ['capability'],
+      rules: [
+        { id: 'a', category: 'capability', effect: 'allow', reasonCode: 'A', obligations: [{ id: 'log', category: 'governance' }] },
+        { id: 'b', category: 'capability', effect: 'deny', reasonCode: 'B', obligations: [{ id: 'notify', category: 'governance' }] },
+      ],
+    };
+    const result = evaluatePolicySet(set, baseContext);
+    expect(result.decision.obligations.map((o) => o.id)).toEqual(['log', 'notify']);
+    expect(result.decision.conflicts[0]?.conflictType).toBe('allow_vs_deny');
+    expect(result.trace.evaluatedRules).toEqual(['a', 'b']);
+  });
+});

--- a/runtime/policy/evaluation.ts
+++ b/runtime/policy/evaluation.ts
@@ -1,0 +1,155 @@
+import type {
+  PolicyConflict,
+  PolicyDecision,
+  PolicyEffect,
+  PolicyEvaluationContext,
+  PolicyEvaluationTrace,
+  PolicyRule,
+  PolicyRuleEvaluation,
+  PolicySet,
+} from './types';
+
+function compareRulePriority(a: PolicyRule, b: PolicyRule): number {
+  return (b.priority ?? 0) - (a.priority ?? 0) || a.id.localeCompare(b.id);
+}
+
+export function evaluatePolicyRule(rule: PolicyRule, context: PolicyEvaluationContext): {
+  evaluation: PolicyRuleEvaluation;
+  conditionResults: Array<{ ruleId: string; conditionId: string; passed: boolean }>;
+  indeterminate: boolean;
+} {
+  const conditions = rule.conditions ?? [];
+  const conditionResults: Array<{ ruleId: string; conditionId: string; passed: boolean }> = [];
+  for (const condition of conditions) {
+    try {
+      const passed = condition.evaluate(context);
+      conditionResults.push({ ruleId: rule.id, conditionId: condition.id, passed });
+      if (!passed) {
+        return {
+          evaluation: { ruleId: rule.id, category: rule.category, effect: 'abstain', matched: false, reasonCode: rule.reasonCode },
+          conditionResults,
+          indeterminate: false,
+        };
+      }
+    } catch {
+      conditionResults.push({ ruleId: rule.id, conditionId: condition.id, passed: false });
+      return {
+        evaluation: { ruleId: rule.id, category: rule.category, effect: 'abstain', matched: false, reasonCode: 'POLICY_CONDITION_EVALUATION_FAILED' },
+        conditionResults,
+        indeterminate: true,
+      };
+    }
+  }
+  return {
+    evaluation: { ruleId: rule.id, category: rule.category, effect: rule.effect, matched: true, reasonCode: rule.reasonCode },
+    conditionResults,
+    indeterminate: false,
+  };
+}
+
+export function classifyPolicyConflict(effects: PolicyEffect[], ruleIds: string[]): PolicyConflict | null {
+  if (effects.includes('allow') && effects.includes('deny')) {
+    return { conflictType: 'allow_vs_deny', ruleIds, reason: 'allow + deny = deny' };
+  }
+  return null;
+}
+
+export function mergePolicyDecisions(input: {
+  protectedOperation: boolean;
+  requiredCategories: string[];
+  evaluations: PolicyRuleEvaluation[];
+  indeterminate: boolean;
+  obligations: PolicyDecision['obligations'];
+  conflicts: PolicyConflict[];
+}): PolicyDecision {
+  const effects = input.evaluations.filter((e) => e.matched).map((e) => e.effect);
+  const denies = effects.includes('deny');
+  const allows = effects.includes('allow');
+
+  const matchedCategories = new Set(input.evaluations.filter((e) => e.matched && e.effect === 'allow').map((e) => e.category));
+  const missingRequiredCategory = input.requiredCategories.find((category) => !matchedCategories.has(category as never));
+
+  if (denies) {
+    return { outcome: 'denied', effect: 'deny', reasonCode: 'POLICY_DENY_OVERRIDES', obligations: input.obligations, conflicts: input.conflicts, evaluatedCategories: [...new Set(input.evaluations.map((e) => e.category))] };
+  }
+  if (input.indeterminate && input.protectedOperation) {
+    return { outcome: 'denied', effect: 'deny', reasonCode: 'POLICY_INDETERMINATE_FAIL_CLOSED', obligations: input.obligations, conflicts: input.conflicts, evaluatedCategories: [...new Set(input.evaluations.map((e) => e.category))] };
+  }
+  if (allows && !missingRequiredCategory) {
+    return { outcome: input.obligations.length > 0 ? 'conditional' : 'allowed', effect: 'allow', reasonCode: input.obligations.length > 0 ? 'POLICY_ALLOWED_WITH_OBLIGATIONS' : 'POLICY_ALLOWED', obligations: input.obligations, conflicts: input.conflicts, evaluatedCategories: [...new Set(input.evaluations.map((e) => e.category))] };
+  }
+  return { outcome: 'indeterminate', effect: 'abstain', reasonCode: missingRequiredCategory ? 'POLICY_REQUIRED_CATEGORY_UNMET' : 'POLICY_ABSTAIN', obligations: input.obligations, conflicts: input.conflicts, evaluatedCategories: [...new Set(input.evaluations.map((e) => e.category))] };
+}
+
+export function buildPolicyTrace(params: {
+  visibility: PolicyEvaluationTrace['visibility'];
+  evaluations: PolicyRuleEvaluation[];
+  skippedRules: string[];
+  conditionResults: PolicyEvaluationTrace['conditionsEvaluated'];
+  decision: PolicyDecision;
+  traceId: string;
+  evaluatedAt?: Date;
+}): PolicyEvaluationTrace {
+  return {
+    traceId: params.traceId,
+    evaluatedRules: params.evaluations.map((e) => e.ruleId),
+    matchedRules: params.evaluations.filter((e) => e.matched).map((e) => e.ruleId),
+    skippedRules: params.skippedRules,
+    conditionsEvaluated: params.conditionResults,
+    obligations: params.decision.obligations.map((o) => o.id),
+    conflicts: params.decision.conflicts,
+    finalDecision: params.decision.outcome,
+    decisionReason: params.decision.reasonCode,
+    evaluatedAt: (params.evaluatedAt ?? new Date()).toISOString(),
+    visibility: params.visibility,
+  };
+}
+
+export function evaluatePolicySet(policySet: PolicySet, context: PolicyEvaluationContext) {
+  const sortedRules = [...policySet.rules].sort(compareRulePriority);
+  const evaluations: PolicyRuleEvaluation[] = [];
+  const conditionResults: PolicyEvaluationTrace['conditionsEvaluated'] = [];
+  let indeterminate = false;
+  for (const rule of sortedRules) {
+    const result = evaluatePolicyRule(rule, context);
+    evaluations.push(result.evaluation);
+    conditionResults.push(...result.conditionResults);
+    indeterminate = indeterminate || result.indeterminate;
+  }
+
+  const conflicts: PolicyConflict[] = [];
+  const conflict = classifyPolicyConflict(evaluations.filter((e) => e.matched).map((e) => e.effect), evaluations.filter((e) => e.matched).map((e) => e.ruleId));
+  if (conflict) {
+    conflicts.push(conflict);
+  }
+
+  const obligations = sortedRules
+    .filter((rule) => evaluations.some((evaluation) => evaluation.ruleId === rule.id && evaluation.matched))
+    .flatMap((rule) => rule.obligations ?? []);
+
+  const decision = mergePolicyDecisions({
+    protectedOperation: context.action.protectedOperation ?? true,
+    requiredCategories: context.requiredCategories ?? policySet.categories,
+    evaluations,
+    indeterminate,
+    obligations,
+    conflicts,
+  });
+
+  return {
+    decision,
+    trace: buildPolicyTrace({
+      visibility: 'internal',
+      evaluations,
+      skippedRules: evaluations.filter((e) => !e.matched).map((e) => e.ruleId),
+      conditionResults,
+      decision,
+      traceId: `${policySet.id}:${context.subject.id}:${context.action.verb}`,
+      evaluatedAt: context.now,
+    }),
+  };
+}
+
+export function normalizePolicyDecision(outcome: PolicyDecision['outcome']): 'allow' | 'deny' {
+  return outcome === 'allowed' || outcome === 'conditional' ? 'allow' : 'deny';
+}

--- a/runtime/policy/index.ts
+++ b/runtime/policy/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './evaluation';

--- a/runtime/policy/types.ts
+++ b/runtime/policy/types.ts
@@ -1,0 +1,102 @@
+export type PolicyId = string;
+export type PolicyVersion = string;
+
+export type PolicyCategory =
+  | 'consent'
+  | 'capability'
+  | 'trust'
+  | 'identity'
+  | 'tenant'
+  | 'runtime'
+  | 'metering'
+  | 'payout'
+  | 'data-access'
+  | 'agent'
+  | 'governance';
+
+export type PolicyScope = 'global' | 'tenant' | 'subject' | 'resource' | 'session' | 'operation';
+export type PolicyEffect = 'allow' | 'deny' | 'abstain';
+export type PolicyOutcome = 'allowed' | 'denied' | 'conditional' | 'indeterminate';
+export type PolicyTraceVisibility = 'internal' | 'audit-safe' | 'sdk-safe' | 'user-facing';
+
+export type PolicySubject = { id: string; tenantId?: string; attributes?: Record<string, unknown> };
+export type PolicyRequester = { id: string; kind?: string; tenantId?: string; attributes?: Record<string, unknown> };
+export type PolicyResource = { id: string; kind: string; tenantId?: string; attributes?: Record<string, unknown> };
+export type PolicyAction = { verb: string; protectedOperation?: boolean };
+
+export type PolicyCondition = {
+  id: string;
+  description?: string;
+  evaluate: (context: PolicyEvaluationContext) => boolean;
+};
+
+export type PolicyObligation = { id: string; category: PolicyCategory; description?: string; payload?: Record<string, unknown> };
+
+export type PolicyRule = {
+  id: string;
+  category: PolicyCategory;
+  effect: PolicyEffect;
+  priority?: number;
+  conditions?: PolicyCondition[];
+  obligations?: PolicyObligation[];
+  reasonCode: string;
+  description?: string;
+};
+
+export type PolicySet = {
+  id: PolicyId;
+  version: PolicyVersion;
+  scope: PolicyScope;
+  categories: PolicyCategory[];
+  rules: PolicyRule[];
+};
+
+export type PolicyConflict = {
+  conflictType: 'allow_vs_deny' | 'indeterminate_condition' | 'required_category_unmet';
+  category?: PolicyCategory;
+  ruleIds: string[];
+  reason: string;
+};
+
+export type PolicyEvaluationContext = {
+  subject: PolicySubject;
+  requester: PolicyRequester;
+  resource: PolicyResource;
+  action: PolicyAction;
+  now: Date;
+  requiresConsent?: boolean;
+  requiresTrust?: boolean;
+  requiredCategories?: PolicyCategory[];
+  attributes?: Record<string, unknown>;
+};
+
+export type PolicyRuleEvaluation = {
+  ruleId: string;
+  category: PolicyCategory;
+  effect: PolicyEffect;
+  matched: boolean;
+  reasonCode: string;
+};
+
+export type PolicyDecision = {
+  outcome: PolicyOutcome;
+  effect: PolicyEffect;
+  reasonCode: string;
+  obligations: PolicyObligation[];
+  conflicts: PolicyConflict[];
+  evaluatedCategories: PolicyCategory[];
+};
+
+export type PolicyEvaluationTrace = {
+  traceId: string;
+  evaluatedRules: string[];
+  matchedRules: string[];
+  skippedRules: string[];
+  conditionsEvaluated: Array<{ ruleId: string; conditionId: string; passed: boolean }>;
+  obligations: string[];
+  conflicts: PolicyConflict[];
+  finalDecision: PolicyOutcome;
+  decisionReason: string;
+  evaluatedAt: string;
+  visibility: PolicyTraceVisibility;
+};

--- a/scripts/check-policy-governance.mjs
+++ b/scripts/check-policy-governance.mjs
@@ -1,0 +1,18 @@
+import { access } from 'node:fs/promises';
+
+const requiredDocs = [
+  'docs/governance/POLICY_ENGINE_ARCHITECTURE.md',
+  'docs/governance/POLICY_SEMANTICS_MODEL.md',
+  'docs/governance/POLICY_EVALUATION_ORDER.md',
+  'docs/governance/POLICY_CONFLICT_RESOLUTION.md',
+  'docs/governance/POLICY_EXPLAINABILITY_TRACE.md',
+  'docs/governance/POLICY_PUBLIC_INTERNAL_BOUNDARIES.md',
+  'docs/governance/POLICY_ADAPTER_GUIDANCE.md',
+  'docs/governance/POLICY_EVOLUTION_ROADMAP.md'
+];
+
+for (const file of requiredDocs) {
+  try { await access(file); } catch { throw new Error(`Missing policy governance doc: ${file}`); }
+}
+
+console.log('Policy governance docs check passed.');


### PR DESCRIPTION
### Motivation
- Runtime decision signals are becoming observable but policy semantics were not canonicalized, risking inconsistent governance and explainability.
- The platform needs a lightweight, vendor-neutral, runtime-safe policy foundation with deterministic evaluation and clear conflict resolution without replacing existing engines.
- Explainability traces and public/internal boundaries are required so audit and SDK consumers can safely consume decision summaries.

### Description
- Add an internal `runtime/policy` module with canonical primitives in `runtime/policy/types.ts` and deterministic evaluators in `runtime/policy/evaluation.ts` including `evaluatePolicyRule`, `evaluatePolicySet`, `mergePolicyDecisions`, `classifyPolicyConflict`, `buildPolicyTrace`, and `normalizePolicyDecision`.
- Wire a low-risk normalization shim into route decision derivation (`runtime/api/routes.ts`) and expose policy internals only via the internal runtime entry (`runtime/internal.ts`) to preserve public SDK boundaries.
- Add governance documentation under `docs/governance/` covering architecture, semantics, evaluation order, conflict resolution, explainability traces, public/internal boundaries, adapter guidance, and a roadmap.
- Add a doc-presence guardrail `scripts/check-policy-governance.mjs`, register `check:policy-governance` in `package.json`, and add deterministic unit tests in `runtime/policy/__tests__/evaluation.test.ts` validating deny-precedence, abstain semantics, indeterminate fail-closed behavior, obligation aggregation, and conflict recording.

### Testing
- Ran `npm run check:policy-governance` which passed and confirmed the governance docs were present.
- Attempted `npm run typecheck` which failed due to pre-existing TypeScript deprecation baseline errors (`baseUrl`/`moduleResolution=node10`) unrelated to these changes.
- Attempted to run the new unit tests via `npm test -- runtime/policy/__tests__/evaluation.test.ts` but tests could not run in this environment because `jest` was not available (`sh: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0897775a6c8325b9b5a4735af7720a)