### PR TITLE
fix(sdk): remove illegal runtime dependency from @aoc/sdk facade

### DIFF
--- a/packages/aoc-sdk/package.json
+++ b/packages/aoc-sdk/package.json
@@ -23,7 +23,5 @@
   "scripts": {
     "build": "tsc -b"
   },
-  "dependencies": {
-    "@aoc-runtime/shared-types": "0.1.0"
-  }
+  "dependencies": {}
 }

--- a/packages/aoc-sdk/tsconfig.json
+++ b/packages/aoc-sdk/tsconfig.json
@@ -6,7 +6,5 @@
     "composite": true
   },
   "include": ["src/**/*.ts"],
-  "references": [
-    { "path": "../shared-types" }
-  ]
+  "references": []
 }


### PR DESCRIPTION
@aoc/sdk declared @aoc-runtime/shared-types as a dependency in violation of the architectural rule that facades may not depend on runtime packages. The dependency was unused — all contract types were already defined locally in src/contracts.ts — so removing the declaration and its tsconfig project reference is sufficient to restore compliance with no functional change.

Fixes: facade has invalid dependency target @aoc-runtime/shared-types (runtime)

https://claude.ai/code/session_01DUPCgy26YMQLxT8hyvcz6A