### PR TITLE
Add sovereign runtime federation model, semantics, docs, tests, and governance check

### DIFF
--- a/FEDERATED_ATTESTATION_MODEL.md
+++ b/FEDERATED_ATTESTATION_MODEL.md
@@ -1,0 +1,5 @@
+# Federated Attestation Model
+
+`RuntimeAttestation` models remote attestation exchange (issuer, subject runtime, checksum, issue time).
+
+Attestation chains are embedded in federated execution lineage to preserve explainability and auditability.

--- a/FEDERATED_CAPABILITY_MODEL.md
+++ b/FEDERATED_CAPABILITY_MODEL.md
@@ -1,0 +1,9 @@
+# Federated Capability Model
+
+`RuntimeFederationCapability` supports:
+- remote delegation,
+- scoped remote execution (`allowedScopes`),
+- attenuated delegation depth,
+- tenant-bound and replay-bound constraints.
+
+`constrainFederatedCapability` enforces trust posture attenuation.

--- a/FEDERATED_COMPATIBILITY_MODEL.md
+++ b/FEDERATED_COMPATIBILITY_MODEL.md
@@ -1,0 +1,8 @@
+# Federated Compatibility Model
+
+`RuntimeFederationVersionAssertion` + `RuntimeFederationCompatibilityMatrix` define runtime protocol and transport compatibility posture.
+
+Compatibility guarantees:
+- incompatible versions fail closed,
+- explicit transport profile requirements,
+- posture mismatches are observable via deny reasons.

--- a/FEDERATED_EXECUTION_LINEAGE.md
+++ b/FEDERATED_EXECUTION_LINEAGE.md
@@ -1,0 +1,5 @@
+# Federated Execution Lineage
+
+`FederatedExecutionReference` + `FederatedExecutionLineage` encode remote provenance, ancestry, checkpoint references, and attestation chains.
+
+Audit-safe lineage can be represented with redacted trace fields using visibility tiers.

--- a/FEDERATED_EXPLAINABILITY_TRACE.md
+++ b/FEDERATED_EXPLAINABILITY_TRACE.md
@@ -1,0 +1,11 @@
+# Federated Explainability Trace
+
+`RuntimeFederationTrace` encodes runtime origin, decision linkage, visibility, and redaction metadata.
+
+Visibility tiers:
+- internal
+- audit-safe
+- sdk-safe
+- operator
+- federation-partner
+- user-facing

--- a/FEDERATED_HANDSHAKE_MODEL.md
+++ b/FEDERATED_HANDSHAKE_MODEL.md
@@ -1,0 +1,10 @@
+# Federated Handshake Model
+
+`RuntimeFederationHandshakeEnvelope` includes:
+- identity exchange,
+- trust posture exchange,
+- version assertion,
+- compatibility matrix,
+- constraints exchange.
+
+Design remains lightweight and transport-neutral.

--- a/FEDERATED_PUBLIC_INTERNAL_BOUNDARIES.md
+++ b/FEDERATED_PUBLIC_INTERNAL_BOUNDARIES.md
@@ -1,0 +1,8 @@
+# Federated Public/Internal Boundaries
+
+- Stable public: high-level federation contracts safe for SDKs.
+- SDK-safe: visibility-filtered traces and non-sensitive decision metadata.
+- Federation-partner-safe: cross-runtime assertions with redactions.
+- Audit-safe: full reason lineage with protected fields redacted.
+- Internal-only: compatibility matrix internals and constraint authoring internals.
+- Experimental/future: enterprise control-plane and distributed-runtime-only policies.

--- a/FEDERATED_REPLAY_SEMANTICS.md
+++ b/FEDERATED_REPLAY_SEMANTICS.md
@@ -1,0 +1,7 @@
+# Federated Replay Semantics
+
+`RuntimeFederationReplay` binds replay authorization to lineage and attestation references.
+
+Replay guarantees:
+- replay preserves federation ancestry.
+- replay without required attestations is deny.

--- a/FEDERATED_RUNTIME_IDENTITY_MODEL.md
+++ b/FEDERATED_RUNTIME_IDENTITY_MODEL.md
@@ -1,0 +1,7 @@
+# Federated Runtime Identity Model
+
+- Sovereign runtime identity: `sovereign: true` in `RuntimeFederationIdentity`.
+- Tenant-scoped identity: explicit `tenantId`.
+- Delegated identity: `delegatedFromRuntimeId` set.
+- Runtime domain identity: `runtimeDomain`.
+- Attestation identity: `attestationIdentityRef` for remote proof linkage.

--- a/FEDERATED_TRUST_SEMANTICS.md
+++ b/FEDERATED_TRUST_SEMANTICS.md
@@ -1,0 +1,10 @@
+# Federated Trust Semantics
+
+Trust states: trusted, untrusted, suspended, revoked, degraded, incompatible, delegated, attested, replay-authorized, replay-denied.
+
+Trust levels: trusted, partially-trusted, capability-limited, replay-authorized, degraded-trust, revoked.
+
+Guarantees:
+- revoked/untrusted/incompatible fail closed.
+- degraded trust constrains delegation depth.
+- capability-limited trust requires explicit capability scopes.

--- a/FEDERATION_EVOLUTION_ROADMAP.md
+++ b/FEDERATION_EVOLUTION_ROADMAP.md
@@ -1,0 +1,7 @@
+# Federation Evolution Roadmap
+
+1. Current: deterministic governance semantics + guardrail checks.
+2. Next: richer reason-code taxonomy for federation constraints.
+3. Enterprise: policy package exchange + partner trust templates.
+4. Sovereign AI runtime: model/runtime attestation profile registries.
+5. Distributed execution future: optional execution fabric adapters that consume (not redefine) federation semantics.

--- a/RUNTIME_FEDERATION_ARCHITECTURE.md
+++ b/RUNTIME_FEDERATION_ARCHITECTURE.md
@@ -1,0 +1,14 @@
+# Runtime Federation Architecture
+
+## Scope
+Governance semantics for sovereign runtime interoperability; no consensus, mesh, scheduler, or infra topology assumptions.
+
+## Core Components
+1. Federation primitives (`runtime/distributed/types.ts`).
+2. Federation decision helpers (`runtime/distributed/federation-semantics.ts`).
+3. Governance checks (`scripts/check-federation-governance.mjs`).
+
+## Determinism Rules
+- Decisions normalize sorted unique reasons.
+- Deny conditions are explicit and reason-coded.
+- Compatibility and trust are independent checks composed into final decision.

--- a/SOVEREIGN_RUNTIME_FEDERATION.md
+++ b/SOVEREIGN_RUNTIME_FEDERATION.md
@@ -1,0 +1,47 @@
+# Sovereign Runtime Federation
+
+## Phase 1 — Federation Audit
+
+### Existing assumptions discovered
+- `runtime/distributed/runtime-federation.ts` was domain-centric and implicitly assumed local runtime authority by validating domain mode compatibility only.
+- Trust posture checks were not first-class runtime assertions.
+- Replay/attestation governance lacked explicit cross-runtime preconditions.
+- Explainability had no canonical cross-runtime redaction normalization contract.
+
+### Missing semantics identified
+- Missing runtime-identity exchange and attestation-bound identity.
+- Missing deterministic trust+compatibility composition for federation decisions.
+- Missing replay-specific trust invariants.
+- Missing boundary classification semantics for sovereign policy isolation.
+
+## Canonical Federation Model Introduced
+- Canonical primitives are defined in `runtime/distributed/types.ts`.
+- Deterministic semantics are implemented in `runtime/distributed/federation-semantics.ts`.
+- The model is fail-closed, transport-neutral, policy-driven, and capability-attentuated.
+
+## Examples
+- Example trusted runtime federation: two sovereign runtimes exchange compatible versions/profiles and no deny constraints; decision is `allow`.
+- Example degraded runtime posture: warn constraints produce deterministic `conditional` decision with `degraded` state.
+- Example remote delegated execution: capability scopes are attenuated by receiving runtime trust posture and max delegation depth.
+- Example federated replay lineage: replay authorization validates lineage-linked attestation references.
+- Example remote attestation chain: `FederatedExecutionLineage.attestationChain` captures remote runtime attestations.
+- Example federation compatibility failure: unsupported federation version yields explicit deny reason.
+- Example sdk-safe federation trace: visibility `sdk-safe` with normalized redaction field list.
+- Example audit-safe federation lineage: visibility `audit-safe` preserves reason ancestry without leaking internal raw fields.
+- Example future sovereign AI runtime federation: attestation identity hooks support model/runtime attestation registries.
+- Example enterprise federated governance flow: policy packages emit constraints with `warn`/`deny` enforcement for partner federations.
+
+## Sovereign Runtime Federation Readiness Summary
+- Federation model introduced: runtime identity, trust, capability, replay, compatibility, boundary, and trace primitives plus deterministic helpers.
+- Runtime trust guarantees: revoked/untrusted/incompatible states fail closed; degraded trust constrains delegation; replay-authorized posture is validated.
+- Federated capability guarantees: remote runtime cannot exceed delegated scopes or delegation depth.
+- Federated lineage guarantees: federated execution references and attestation chains preserve ancestry.
+- Federated replay guarantees: replay authorization requires trust posture and attestation references.
+- Compatibility posture: version/profile/protocol checks remain explicit and deny on mismatch.
+- Explainability behavior: deterministic decision normalization and stable redaction normalization.
+- SDK/public exposure posture: semantics are internal runtime-surface focused with visibility tiers for sdk-safe and audit-safe traces.
+- Remaining federation risks: policy-authoring quality and reason-code coverage breadth remain organizational governance risks.
+- Future sovereign AI-runtime readiness: attestation identity and chain structures support AI-runtime proof exchange.
+- Future enterprise federation readiness: constraints and compatibility matrix patterns support partner governance onboarding.
+- Future distributed execution readiness: semantics are ready for future execution adapters without introducing orchestration infrastructure now.
+- Next recommended platform step: integrate reason-code taxonomy extension for federation-specific trust/compatibility/replay violations.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "check:policy-governance": "node scripts/check-policy-governance.mjs",
     "check:reason-code-governance": "node scripts/check-reason-code-governance.mjs",
     "check:capability-governance": "node scripts/check-capability-governance.mjs",
-    "check:execution-governance": "node scripts/check-execution-governance.mjs"
+    "check:execution-governance": "node scripts/check-execution-governance.mjs",
+    "check:federation-governance": "node scripts/check-federation-governance.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/runtime/distributed/__tests__/federation-semantics.test.ts
+++ b/runtime/distributed/__tests__/federation-semantics.test.ts
@@ -1,0 +1,108 @@
+import {
+  buildRuntimeFederationAssertion,
+  constrainFederatedCapability,
+  normalizeRuntimeFederationDecision,
+  redactFederationTrace,
+  validateFederatedReplay,
+  validateRuntimeCompatibility,
+  validateRuntimeTrust,
+} from '../federation-semantics';
+
+describe('federation semantics', () => {
+  test('incompatible runtimes fail closed', () => {
+    const result = validateRuntimeCompatibility(
+      { federationVersion: '2.0', runtimeProtocolVersion: '1', transportProfile: 'http-json' },
+      { supportedFederationVersions: ['1.0'], runtimeProtocolVersion: '1', supportedTransportProfiles: ['http-json'] },
+    );
+    expect(result.compatible).toBe(false);
+  });
+
+  test('revoked runtime trust invalidates federation', () => {
+    const result = validateRuntimeTrust({
+      runtimeId: 'r1',
+      state: 'revoked',
+      trustLevel: 'revoked',
+      allowedCapabilities: ['cap.read'],
+      maxDelegationDepth: 0,
+      replayAuthorized: false,
+    });
+    expect(result.compatible).toBe(false);
+  });
+
+  test('remote runtime cannot exceed delegated scope', () => {
+    const constrained = constrainFederatedCapability(
+      {
+        capabilityId: 'cap1',
+        sourceRuntimeId: 'r1',
+        targetRuntimeId: 'r2',
+        allowedScopes: ['cap.read', 'cap.write'],
+        delegationDepth: 3,
+        tenantBound: true,
+        replayBound: true,
+      },
+      {
+        runtimeId: 'r2',
+        state: 'trusted',
+        trustLevel: 'capability-limited',
+        allowedCapabilities: ['cap.read'],
+        maxDelegationDepth: 1,
+        replayAuthorized: true,
+      },
+    );
+
+    expect(constrained.allowedScopes).toEqual(['cap.read']);
+    expect(constrained.delegationDepth).toBe(1);
+  });
+
+  test('federation decision normalization is deterministic', () => {
+    const normalized = normalizeRuntimeFederationDecision({
+      decisionId: 'd1',
+      category: 'governance',
+      state: 'trusted',
+      decision: 'allow',
+      reasons: ['b', 'a', 'a'],
+    });
+
+    expect(normalized.reasons).toEqual(['a', 'b']);
+    expect(normalized.explainabilityRef).toBe('federation:d1');
+  });
+
+  test('federation constraints fail closed', () => {
+    const decision = buildRuntimeFederationAssertion(
+      {
+        handshakeId: 'h1',
+        sourceIdentity: { runtimeId: 'r1', runtimeDomain: 'd1', tenantId: 't1', sovereign: true },
+        targetIdentity: { runtimeId: 'r2', runtimeDomain: 'd2', tenantId: 't1', sovereign: true },
+        trust: { runtimeId: 'r2', state: 'trusted', trustLevel: 'trusted', allowedCapabilities: ['cap.read'], maxDelegationDepth: 2, replayAuthorized: true },
+        version: { federationVersion: '1.0', runtimeProtocolVersion: '1', transportProfile: 'http-json' },
+        compatibilityMatrix: { supportedFederationVersions: ['1.0'], runtimeProtocolVersion: '1', supportedTransportProfiles: ['http-json'] },
+        constraints: [],
+      },
+      { runtimeId: 'r2', state: 'trusted', trustLevel: 'trusted', allowedCapabilities: ['cap.read'], maxDelegationDepth: 2, replayAuthorized: true },
+      [{ constraintId: 'c1', category: 'trust', reasonCode: 'trust.denied', enforcement: 'deny' }],
+    );
+
+    expect(decision.decision).toBe('deny');
+  });
+
+  test('replay preserves attestation requirement', () => {
+    const result = validateFederatedReplay(
+      { replayId: 'rp1', lineageId: 'ln1', authorized: true, attestationRefs: [] },
+      { runtimeId: 'r2', state: 'replay-authorized', trustLevel: 'replay-authorized', allowedCapabilities: ['cap.read'], maxDelegationDepth: 1, replayAuthorized: true },
+    );
+
+    expect(result.compatible).toBe(false);
+  });
+
+  test('trace redaction normalization remains deterministic', () => {
+    const trace = redactFederationTrace({
+      traceId: 'tr1',
+      runtimeOrigin: 'r1',
+      decisionId: 'd1',
+      visibility: 'audit-safe',
+      redactedFields: ['tenant.secrets', 'token.raw', 'tenant.secrets'],
+    });
+
+    expect(trace.redactedFields).toEqual(['tenant.secrets', 'token.raw']);
+  });
+});

--- a/runtime/distributed/federation-semantics.ts
+++ b/runtime/distributed/federation-semantics.ts
@@ -1,0 +1,107 @@
+import {
+  FederationCompatibilityResult,
+  RuntimeFederationBoundary,
+  RuntimeFederationCapability,
+  RuntimeFederationCompatibilityMatrix,
+  RuntimeFederationConstraint,
+  RuntimeFederationDecision,
+  RuntimeFederationHandshakeEnvelope,
+  RuntimeFederationReplay,
+  RuntimeFederationState,
+  RuntimeFederationTrace,
+  RuntimeFederationTrustLevel,
+  RuntimeFederationVersionAssertion,
+  RuntimeTrustAssertion,
+} from './types';
+
+const INCOMPATIBLE_STATES: RuntimeFederationState[] = ['revoked', 'incompatible', 'untrusted'];
+
+export function validateRuntimeTrust(assertion: RuntimeTrustAssertion): FederationCompatibilityResult {
+  const reasons: string[] = [];
+  if (INCOMPATIBLE_STATES.includes(assertion.state)) reasons.push('Runtime trust state is not eligible for federation operations.');
+  if (assertion.maxDelegationDepth < 0) reasons.push('maxDelegationDepth cannot be negative.');
+  if (assertion.state === 'degraded' && assertion.maxDelegationDepth > 1) reasons.push('Degraded trust posture requires maxDelegationDepth <= 1.');
+  if (assertion.trustLevel === 'capability-limited' && assertion.allowedCapabilities.length === 0) reasons.push('Capability-limited trust posture must declare at least one allowed capability.');
+  if (!assertion.replayAuthorized && assertion.state === 'replay-authorized') reasons.push('replay-authorized state requires replayAuthorized=true.');
+  return { compatible: reasons.length === 0, reasons };
+}
+
+export function validateRuntimeCompatibility(
+  version: RuntimeFederationVersionAssertion,
+  matrix: RuntimeFederationCompatibilityMatrix,
+): FederationCompatibilityResult {
+  const reasons: string[] = [];
+  if (!matrix.supportedFederationVersions.includes(version.federationVersion)) reasons.push('Unsupported federation version.');
+  if (!matrix.supportedTransportProfiles.includes(version.transportProfile)) reasons.push('Unsupported transport profile.');
+  if (version.runtimeProtocolVersion !== matrix.runtimeProtocolVersion) reasons.push('Runtime protocol version mismatch.');
+  return { compatible: reasons.length === 0, reasons };
+}
+
+export function classifyRuntimeFederationBoundary(boundary: RuntimeFederationBoundary): 'strict' | 'attenuated' | 'open' {
+  if (boundary.policyIsolation === 'strict' || boundary.visibility === 'internal') return 'strict';
+  if (boundary.delegation === 'attenuated' || boundary.replay === 'deny-by-default') return 'attenuated';
+  return 'open';
+}
+
+export function buildRuntimeFederationAssertion(
+  handshake: RuntimeFederationHandshakeEnvelope,
+  trust: RuntimeTrustAssertion,
+  constraints: RuntimeFederationConstraint[],
+): RuntimeFederationDecision {
+  const trustResult = validateRuntimeTrust(trust);
+  const compatibilityResult = validateRuntimeCompatibility(handshake.version, handshake.compatibilityMatrix);
+  const denyReasons = [
+    ...trustResult.reasons,
+    ...compatibilityResult.reasons,
+    ...constraints.filter((c) => c.enforcement === 'deny').map((c) => c.reasonCode),
+  ];
+  const warnReasons = constraints.filter((c) => c.enforcement === 'warn').map((c) => c.reasonCode);
+
+  return normalizeRuntimeFederationDecision({
+    decisionId: handshake.handshakeId,
+    state: denyReasons.length === 0 ? (warnReasons.length > 0 ? 'degraded' : 'trusted') : 'incompatible',
+    decision: denyReasons.length === 0 ? (warnReasons.length > 0 ? 'conditional' : 'allow') : 'deny',
+    reasons: [...denyReasons, ...warnReasons],
+    category: 'governance',
+  });
+}
+
+export function normalizeRuntimeFederationDecision(decision: RuntimeFederationDecision): RuntimeFederationDecision {
+  const uniqueReasons = [...new Set(decision.reasons)].sort();
+  const trustLevel: RuntimeFederationTrustLevel = decision.decision === 'allow'
+    ? 'trusted'
+    : decision.decision === 'conditional'
+      ? 'partially-trusted'
+      : 'untrusted';
+  return {
+    ...decision,
+    reasons: uniqueReasons,
+    trustLevel,
+    explainabilityRef: decision.explainabilityRef ?? `federation:${decision.decisionId}`,
+  };
+}
+
+export function constrainFederatedCapability(
+  capability: RuntimeFederationCapability,
+  trust: RuntimeTrustAssertion,
+): RuntimeFederationCapability {
+  const allowed = new Set(trust.allowedCapabilities);
+  return {
+    ...capability,
+    allowedScopes: capability.allowedScopes.filter((scope) => allowed.has(scope)),
+    delegationDepth: Math.max(0, Math.min(capability.delegationDepth, trust.maxDelegationDepth)),
+  };
+}
+
+export function validateFederatedReplay(replay: RuntimeFederationReplay, trust: RuntimeTrustAssertion): FederationCompatibilityResult {
+  const reasons: string[] = [];
+  if (!trust.replayAuthorized) reasons.push('Trust posture does not authorize replay.');
+  if (replay.authorized && replay.attestationRefs.length === 0) reasons.push('Authorized replay requires attestation references.');
+  if (!replay.authorized && trust.replayAuthorized) reasons.push('Replay denied despite replay-authorized trust posture.');
+  return { compatible: reasons.length === 0, reasons };
+}
+
+export function redactFederationTrace(trace: RuntimeFederationTrace): RuntimeFederationTrace {
+  const redactedFields = [...new Set(trace.redactedFields)].sort();
+  return { ...trace, redactedFields };
+}

--- a/runtime/distributed/index.ts
+++ b/runtime/distributed/index.ts
@@ -8,3 +8,5 @@ export * from './distributed-capabilities';
 export * from './distributed-revocation';
 export * from './remote-audit';
 export * from './governance-isolation';
+
+export * from './federation-semantics';

--- a/runtime/distributed/types.ts
+++ b/runtime/distributed/types.ts
@@ -146,3 +146,176 @@ export interface AIConnectorAttestation {
   policyScoped: boolean;
   tokenUsage?: { input: number; output: number };
 }
+
+export type RuntimeId = string;
+export type RuntimeDomain = string;
+export type RuntimeFederationCategory =
+  | 'trust'
+  | 'delegation'
+  | 'replay'
+  | 'attestation'
+  | 'compatibility'
+  | 'lineage'
+  | 'transport'
+  | 'execution'
+  | 'governance'
+  | 'tenant'
+  | 'sdk'
+  | 'orchestration';
+
+export type RuntimeFederationState =
+  | 'trusted'
+  | 'untrusted'
+  | 'suspended'
+  | 'revoked'
+  | 'degraded'
+  | 'incompatible'
+  | 'delegated'
+  | 'attested'
+  | 'replay-authorized'
+  | 'replay-denied';
+
+export type RuntimeFederationTrustLevel =
+  | 'trusted'
+  | 'partially-trusted'
+  | 'capability-limited'
+  | 'replay-authorized'
+  | 'degraded-trust'
+  | 'revoked';
+
+export interface RuntimeFederationIdentity {
+  runtimeId: RuntimeId;
+  runtimeDomain: RuntimeDomain;
+  tenantId: TenantId;
+  sovereign: boolean;
+  delegatedFromRuntimeId?: RuntimeId;
+  attestationIdentityRef?: string;
+}
+
+export interface RuntimeFederationBoundary {
+  sourceRuntimeId: RuntimeId;
+  targetRuntimeId: RuntimeId;
+  policyIsolation: 'strict' | 'shared';
+  delegation: 'none' | 'attenuated' | 'scoped';
+  replay: 'deny-by-default' | 'allow-with-attestation';
+  visibility: 'internal' | 'audit-safe' | 'sdk-safe' | 'operator' | 'federation-partner' | 'user-facing';
+}
+
+export interface RuntimeTrustAssertion {
+  runtimeId: RuntimeId;
+  state: RuntimeFederationState;
+  trustLevel: RuntimeFederationTrustLevel;
+  allowedCapabilities: string[];
+  maxDelegationDepth: number;
+  replayAuthorized: boolean;
+}
+
+export interface RuntimeAttestation {
+  attestationId: string;
+  runtimeId: RuntimeId;
+  attestedByRuntimeId: RuntimeId;
+  checksum: string;
+  issuedAt: string;
+}
+
+export interface RuntimeFederationCapability {
+  capabilityId: string;
+  sourceRuntimeId: RuntimeId;
+  targetRuntimeId: RuntimeId;
+  allowedScopes: string[];
+  delegationDepth: number;
+  tenantBound: boolean;
+  replayBound: boolean;
+}
+
+export interface FederatedExecutionReference {
+  executionId: string;
+  runtimeId: RuntimeId;
+  parentExecutionId?: string;
+  checkpointRef?: string;
+}
+
+export interface FederatedExecutionLineage {
+  lineageId: string;
+  ancestry: FederatedExecutionReference[];
+  attestationChain: RuntimeAttestation[];
+}
+
+export interface RuntimeCompatibilityAssertion {
+  sourceRuntimeId: RuntimeId;
+  targetRuntimeId: RuntimeId;
+  compatible: boolean;
+  reasons: string[];
+}
+
+export interface RuntimeFederationRelationship {
+  relationshipId: string;
+  sourceRuntimeId: RuntimeId;
+  targetRuntimeId: RuntimeId;
+  state: RuntimeFederationState;
+}
+
+export interface RuntimeFederationConstraint {
+  constraintId: string;
+  category: RuntimeFederationCategory;
+  reasonCode: string;
+  enforcement: 'warn' | 'deny';
+}
+
+export interface RuntimeFederationPolicy {
+  policyId: string;
+  categories: RuntimeFederationCategory[];
+  constraints: RuntimeFederationConstraint[];
+}
+
+export interface RuntimeFederationDecision {
+  decisionId: string;
+  category: RuntimeFederationCategory;
+  state: RuntimeFederationState;
+  decision: 'allow' | 'deny' | 'conditional';
+  reasons: string[];
+  trustLevel?: RuntimeFederationTrustLevel;
+  explainabilityRef?: string;
+}
+
+export interface RuntimeFederationReplay {
+  replayId: string;
+  lineageId: string;
+  authorized: boolean;
+  attestationRefs: string[];
+}
+
+export interface RuntimeFederationTrace {
+  traceId: string;
+  runtimeOrigin: RuntimeId;
+  decisionId: string;
+  visibility: RuntimeFederationBoundary['visibility'];
+  redactedFields: string[];
+}
+
+export type RuntimeFederationVisibility = RuntimeFederationBoundary['visibility'];
+
+export interface RuntimeFederationVersionAssertion {
+  federationVersion: string;
+  runtimeProtocolVersion: string;
+  transportProfile: string;
+}
+
+export interface RuntimeFederationCompatibilityMatrix {
+  supportedFederationVersions: string[];
+  runtimeProtocolVersion: string;
+  supportedTransportProfiles: string[];
+}
+
+export interface RuntimeFederationHandshake {
+  handshakeId: string;
+  sourceIdentity: RuntimeFederationIdentity;
+  targetIdentity: RuntimeFederationIdentity;
+  trust: RuntimeTrustAssertion;
+  version: RuntimeFederationVersionAssertion;
+}
+
+export interface RuntimeFederationHandshakeEnvelope extends RuntimeFederationHandshake {
+  compatibilityMatrix: RuntimeFederationCompatibilityMatrix;
+  constraints: RuntimeFederationConstraint[];
+}

--- a/scripts/check-federation-governance.mjs
+++ b/scripts/check-federation-governance.mjs
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const docs = [
+  'RUNTIME_FEDERATION_ARCHITECTURE.md',
+  'FEDERATED_RUNTIME_IDENTITY_MODEL.md',
+  'FEDERATED_TRUST_SEMANTICS.md',
+  'FEDERATED_CAPABILITY_MODEL.md',
+  'FEDERATED_EXECUTION_LINEAGE.md',
+  'FEDERATED_REPLAY_SEMANTICS.md',
+  'FEDERATED_ATTESTATION_MODEL.md',
+  'FEDERATED_HANDSHAKE_MODEL.md',
+  'FEDERATED_COMPATIBILITY_MODEL.md',
+  'FEDERATED_EXPLAINABILITY_TRACE.md',
+  'FEDERATED_PUBLIC_INTERNAL_BOUNDARIES.md',
+  'SOVEREIGN_RUNTIME_FEDERATION.md',
+  'FEDERATION_EVOLUTION_ROADMAP.md',
+];
+
+const missing = docs.filter((d) => !existsSync(d));
+if (missing.length) {
+  console.error('Missing federation governance docs:', missing.join(', '));
+  process.exit(1);
+}
+
+const requiredTerms = ['federation', 'runtime', 'trust', 'lineage'];
+const corpus = docs.map((doc) => readFileSync(doc, 'utf8').toLowerCase()).join('\n');
+for (const term of requiredTerms) {
+  if (!corpus.includes(term)) {
+    console.error(`Federation governance corpus missing required term: ${term}`);
+    process.exit(1);
+  }
+}
+
+const sovereignDoc = readFileSync('SOVEREIGN_RUNTIME_FEDERATION.md', 'utf8').toLowerCase();
+const requiredExamples = [
+  'trusted runtime federation',
+  'degraded runtime posture',
+  'remote delegated execution',
+  'federated replay lineage',
+  'remote attestation chain',
+  'federation compatibility failure',
+  'sdk-safe federation trace',
+  'audit-safe federation lineage',
+  'future sovereign ai runtime federation',
+  'enterprise federated governance flow',
+];
+for (const example of requiredExamples) {
+  if (!sovereignDoc.includes(example)) {
+    console.error(`SOVEREIGN_RUNTIME_FEDERATION.md missing example: ${example}`);
+    process.exit(1);
+  }
+}
+
+console.log('Federation governance checks passed.');


### PR DESCRIPTION
### Motivation

- Introduce a canonical, deterministic federation model and helpers for sovereign runtime interoperability covering identity, trust, capability, compatibility, lineage, replay, attestation, and explainability.
- Provide documentation and a lightweight governance checker to ensure the federation corpus is present and contains required terms and examples.

### Description

- Add a set of federation design docs (`RUNTIME_FEDERATION_ARCHITECTURE.md`, `SOVEREIGN_RUNTIME_FEDERATION.md`, `FEDERATED_*` docs, and `FEDERATION_EVOLUTION_ROADMAP.md`) that describe models, boundaries, and examples.
- Extend `runtime/distributed/types.ts` with federation types (identity, trust, capability, attestation, lineage, handshake, compatibility matrix, replay, trace, states, and trust levels).
- Implement deterministic federation semantics in `runtime/distributed/federation-semantics.ts` with functions including `validateRuntimeTrust`, `validateRuntimeCompatibility`, `buildRuntimeFederationAssertion`, `normalizeRuntimeFederationDecision`, `constrainFederatedCapability`, `validateFederatedReplay`, and `redactFederationTrace` and re-export it from `runtime/distributed/index.ts`.
- Add unit tests in `runtime/distributed/__tests__/federation-semantics.test.ts` that exercise compatibility, trust, capability attenuation, decision normalization, replay validation, and trace redaction.
- Add `scripts/check-federation-governance.mjs` and wire it into `package.json` as `check:federation-governance` to validate presence of docs and required corpus terms/examples.

### Testing

- Ran `npm test` (Jest) which executed `runtime/distributed/__tests__/federation-semantics.test.ts`; the federation semantics unit tests passed.
- Ran `npm run check:federation-governance` (which runs `node scripts/check-federation-governance.mjs`) and the governance documentation checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a5e675c08325a0fe13f95dba1cfe)