### PR TITLE
Introduce temporal governance docs, runtime temporal types, validation and tests

### DIFF
--- a/CAUSAL_EXECUTION_MODEL.md
+++ b/CAUSAL_EXECUTION_MODEL.md
@@ -1,0 +1,43 @@
+# CAUSAL EXECUTION MODEL
+
+## Scope
+Execution-before/replay-before/mutation-after causal guarantees.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/DETERMINISTIC_COGNITION_MODEL.md
+++ b/DETERMINISTIC_COGNITION_MODEL.md
@@ -1,0 +1,43 @@
+# DETERMINISTIC COGNITION MODEL
+
+## Scope
+Deterministic cognition posture and replay-safe evolution.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/DETERMINISTIC_REPLAY_SEMANTICS.md
+++ b/DETERMINISTIC_REPLAY_SEMANTICS.md
@@ -1,0 +1,43 @@
+# DETERMINISTIC REPLAY SEMANTICS
+
+## Scope
+Deterministic replay chronology and mutation constraints.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/RUNTIME_TEMPORAL_ARCHITECTURE.md
+++ b/RUNTIME_TEMPORAL_ARCHITECTURE.md
@@ -1,0 +1,43 @@
+# RUNTIME TEMPORAL ARCHITECTURE
+
+## Scope
+Runtime temporal architecture and audit findings.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/SOVEREIGN_TEMPORAL_CONSISTENCY.md
+++ b/SOVEREIGN_TEMPORAL_CONSISTENCY.md
@@ -1,0 +1,43 @@
+# SOVEREIGN TEMPORAL CONSISTENCY
+
+## Scope
+Sovereign AI temporal determinism readiness model.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/TEMPORAL_CONSISTENCY_MODEL.md
+++ b/TEMPORAL_CONSISTENCY_MODEL.md
@@ -1,0 +1,43 @@
+# TEMPORAL CONSISTENCY MODEL
+
+## Scope
+Canonical temporal consistency model and primitives.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/TEMPORAL_CONTINUITY_MODEL.md
+++ b/TEMPORAL_CONTINUITY_MODEL.md
@@ -1,0 +1,43 @@
+# TEMPORAL CONTINUITY MODEL
+
+## Scope
+Continuity chronology and cognitive evolution sequencing.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/TEMPORAL_EVOLUTION_ROADMAP.md
+++ b/TEMPORAL_EVOLUTION_ROADMAP.md
@@ -1,0 +1,43 @@
+# TEMPORAL EVOLUTION ROADMAP
+
+## Scope
+Temporal determinism roadmap toward enterprise orchestration.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/TEMPORAL_EXPLAINABILITY_TRACE.md
+++ b/TEMPORAL_EXPLAINABILITY_TRACE.md
@@ -1,0 +1,43 @@
+# TEMPORAL EXPLAINABILITY TRACE
+
+## Scope
+Explainability and telemetry chronology visibility tiers.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/TEMPORAL_FEDERATION_GOVERNANCE.md
+++ b/TEMPORAL_FEDERATION_GOVERNANCE.md
@@ -1,0 +1,43 @@
+# TEMPORAL FEDERATION GOVERNANCE
+
+## Scope
+Federated chronology provenance and trust posture governance.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/TEMPORAL_PUBLIC_INTERNAL_BOUNDARIES.md
+++ b/TEMPORAL_PUBLIC_INTERNAL_BOUNDARIES.md
@@ -1,0 +1,43 @@
+# TEMPORAL PUBLIC INTERNAL BOUNDARIES
+
+## Scope
+Public/internal boundary mapping for temporal semantics.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/TEMPORAL_TRUST_POSTURE.md
+++ b/TEMPORAL_TRUST_POSTURE.md
@@ -1,0 +1,43 @@
+# TEMPORAL TRUST POSTURE
+
+## Scope
+Temporal trust levels and fail-closed rules.
+
+## Phase 1 Audit Summary
+- Temporal ordering was previously implicit across execution, replay, federation handoff, and continuity records.
+- Deterministic sequencing guarantees were incomplete for replay chronology and coordination ordering.
+- Temporal provenance and conflict semantics were missing for federation and continuity mutation pathways.
+
+## Canonical Semantics
+- Adopt `TemporalSequenceEnvelope` as the unit for deterministic chronology, causality constraints, lineage, trust posture, and visibility tier.
+- Enforce categories: execution, replay, federation, cognition, coordination, sequencing, continuity, policy, capability, audit, telemetry, explainability, sdk, governance, tenant.
+- Enforce states: ordered, replayable, constrained, attested, federated, deterministic, degraded, conflicted, resolved, suspended, revoked, immutable, mutable, archived.
+
+## Guarantees
+- Replay chronology must preserve strict sequence monotonicity and causal prerequisites.
+- Mutation chronology is append-only in replay mode and fail-closed on invariant violations.
+- Federation chronology requires provenance references and trust posture checks.
+- Continuity chronology binds cognition evolution to immutable lineage ancestry.
+
+## Examples
+1. Deterministic replay chronology: seq-41 → seq-42 → seq-43 remains unchanged during replay.
+2. Replay causality preservation: seq-43 rejected when `mustHappenAfter` references an unseen event.
+3. Federated continuity: local lineage `lin-A` continues on partner runtime with provenanceRef and trust posture = `federated_chronology`.
+4. Sequencing conflict resolution: `sequence_regression` classified then resolved as `reject` or `manual_governance_review`.
+5. Replay-aware cognition evolution: continuitySequence increments without ancestry rewrites.
+6. Trust degradation: posture transitions to `degraded_chronology`, replay restricted to attested read-only path.
+7. SDK-safe chronology trace: envelopeId/category/sequence/state exposed, sensitive refs redacted.
+8. Audit-safe lineage: includes chronology hash and attestation id.
+9. Sovereign deterministic cognition: sovereign chronology uses local monotonic execution with replay attestations.
+10. Enterprise deterministic orchestration readiness: control-plane may consume envelopes and assertions without owning a scheduler.
+
+## Public/Internal Boundary Guidance
+- Stable runtime/internal API: primitive types + validators in `runtime/execution-fabric/temporal.ts`.
+- SDK-safe: redacted chronology traces and deterministic assertion outputs only.
+- Federation-partner-safe: provenance-bound envelopes and trust posture signals only.
+- Internal-only: raw chronology internals and unresolved conflict payloads.
+
+## Validation & Guardrails
+- `validateTemporalConsistency`, `validateReplayChronology`, `validateCausalOrdering`, `validateDeterministicReplay` enforce invariants.
+- `classifyTemporalConflict` and `classifyChronologyConflict` provide fail-closed conflict semantics.
+- `npm run check:temporal-governance` validates temporal docs and required runtime temporal tokens.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "check:release-governance": "node scripts/check-release-governance.mjs",
     "check:observability-governance": "node scripts/check-observability-governance.mjs",
     "check:memory-governance": "node scripts/check-memory-governance.mjs",
-    "check:sdk-exports": "node scripts/check-sdk-exports.mjs"
+    "check:sdk-exports": "node scripts/check-sdk-exports.mjs",
+    "check:temporal-governance": "node scripts/check-temporal-governance.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/runtime/execution-fabric/__tests__/temporal.test.ts
+++ b/runtime/execution-fabric/__tests__/temporal.test.ts
@@ -1,0 +1,70 @@
+import {
+  buildTemporalAssertion,
+  classifyTemporalConflict,
+  validateCausalOrdering,
+  validateDeterministicReplay,
+  validateReplayChronology,
+  validateTemporalConsistency,
+  type TemporalSequenceEnvelope,
+} from '../temporal';
+
+const base = (sequence: number, eventRef: string): TemporalSequenceEnvelope => ({
+  envelopeId: `env-${sequence}`,
+  category: 'execution',
+  sequence,
+  eventRef,
+  executionRef: { executionPlanId: 'plan-1', sequence },
+  lineage: { lineageId: 'lin-1', ancestry: ['lin-root', 'lin-1'] },
+  continuityRef: { continuityId: 'cont-1', lineageId: 'lin-1', continuitySequence: sequence },
+  orderingConstraint: { mustHappenAfter: sequence === 0 ? [] : [`event-${sequence - 1}`], mustHappenBefore: [] },
+  replayConstraint: { replayMustPreserveSequence: true, replayMustPreserveCausality: true, replayMutationsMustBeAppendOnly: true },
+  trustPosture: 'trusted_chronology',
+  clockPosture: 'runtime_monotonic',
+  state: 'deterministic',
+  visibility: 'audit-safe',
+  timestamp: new Date().toISOString(),
+});
+
+describe('temporal governance helpers', () => {
+  it('validates deterministic replay chronology', () => {
+    const envelopes = [base(0, 'event-0'), base(1, 'event-1')];
+    expect(validateReplayChronology(envelopes)).toBe(true);
+    expect(validateDeterministicReplay(envelopes)).toBe(true);
+    expect(validateCausalOrdering(envelopes)).toBe(true);
+  });
+
+  it('fails on sequence regression conflict', () => {
+    const first = base(2, 'event-2');
+    const second = base(1, 'event-1');
+    expect(classifyTemporalConflict(first, second)).toBe('sequence_regression');
+  });
+
+  it('fails on federation provenance violation', () => {
+    const envelope = {
+      ...base(0, 'event-0'),
+      federationRef: {
+        localRuntimeId: 'r1',
+        remoteRuntimeId: 'r2',
+        federationSessionId: 'fed-1',
+        receivedSequence: 1,
+        provenanceRef: '',
+      },
+    };
+    expect(classifyTemporalConflict(undefined, envelope)).toBe('federation_provenance_violation');
+  });
+
+  it('builds and validates temporal consistency assertions', () => {
+    const envelope = base(0, 'event-0');
+    const assertion = buildTemporalAssertion(envelope);
+    expect(validateTemporalConsistency(envelope, assertion)).toBe(true);
+  });
+
+  it('rejects causal self dependency in assertions', () => {
+    const envelope = {
+      ...base(1, 'event-1'),
+      orderingConstraint: { mustHappenAfter: ['event-1'], mustHappenBefore: [] },
+    };
+    const assertion = buildTemporalAssertion(envelope);
+    expect(assertion.causallyOrdered).toBe(false);
+  });
+});

--- a/runtime/execution-fabric/index.ts
+++ b/runtime/execution-fabric/index.ts
@@ -1,3 +1,5 @@
 export * from './execution-fabric';
 export * from './types';
 export * from './lifecycle';
+
+export * from './temporal';

--- a/runtime/execution-fabric/temporal.ts
+++ b/runtime/execution-fabric/temporal.ts
@@ -1,0 +1,174 @@
+export type TemporalCategory =
+  | 'execution'
+  | 'replay'
+  | 'federation'
+  | 'cognition'
+  | 'coordination'
+  | 'sequencing'
+  | 'continuity'
+  | 'policy'
+  | 'capability'
+  | 'audit'
+  | 'telemetry'
+  | 'explainability'
+  | 'sdk'
+  | 'governance'
+  | 'tenant';
+
+export type TemporalState =
+  | 'ordered'
+  | 'replayable'
+  | 'constrained'
+  | 'attested'
+  | 'federated'
+  | 'deterministic'
+  | 'degraded'
+  | 'conflicted'
+  | 'resolved'
+  | 'suspended'
+  | 'revoked'
+  | 'immutable'
+  | 'mutable'
+  | 'archived';
+
+export type TemporalVisibility =
+  | 'internal'
+  | 'audit-safe'
+  | 'sdk-safe'
+  | 'operator'
+  | 'federation-partner'
+  | 'governance-only'
+  | 'user-facing';
+
+export type TemporalTrustPosture =
+  | 'sovereign_chronology'
+  | 'trusted_chronology'
+  | 'replay_derived_chronology'
+  | 'delegated_chronology'
+  | 'federated_chronology'
+  | 'degraded_chronology'
+  | 'revoked_chronology';
+
+export type TemporalClockPosture = 'runtime_monotonic' | 'runtime_wall_clock' | 'federated_received' | 'replay_derived';
+
+export interface TemporalExecutionReference { executionPlanId: string; stepId?: string; sequence: number; }
+export interface TemporalLineage { lineageId: string; parentLineageId?: string; ancestry: string[]; }
+export interface TemporalContinuityReference { continuityId: string; lineageId: string; continuitySequence: number; }
+export interface TemporalReplayReference { replayId: string; replayedFromPlanId: string; checkpointId?: string; replaySequence: number; }
+export interface TemporalMutationWindow { openedAt: string; closedAt?: string; mutationType: 'append-only' | 'replay-derived' | 'delegated' | 'federated'; }
+export interface TemporalCoordinationWindow { coordinationId: string; openedAt: string; closedAt?: string; orderedSteps: string[]; }
+export interface TemporalFederationReference { localRuntimeId: string; remoteRuntimeId: string; federationSessionId: string; receivedSequence: number; provenanceRef: string; }
+export interface TemporalOrderingConstraint { mustHappenAfter: string[]; mustHappenBefore: string[]; }
+export interface TemporalReplayConstraint { replayMustPreserveSequence: boolean; replayMustPreserveCausality: boolean; replayMutationsMustBeAppendOnly: boolean; }
+export interface TemporalContextWindow { startedAt: string; endedAt?: string; category: TemporalCategory; }
+
+export interface TemporalSequenceEnvelope {
+  envelopeId: string;
+  category: TemporalCategory;
+  sequence: number;
+  eventRef: string;
+  executionRef: TemporalExecutionReference;
+  lineage: TemporalLineage;
+  continuityRef?: TemporalContinuityReference;
+  replayRef?: TemporalReplayReference;
+  federationRef?: TemporalFederationReference;
+  orderingConstraint: TemporalOrderingConstraint;
+  replayConstraint: TemporalReplayConstraint;
+  trustPosture: TemporalTrustPosture;
+  clockPosture: TemporalClockPosture;
+  state: TemporalState;
+  visibility: TemporalVisibility;
+  timestamp: string;
+}
+
+export interface TemporalDeterminismAssertion { deterministic: boolean; rationale: string; }
+export interface TemporalConsistencyAssertion extends TemporalDeterminismAssertion { replaySafe: boolean; causallyOrdered: boolean; continuitySafe: boolean; federationSafe: boolean; }
+
+export interface TemporalAttestation { attestationId: string; envelopeId: string; chronologyHash: string; assertedAt: string; assertedBy: string; }
+
+export type TemporalConflict =
+  | 'sequence_gap'
+  | 'sequence_regression'
+  | 'causality_violation'
+  | 'replay_mutation_violation'
+  | 'federation_provenance_violation'
+  | 'continuity_ancestry_violation';
+
+export type TemporalResolution = 'reject' | 'suspend' | 'append_correction' | 'require_attestation' | 'manual_governance_review';
+
+export interface TemporalChronology { chronologyId: string; envelopes: TemporalSequenceEnvelope[]; immutable: boolean; }
+
+export function normalizeTemporalAssertion(assertion: TemporalConsistencyAssertion): TemporalConsistencyAssertion {
+  return {
+    deterministic: Boolean(assertion.deterministic),
+    replaySafe: Boolean(assertion.replaySafe),
+    causallyOrdered: Boolean(assertion.causallyOrdered),
+    continuitySafe: Boolean(assertion.continuitySafe),
+    federationSafe: Boolean(assertion.federationSafe),
+    rationale: assertion.rationale.trim(),
+  };
+}
+
+export function classifyTemporalConflict(previous: TemporalSequenceEnvelope | undefined, next: TemporalSequenceEnvelope): TemporalConflict | null {
+  if (next.orderingConstraint.mustHappenAfter.includes(next.eventRef) || next.orderingConstraint.mustHappenBefore.includes(next.eventRef)) {
+    return 'causality_violation';
+  }
+  if (!next.replayConstraint.replayMutationsMustBeAppendOnly) return 'replay_mutation_violation';
+  if (next.federationRef && next.federationRef.provenanceRef.trim().length === 0) return 'federation_provenance_violation';
+  if (next.continuityRef && !next.lineage.ancestry.includes(next.continuityRef.lineageId) && next.lineage.lineageId !== next.continuityRef.lineageId) {
+    return 'continuity_ancestry_violation';
+  }
+  if (!previous) return null;
+  if (next.sequence < previous.sequence) return 'sequence_regression';
+  if (next.sequence > previous.sequence + 1) return 'sequence_gap';
+  return null;
+}
+
+export function validateReplayChronology(replayEnvelopes: TemporalSequenceEnvelope[]): boolean {
+  for (let i = 0; i < replayEnvelopes.length; i += 1) {
+    const current = replayEnvelopes[i];
+    if (!current.replayConstraint.replayMustPreserveSequence || !current.replayConstraint.replayMustPreserveCausality || !current.replayConstraint.replayMutationsMustBeAppendOnly) return false;
+    if (i > 0 && current.sequence <= replayEnvelopes[i - 1].sequence) return false;
+    if (classifyTemporalConflict(i > 0 ? replayEnvelopes[i - 1] : undefined, current)) return false;
+  }
+  return true;
+}
+
+export function validateCausalOrdering(envelopes: TemporalSequenceEnvelope[]): boolean {
+  const seen = new Set<string>();
+  for (const envelope of envelopes) {
+    if (envelope.orderingConstraint.mustHappenBefore.includes(envelope.eventRef)) return false;
+    for (const prerequisite of envelope.orderingConstraint.mustHappenAfter) {
+      if (!seen.has(prerequisite)) return false;
+    }
+    seen.add(envelope.eventRef);
+  }
+  return true;
+}
+
+export function buildTemporalAssertion(envelope: TemporalSequenceEnvelope): TemporalConsistencyAssertion {
+  const selfConsistent = !envelope.orderingConstraint.mustHappenAfter.includes(envelope.eventRef) && !envelope.orderingConstraint.mustHappenBefore.includes(envelope.eventRef);
+  return {
+    deterministic: envelope.state !== 'conflicted' && envelope.state !== 'degraded',
+    replaySafe: envelope.replayConstraint.replayMustPreserveSequence && envelope.replayConstraint.replayMustPreserveCausality && envelope.replayConstraint.replayMutationsMustBeAppendOnly,
+    causallyOrdered: selfConsistent,
+    continuitySafe: envelope.continuityRef !== undefined && (envelope.continuityRef.lineageId === envelope.lineage.lineageId || envelope.lineage.ancestry.includes(envelope.continuityRef.lineageId)),
+    federationSafe: envelope.federationRef === undefined || (envelope.trustPosture !== 'revoked_chronology' && envelope.federationRef.provenanceRef.trim().length > 0),
+    rationale: `Temporal envelope ${envelope.envelopeId} evaluated in deterministic posture`,
+  };
+}
+
+export function validateTemporalConsistency(envelope: TemporalSequenceEnvelope, assertion: TemporalConsistencyAssertion): boolean {
+  const normalized = normalizeTemporalAssertion(assertion);
+  return normalized.deterministic && normalized.replaySafe && normalized.causallyOrdered && normalized.continuitySafe && normalized.federationSafe && envelope.sequence >= 0 && classifyTemporalConflict(undefined, envelope) === null;
+}
+
+export function validateDeterministicReplay(envelopes: TemporalSequenceEnvelope[]): boolean {
+  return validateReplayChronology(envelopes) && validateCausalOrdering(envelopes);
+}
+
+export function normalizeTemporalDecision(resolution: TemporalResolution): TemporalResolution {
+  return resolution;
+}
+
+export const classifyChronologyConflict = classifyTemporalConflict;

--- a/scripts/check-temporal-governance.mjs
+++ b/scripts/check-temporal-governance.mjs
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+
+const requiredDocs = [
+  'RUNTIME_TEMPORAL_ARCHITECTURE.md',
+  'TEMPORAL_CONSISTENCY_MODEL.md',
+  'DETERMINISTIC_REPLAY_SEMANTICS.md',
+  'CAUSAL_EXECUTION_MODEL.md',
+  'TEMPORAL_CONTINUITY_MODEL.md',
+  'TEMPORAL_FEDERATION_GOVERNANCE.md',
+  'TEMPORAL_EXPLAINABILITY_TRACE.md',
+  'TEMPORAL_TRUST_POSTURE.md',
+  'DETERMINISTIC_COGNITION_MODEL.md',
+  'TEMPORAL_PUBLIC_INTERNAL_BOUNDARIES.md',
+  'SOVEREIGN_TEMPORAL_CONSISTENCY.md',
+  'TEMPORAL_EVOLUTION_ROADMAP.md',
+];
+
+const missing = requiredDocs.filter((file) => !fs.existsSync(file));
+if (missing.length > 0) {
+  console.error('Temporal governance docs missing:');
+  for (const file of missing) console.error(` - ${file}`);
+  process.exit(1);
+}
+
+const temporalTypes = fs.readFileSync('runtime/execution-fabric/temporal.ts', 'utf8');
+const requiredTokens = [
+  'TemporalExecutionReference',
+  'TemporalLineage',
+  'TemporalContinuityReference',
+  'TemporalReplayReference',
+  'TemporalSequenceEnvelope',
+  'validateTemporalConsistency',
+  'validateReplayChronology',
+  'validateCausalOrdering',
+  'validateDeterministicReplay',
+  'classifyChronologyConflict',
+  "'sequence_regression'",
+  "'federated_chronology'",
+];
+
+for (const token of requiredTokens) {
+  if (!temporalTypes.includes(token)) {
+    console.error(`Missing temporal governance token in runtime/execution-fabric/temporal.ts: ${token}`);
+    process.exit(1);
+  }
+}
+
+console.log('Temporal governance checks passed.');


### PR DESCRIPTION
### Motivation
- Establish a canonical temporal/chronology model to support deterministic replay, federation provenance and continuity guarantees across the runtime. 
- Provide explicit semantics, visibility boundaries and guardrails so replay/mutation/federation pathways can be validated and governed. 

### Description
- Add a suite of temporal governance docs (e.g. `TEMPORAL_CONSISTENCY_MODEL.md`, `RUNTIME_TEMPORAL_ARCHITECTURE.md`, `TEMPORAL_FEDERATION_GOVERNANCE.md`, and related files) describing semantics, examples and public/internal boundaries. 
- Introduce `runtime/execution-fabric/temporal.ts` that defines `TemporalSequenceEnvelope` and related types, conflict classification, validation helpers (`validateReplayChronology`, `validateCausalOrdering`, `validateTemporalConsistency`, `validateDeterministicReplay`) and assertion builders. 
- Export the temporal module from `runtime/execution-fabric/index.ts`, add `scripts/check-temporal-governance.mjs` to verify required docs and tokens, and add `check:temporal-governance` to `package.json` scripts. 
- Add unit tests in `runtime/execution-fabric/__tests__/temporal.test.ts` that exercise chronology validation, conflict classification, federation provenance checks and assertion building. 

### Testing
- Ran the new unit tests in `runtime/execution-fabric/__tests__/temporal.test.ts` via the test harness and the tests passed. 
- Executed the temporal governance checker via `npm run check:temporal-governance` and it validated presence of docs and required tokens. 
- The added validation helpers were exercised by the tests to confirm `validateReplayChronology`, `validateCausalOrdering`, `validateTemporalConsistency` and `validateDeterministicReplay` behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3dad68dc8325b2d1984de61a4ed0)