### PR TITLE
Add RFC-005: Canonical Claims Framework (trust & authority model)

### DIFF
--- a/docs/audits/rfc005-source-audit.md
+++ b/docs/audits/rfc005-source-audit.md
@@ -1,0 +1,295 @@
+# RFC-005 Source Audit — Claims, Trust, Authority, and Governance
+
+| Field | Value |
+|---|---|
+| Audit | RFC-005 Claims Framework Source Audit |
+| Date | 2026-06-02 |
+| Scope | Repository review of claims, evidence, attestations, verification, standing, capabilities, authority, decisions, identity, and governance concepts |
+| Output RFC | `docs/rfcs/RFC-005-Claims-Framework.md` |
+
+---
+
+## Executive Summary
+
+The repository already contains substantial trust and authority primitives, but they are distributed across protocol packages, runtime modules, governance documents, and identity/trust services. The audit confirms that AOC has approximately 70–80% of the implementation building blocks needed for a trust framework, while lacking a single constitutional model that explains how those blocks relate.
+
+RFC-005 should therefore be concept-first and normative: it should not replace existing implementation files, but should define the canonical chain that future implementations must satisfy:
+
+```text
+Evidence → Assertion → Claim → Attestation → Verification → Standing → Capability → Authority → Decision
+```
+
+The most important gap is the absence of **Assertion** and **Standing** as first-class protocol concepts. Existing systems imply both concepts, but neither is defined as the constitutional bridge between evidence, claims, verification, capabilities, and decisions.
+
+---
+
+## Audit Method
+
+The audit reviewed repository locations containing trust-adjacent concepts, including:
+
+- `packages/protocol/src/claims/`
+- `packages/identity/src/`
+- `runtime/trust/`
+- `runtime/attestations/`
+- `runtime/governance/`
+- `protocol/identity/`
+- `protocol/capability/`
+- `protocol/capabilities/`
+- `protocol/enforcement/`
+- `protocol/policy/`
+- `protocol/governance/`
+- `docs/rfcs/RFC-004-evidence-layer-v1.md`
+- `protocol/charter/README.md`
+- `protocol/protocol-invariants-spec.md`
+
+This audit intentionally did not modify code, runtime behavior, package exports, or implementation contracts.
+
+---
+
+## 1. Existing Claim Concepts
+
+### Locations Reviewed
+
+- `packages/protocol/src/claims/index.ts`
+- `packages/identity/src/contracts.ts`
+- `runtime/trust/types.ts`
+- `protocol/identity/types.ts`
+- `protocol/identity/trust-chain.ts`
+
+### Findings
+
+1. A minimal protocol-level claim interface exists with a `type` and primitive `value` shape.
+2. The identity package defines richer claims with name, value, issuer, issued timestamp, optional expiration, and confidence.
+3. Identity contracts already embed claims as part of principal identity state.
+4. Trust metadata in identity contracts references assurance level, verification methods, trust frameworks, attestation time, attester identity, and risk flags.
+5. Credential records in the trust runtime imply claims about KYC level, issuer, subject, credential hash, issuance, expiration, and revocation.
+
+### Gap
+
+The repository lacks a canonical definition that distinguishes:
+
+- raw assertion of facts,
+- formal claims,
+- attested claims,
+- verified claims,
+- currently active claims.
+
+Claims exist structurally, but the repository does not yet define their constitutional meaning.
+
+---
+
+## 2. Existing Evidence Concepts
+
+### Locations Reviewed
+
+- `docs/rfcs/RFC-004-evidence-layer-v1.md`
+- `protocol/audit/`
+- `runtime/attestations/integrity-proof.ts`
+- `protocol/policy/decision-trace.ts`
+
+### Findings
+
+1. RFC-004 defines the Evidence Layer as a protocol-neutral model for artifacts with evidentiary value.
+2. RFC-004 already emphasizes intrinsic verifiability, infrastructure independence, portability, public verification rules, integrity by structure, and persistence beyond producers.
+3. Audit-plane and decision trace modules provide operational records that can become evidence for governance or runtime decisions.
+4. Integrity proof types in attestation runtime provide hash and chain semantics that can support evidentiary integrity.
+
+### Gap
+
+Evidence is well specified as a layer, but its relationship to claims is not canonically defined. RFC-005 should state that evidence does not directly become authority; evidence first supports assertions, which are then formalized into claims.
+
+---
+
+## 3. Existing Attestation Concepts
+
+### Locations Reviewed
+
+- `runtime/attestations/types.ts`
+- `runtime/attestations/attestation-chain.ts`
+- `runtime/attestations/governance-attestation.ts`
+- `runtime/attestations/capability-attestation.ts`
+- `runtime/attestations/ai-attestation.ts`
+- `runtime/attestations/remote-attestation.ts`
+
+### Findings
+
+1. Runtime attestations cover governance decisions, capability issuance/use, delegation validation, AI execution, remote governance, and audit snapshots.
+2. Governance attestations bind actor, governance session, policy trace, relationship, capabilities, decision, issue time, integrity proof, and optional previous attestation.
+3. Capability attestations bind capability identity to an issuing runtime, governance attestation, validity window, and revocation references.
+4. AI and remote governance attestations already recognize non-human and federated attesters.
+5. Integrity proof support exists for local hashes, chained hashes, and replay guards.
+
+### Gap
+
+Attestations currently support runtime events and governance state, but no canonical document defines attestation as a signed declaration supporting a claim. RFC-005 should make attestation distinct from the claim itself.
+
+---
+
+## 4. Existing Verification Concepts
+
+### Locations Reviewed
+
+- `runtime/trust/service.ts`
+- `protocol/capability/capability-verify.ts`
+- `protocol/capability/capability-state.ts`
+- `protocol/enforcement/enforcement-engine.ts`
+- `protocol/enforcement/enforcement-types.ts`
+- `runtime/attestations/*validation*` and validation helpers
+
+### Findings
+
+1. Identity verification evaluates credential existence, issuer activity, credential revocation, expiration, and consent requirements.
+2. Capability verification and enforcement evaluate capability validity, revocation, activation window, expiration, scope, permission, subject, grantee, and market-maker constraints.
+3. Attestation validators produce validation results and reason lists.
+4. Enforcement decisions are deterministic and expose allow/deny decision states with reason codes and evaluated context.
+
+### Gap
+
+Verification exists in multiple runtime-specific forms. RFC-005 should define verification as a protocol concept: evidence evaluation, attestation validation, policy validation, and chain validation.
+
+---
+
+## 5. Existing Standing Concepts
+
+### Locations Reviewed
+
+- `protocol/capability/capability-types.ts`
+- `protocol/capability/capability-state.ts`
+- `runtime/trust/types.ts`
+- `runtime/trust/service.ts`
+- `packages/identity/src/contracts.ts`
+
+### Findings
+
+1. Capability state already includes active, expired, not-yet-active, revoked, and invalid.
+2. Identity contracts include status values active, suspended, and revoked.
+3. Credential records include expiration and revocation timestamps.
+4. Verification outputs distinguish verified, not found, issuer inactive, expired, revoked, and consent required.
+
+### Gap
+
+The concept of **Standing** is strongly implied but not named as a first-class constitutional concept. RFC-005 should define standing as the current validity state of a claim and explain that a historically true claim may not be active authority.
+
+---
+
+## 6. Existing Capability Concepts
+
+### Locations Reviewed
+
+- `protocol/capability/`
+- `protocol/capabilities/`
+- `capability/`
+- `aoc/capabilities/`
+- `packages/capability-runtime/`
+- `packages/capability-tokens/`
+- `CAPABILITY_ATTENUATION_MODEL.md`
+
+### Findings
+
+1. AOC has extensive capability token, lifecycle, attenuation, delegation, enforcement, and consumption semantics.
+2. Capabilities include subject, grantee, scope, permissions, issue and expiration windows, parent consent reference, and hash identity.
+3. The capability attenuation model already states that child authority is subset-only and removed authority cannot be reintroduced.
+4. Capability evaluation produces reason codes and explainable allow/deny outcomes.
+
+### Gap
+
+Capabilities are currently implemented primarily as authorization/runtime artifacts, but their constitutional derivation from standing claims is not explicit. RFC-005 should define a capability as permission derived from standing claims and policy.
+
+---
+
+## 7. Existing Authority Concepts
+
+### Locations Reviewed
+
+- `runtime/governance/types.ts`
+- `runtime/governance/autonomous-governance-runtime.ts`
+- `protocol/identity/delegation.ts`
+- `protocol/capability-delegation/`
+- `CAPABILITY_ATTENUATION_MODEL.md`
+
+### Findings
+
+1. Machine authority profiles include authority ID, machine actor, issuer, capability allow list, namespace allow list, trust path, delegation chain, issue time, expiration, and revocation.
+2. Autonomous execution grants bind authority to machine actors, scopes, issue time, expiration, and revocation.
+3. Delegation and attenuation concepts ensure derived authority cannot exceed parent authority.
+4. Governance decision outputs contain lineage, trust path, capability provenance, and authority source.
+
+### Gap
+
+Authority is implemented in specific runtime contexts, especially autonomous and machine governance, but there is no universal definition stating that authority is derived, explainable, policy-bound, and never assumed solely from identity or claim presence.
+
+---
+
+## 8. Existing Governance and Decision Concepts
+
+### Locations Reviewed
+
+- `runtime/governance/`
+- `protocol/governance/governance-compliance-spec.md`
+- `docs/governance/`
+- `protocol/policy/decision-trace.ts`
+- `protocol/enforcement/enforcement-types.ts`
+- `protocol/execution/`
+
+### Findings
+
+1. Governance runtime tracks session states such as pending, evaluating, approved, denied, escalated, awaiting human review, completed, and failed.
+2. Governance obligations include purpose assertions, frequency enforcement, AI escalation, human review, relationship validation, consent reaffirmation, machine audit, machine escalation, machine approval, machine reconciliation, and machine expiration.
+3. Policy traces record evaluated policies, decision reason, actor, resource, and evaluation time.
+4. Enforcement decisions expose allow/deny state, reason code, reasons, evaluated time, normalized request, normalized capability, matched scope, and matched permissions.
+5. Governance compliance emphasizes invariant preservation, auditability, and respect for Vault decisions.
+
+### Gap
+
+Decision traceability exists operationally, but there is no single constitutional requirement that every decision be explainable backward through authority, capability, standing, verification, attestation, claim, assertion, and evidence.
+
+---
+
+## 9. Constitutional Alignment Findings
+
+### Charter Alignment
+
+The AOC Charter emphasizes self-sovereignty, consent-first architecture, local-first/global-compatible infrastructure, minimal trust surfaces, market neutrality, open-source auditable specifications, and transparent governance. RFC-005 should align trust and authority with these principles by requiring explicit, portable, verifiable, and explainable chains.
+
+### Protocol Invariant Alignment
+
+The protocol invariants specification provides a cross-object registry and enforcement posture for authorization, integrity, security, lifecycle, and audit requirements. RFC-005 should define conceptual invariants for trust and authority chains without replacing object-level invariants.
+
+### Governance Compliance Alignment
+
+Governance compliance requires implementers not to weaken protocol invariants, to respect access decisions, and to provide auditability. RFC-005 should supply the conceptual foundation that explains why those requirements exist.
+
+---
+
+## 10. Gaps Discovered
+
+1. **Assertion is missing as a first-class concept.** Evidence is interpreted in practice, but interpretation is not named or governed.
+2. **Standing is missing as a first-class concept.** Expiration, revocation, suspension, and active state exist, but are not unified across claim types.
+3. **Claim truth is not separated from claim form.** Existing claim structures may imply that formatted claims are accepted facts.
+4. **Attestation is not canonically linked to claims.** Runtime attestations exist, but claim support semantics are not formalized.
+5. **Authority is not universally derived.** Runtime authority exists in specific contexts, but not yet as a general protocol rule.
+6. **Explainability chain is incomplete.** Decisions have traces and reason codes, but no constitutional backward chain exists across all layers.
+7. **Credentials are not canonically defined as claim collections.** Credential records exist, but credential semantics should be defined at the concept layer.
+8. **No single trust graph model exists.** Trust relationships are spread across identity, credential, capability, policy, runtime governance, and evidence concepts.
+
+---
+
+## 11. Future RFC Recommendations
+
+Future RFCs should build from RFC-005 and define:
+
+1. **Claim Schema RFC** — canonical claim object fields, subject/issuer models, claim type registry, temporal fields, and evidence references.
+2. **Verification Engine RFC** — deterministic verification inputs, outputs, reason codes, assurance levels, and policy hooks.
+3. **Standing Engine RFC** — canonical standing states, transitions, revocation/suspension/supersession semantics, and historical validity rules.
+4. **Authority Engine RFC** — derivation of authority from standing claims, capability grants, delegation constraints, and policy.
+5. **Credential Framework RFC** — credential as a portable bundle of claims, attestations, evidence references, and standing metadata.
+6. **Trust Graph RFC** — graph model linking principals, identities, claims, attestations, evidence, policies, capabilities, and decisions.
+7. **Runtime Authorization RFC** — mapping constitutional authority concepts to enforcement engines and runtime decision points.
+
+---
+
+## Conclusion
+
+The repository contains mature partial implementations for claims, identity, evidence, attestations, verification, capability enforcement, governance sessions, policy traces, trust services, and authority profiles. These pieces are consistent with a larger trust model, but they require constitutional unification.
+
+RFC-005 should become the canonical document that defines the trust and authority chain for all future AOC ecosystem implementations.

--- a/docs/rfcs/RFC-005-Claims-Framework.md
+++ b/docs/rfcs/RFC-005-Claims-Framework.md
@@ -1,0 +1,1106 @@
+# RFC-005 — AOC Claims Framework: Canonical Trust and Authority Model
+
+| Field | Value |
+|---|---|
+| RFC Number | 005 |
+| Title | AOC Claims Framework: Canonical Trust and Authority Model |
+| Status | Draft |
+| Category | Core Protocol / Constitutional Specification |
+| Authors | AOC Protocol Architecture Working Group |
+| Created | 2026-06-02 |
+| Last Updated | 2026-06-02 |
+| Supersedes | — |
+| Related | AOC Charter, RFC-004 Evidence Layer v1.0, Governance Compliance Specification, Protocol Invariants Specification |
+
+---
+
+## Abstract
+
+This RFC defines the canonical trust and authority model for the Architects of Change Protocol ecosystem. It introduces a constitutional chain connecting evidence, assertions, claims, attestations, verification, standing, capabilities, authority, and decisions.
+
+The canonical chain is:
+
+```text
+Evidence
+  ↓
+Assertion
+  ↓
+Claim
+  ↓
+Attestation
+  ↓
+Verification
+  ↓
+Standing
+  ↓
+Capability
+  ↓
+Authority
+  ↓
+Decision
+```
+
+This RFC is concept-first and implementation-neutral. It does not define a database schema, API, runtime engine, storage model, credential format, or product implementation. It defines the protocol concepts that all future AOC implementations must preserve.
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Definitions](#2-definitions)
+3. [The Trust Chain](#3-the-trust-chain)
+4. [The Authority Chain](#4-the-authority-chain)
+5. [Assertions](#5-assertions)
+6. [Claims](#6-claims)
+7. [Attestations](#7-attestations)
+8. [Verification](#8-verification)
+9. [Standing](#9-standing)
+10. [Capabilities](#10-capabilities)
+11. [Authority](#11-authority)
+12. [Decisions](#12-decisions)
+13. [Credentials](#13-credentials)
+14. [Explainability](#14-explainability)
+15. [Constitutional Principles](#15-constitutional-principles)
+16. [Non-Goals](#16-non-goals)
+17. [Future RFC Dependencies](#17-future-rfc-dependencies)
+18. [Conformance](#18-conformance)
+19. [Conclusion](#19-conclusion)
+
+---
+
+## 1. Introduction
+
+Trust in AOC is not an assumption. Trust is a protocol state that must be created, supported, evaluated, maintained, and explained.
+
+A system that merely stores identities, roles, credentials, or permissions does not by itself create trustworthy authority. A person may have an identity but no current authority. A credential may have been valid yesterday but revoked today. A document may exist but not support the interpretation made from it. A decision may be permitted by a user interface but still lack constitutional authority under the protocol.
+
+RFC-005 exists to prevent these failures by requiring every consequential decision in the AOC ecosystem to be explainable through a complete trust and authority chain.
+
+### 1.1 Why trust must be modeled explicitly
+
+Trust must be modeled explicitly because AOC is intended to operate across organizations, jurisdictions, runtimes, products, market makers, autonomous agents, and human governance bodies. In such an ecosystem, there is no single default institution that can be trusted to decide what is true or who is authorized.
+
+Explicit trust modeling ensures that:
+
+- evidence is not confused with interpretation;
+- claims are not confused with truth;
+- attestations are not confused with verification;
+- verification is not confused with current validity;
+- capabilities are not confused with authority;
+- decisions are not accepted without justification.
+
+### 1.2 Why authority cannot be assumed
+
+Authority cannot be inferred solely from identity, employment, role title, possession of a credential, possession of a token, or prior approval. Authority is derived from standing claims and policy in a specific context.
+
+For example, a principal may be the Chief Financial Officer of an organization and still lack authority to approve a specific payment if the relevant budget authority claim has expired, has been suspended, does not cover the requested amount, or is constrained by policy requiring board review.
+
+### 1.3 Why decisions require justification
+
+A decision is a consequential action taken under authority. AOC decisions may approve budgets, deploy systems, grant access, issue credentials, perform AI actions, validate relationships, or execute market-maker operations. Such decisions affect rights, resources, obligations, and trust relationships.
+
+Therefore, a decision must be justified by an authority chain, and that authority chain must be supported by a trust chain.
+
+### 1.4 Why explainability is constitutional
+
+Explainability is a constitutional requirement because AOC is a sovereignty-oriented protocol. Participants must be able to inspect why an action was allowed, denied, escalated, suspended, or revoked. Auditors must be able to reconstruct authority. Governance officers must be able to identify policy failures. Engineers must be able to implement fail-closed systems. Enterprise architects must be able to prove control boundaries.
+
+A decision that cannot be explained is not constitutionally complete under RFC-005.
+
+---
+
+## 2. Definitions
+
+The following definitions are canonical for RFC-005. They are protocol-neutral and implementation-neutral.
+
+### 2.1 Evidence
+
+**Evidence** is a record, artifact, observation, event, document, trace, or proof that can support an interpretation about a subject, action, state, or event.
+
+Evidence may be digital or physical, direct or indirect, human-produced or machine-produced. Evidence does not, by itself, determine what conclusion should be drawn from it.
+
+### 2.2 Assertion
+
+**Assertion** is an interpretation made from evidence.
+
+An assertion expresses what a principal, system, policy, auditor, or governance process believes the evidence indicates. Assertions are distinct from claims because they are interpretive bridges between evidence and formal protocol statements.
+
+### 2.3 Claim
+
+**Claim** is a formal statement asserted about a subject.
+
+A claim may describe identity, role, certification, authorization, capability eligibility, relationship, compliance status, governance status, or another protocol-relevant fact. A claim is not automatically true merely because it is well formed.
+
+### 2.4 Attestation
+
+**Attestation** is a signed or otherwise attributable declaration supporting a claim.
+
+An attestation binds an attester to a declaration that a claim is supported according to some context, evidence, policy, or authority. Attestation is not identical to verification.
+
+### 2.5 Verification
+
+**Verification** is the process of evaluating whether a claim is supported.
+
+Verification may evaluate evidence, attestations, signatures, issuer status, policy requirements, temporal validity, revocation state, chain integrity, and conformance to protocol rules.
+
+### 2.6 Standing
+
+**Standing** is the current validity state of a claim.
+
+Standing answers whether a claim is currently usable for trust, capability, authority, or decision purposes. A claim may be historically true but lack current standing.
+
+### 2.7 Capability
+
+**Capability** is a permission derived from standing claims and policy.
+
+A capability expresses what a principal or system may do within defined scope, constraints, time bounds, and context. A capability is not self-justifying; it must be derivable from standing claims and policy.
+
+### 2.8 Authority
+
+**Authority** is the recognized ability to make a decision in a defined context.
+
+Authority is derived from standing claims, capabilities, delegation rules, governance policy, and applicable constraints. Authority is not assumed from identity alone.
+
+### 2.9 Decision
+
+**Decision** is an action or determination taken under authority.
+
+A decision may allow, deny, approve, revoke, suspend, issue, deploy, grant, escalate, or otherwise alter protocol state or organizational state.
+
+### 2.10 Credential
+
+**Credential** is a collection of claims packaged for presentation, verification, or recognition.
+
+A credential may include evidence references, attestations, issuer metadata, verification methods, standing metadata, and expiration or revocation information.
+
+### 2.11 Principal
+
+**Principal** is an entity capable of being the subject, issuer, attester, verifier, authority holder, delegate, or actor in a protocol context.
+
+A principal may be a human, organization, service, workload, AI agent, governance body, runtime, or remote system.
+
+### 2.12 Identity
+
+**Identity** is the protocol-recognized representation of a principal.
+
+Identity may include identifiers, claims, credentials, status, trust metadata, tenant context, federation context, and other attributes needed to distinguish and evaluate the principal.
+
+---
+
+## 3. The Trust Chain
+
+The canonical trust chain is:
+
+```text
+Evidence
+  ↓
+Assertion
+  ↓
+Claim
+  ↓
+Attestation
+  ↓
+Verification
+  ↓
+Standing
+```
+
+This chain defines how information becomes usable trust state.
+
+### 3.1 Evidence → Assertion
+
+Evidence becomes meaningful only when interpreted. A board resolution, employment agreement, certificate, signed audit report, machine log, policy trace, or governance record may support multiple interpretations. The assertion layer captures the specific interpretation being made.
+
+Example:
+
+- Evidence: Board resolution dated 2026-05-15.
+- Assertion: Victor may approve operating budgets up to USD 250,000 for the Growth Division.
+
+Skipping this layer is dangerous because evidence may be ambiguous. A document may show that a meeting occurred without proving that a specific authority was granted.
+
+### 3.2 Assertion → Claim
+
+An assertion becomes a claim when it is formalized as a protocol statement about a subject.
+
+Example:
+
+- Assertion: Victor may approve operating budgets up to USD 250,000 for the Growth Division.
+- Claim: Budget Approval Authority Claim for subject `Victor`, scope `Growth Division`, limit `USD 250,000`, source assertion `Board Resolution Interpretation`.
+
+Skipping this layer is dangerous because informal interpretations cannot be consistently verified, exchanged, audited, revoked, or used by policy engines.
+
+### 3.3 Claim → Attestation
+
+A claim is supported when an attester declares that the claim is valid, accurate, or otherwise acceptable according to the attester's authority and context.
+
+Example:
+
+- Claim: Victor has budget approval authority up to USD 250,000.
+- Attestation: Corporate Secretary signs an attestation that the claim reflects the approved board resolution.
+
+Skipping this layer is dangerous because a claim without attributable support may be self-asserted, forged, stale, or outside the issuer's authority.
+
+### 3.4 Attestation → Verification
+
+An attestation must be evaluated. Verification determines whether the attestation is authentic, attributable, current, policy-compatible, and sufficient for the claim it supports.
+
+Example verification questions:
+
+- Was the attestation signed by a recognized attester?
+- Was the attester authorized to support this claim type?
+- Does the evidence match the claim scope?
+- Has the attestation expired, been revoked, or been superseded?
+- Does policy require multiple attestations?
+
+Skipping this layer is dangerous because signed statements may be invalid, compromised, mis-scoped, unauthorized, or insufficient.
+
+### 3.5 Verification → Standing
+
+Verification produces an evaluation result. Standing expresses whether the claim is currently usable.
+
+Example:
+
+- Verification result: The claim was validly issued and supported on 2026-05-15.
+- Standing on 2026-06-02: Active.
+- Standing on 2027-06-02 after expiration: Expired.
+- Standing after board repeal: Revoked or Superseded.
+
+Skipping this layer is dangerous because historical truth does not imply present authority. A claim may have been verified in the past and still be unusable today.
+
+### 3.6 Trust Chain Examples
+
+#### Budget authority
+
+```text
+Board Resolution
+  ↓
+Victor may approve Growth Division budgets up to USD 250,000
+  ↓
+Budget Approval Authority Claim
+  ↓
+Corporate Secretary Attestation
+  ↓
+Verification of signature, scope, policy, and board authority
+  ↓
+Active standing until expiration, revocation, or supersession
+```
+
+#### Security certification
+
+```text
+Certification exam record and provider certificate
+  ↓
+Asha passed the required cloud security certification
+  ↓
+Security Certification Claim
+  ↓
+Certification Authority Attestation
+  ↓
+Verification of issuer, credential hash, date, and revocation registry
+  ↓
+Active, Expired, Suspended, Revoked, or Superseded standing
+```
+
+#### AI execution trust
+
+```text
+Model execution logs and policy trace
+  ↓
+AI agent executed within approved scope
+  ↓
+AI Execution Compliance Claim
+  ↓
+Runtime Attestation
+  ↓
+Verification of runtime identity, trace integrity, policy match, and replay protection
+  ↓
+Active or invalid standing for audit and future authority analysis
+```
+
+---
+
+## 4. The Authority Chain
+
+The canonical authority chain is:
+
+```text
+Claim
+  ↓
+Capability
+  ↓
+Authority
+  ↓
+Decision
+```
+
+In full constitutional form, it is preceded by the trust chain:
+
+```text
+Evidence → Assertion → Claim → Attestation → Verification → Standing → Capability → Authority → Decision
+```
+
+### 4.1 Claim does not automatically grant authority
+
+A claim is a formal statement. It may be false, unsupported, unverified, expired, revoked, suspended, superseded, mis-scoped, or insufficient. Therefore, a claim never grants authority merely by existing.
+
+Examples:
+
+- An identity claim does not automatically grant system access.
+- A role claim does not automatically grant budget authority.
+- A certification claim does not automatically authorize production deployment.
+- A credential claim does not automatically authorize credential issuance.
+
+### 4.2 Authority emerges from verified claims and policy
+
+Authority is derived when standing claims satisfy policy requirements for a specific decision context.
+
+For example:
+
+1. Victor has an active identity claim.
+2. Victor has an active role claim as Growth Division CFO.
+3. Victor has an active budget authority claim up to USD 250,000.
+4. Policy permits Growth Division CFOs with budget authority standing to approve operating budgets under USD 250,000.
+5. A capability is derived: `CanApproveBudget` for the relevant scope and limit.
+6. Authority is recognized for the specific approval decision.
+7. The decision is recorded and explainable.
+
+---
+
+## 5. Assertions
+
+Assertion is a first-class protocol concept in RFC-005.
+
+### 5.1 Definition
+
+```text
+Assertion = an interpretation made from evidence.
+```
+
+Assertions are necessary because evidence rarely speaks in protocol-native form. Evidence must be read, interpreted, scoped, and translated into meaning before it can become a formal claim.
+
+### 5.2 Example
+
+```text
+Evidence:
+  Board Resolution
+
+Assertion:
+  Victor may approve budgets.
+
+Claim:
+  Approved Budget Authority Claim
+```
+
+### 5.3 Why assertion is distinct from claim
+
+Assertion is distinct from claim because an assertion captures interpretive meaning, while a claim captures formal protocol meaning.
+
+An assertion may be:
+
+- disputed;
+- incomplete;
+- ambiguous;
+- context-dependent;
+- human-reviewed;
+- machine-derived;
+- one of several possible interpretations of the same evidence.
+
+A claim must be formal enough to be exchanged, attested, verified, evaluated for standing, and consumed by policy.
+
+### 5.4 Assertion requirements
+
+A conformant future implementation that represents assertions SHOULD identify:
+
+- the evidence being interpreted;
+- the subject of the interpretation;
+- the interpreter or process making the interpretation;
+- the time of interpretation;
+- the claim type or claim family the assertion may support;
+- any ambiguity, confidence, or review status relevant to the interpretation.
+
+This RFC does not mandate a storage schema for assertions.
+
+---
+
+## 6. Claims
+
+### 6.1 Definition
+
+```text
+Claim = a formal statement asserted about a subject.
+```
+
+A claim is the canonical unit of formal trust expression in AOC.
+
+### 6.2 Claim examples
+
+Examples include:
+
+- **Identity Claim** — a statement about who or what a principal is.
+- **Capability Claim** — a statement that a principal satisfies prerequisites for a capability.
+- **Certification Claim** — a statement that a principal holds a certification.
+- **Role Claim** — a statement that a principal occupies a role.
+- **Authorization Claim** — a statement that a principal is eligible for a specific authorization.
+- **Relationship Claim** — a statement that a principal has a relationship to another principal or entity.
+- **Compliance Claim** — a statement that a principal, process, or artifact satisfies a requirement.
+- **Governance Claim** — a statement about approval, review, delegation, mandate, quorum, or policy outcome.
+
+### 6.3 Claims are not automatically true
+
+A claim is not truth. A claim is a formal assertion that must be supported, attested, verified, and evaluated for standing before it can participate in authority.
+
+AOC implementations MUST NOT treat claim presence alone as sufficient authority.
+
+### 6.4 Claim subjects and issuers
+
+A claim SHOULD distinguish at least:
+
+- the subject the claim is about;
+- the issuer or originator of the claim;
+- the claim type;
+- the claim value or statement;
+- temporal boundaries, when relevant;
+- supporting assertion or evidence references, when available;
+- attestation and verification references, when available.
+
+This RFC does not require a specific claim schema. A future Claim Schema RFC should define canonical fields.
+
+---
+
+## 7. Attestations
+
+### 7.1 Definition
+
+```text
+Attestation = a signed declaration supporting a claim.
+```
+
+An attestation creates accountability. It answers: who, or what, stands behind this claim?
+
+### 7.2 Attester examples
+
+Attesters may include:
+
+- an organization;
+- a person;
+- an AI system;
+- a remote system;
+- a governance body;
+- a certification authority;
+- a runtime environment;
+- a trust registry;
+- a policy engine;
+- an auditor.
+
+### 7.3 Claim vs Attestation
+
+A claim and an attestation are different protocol concepts.
+
+| Concept | Purpose | Question Answered |
+|---|---|---|
+| Claim | Formal statement about a subject | What is being asserted? |
+| Attestation | Attributable support for a claim | Who or what supports it? |
+
+A claim may exist without an attestation, but such a claim may lack sufficient support for verification. An attestation may support one claim, multiple claims, or a claim family, depending on future schema definitions.
+
+### 7.4 Attestation requirements
+
+A conformant attestation model SHOULD identify:
+
+- the claim or claims supported;
+- the attester;
+- the attester's authority or role;
+- the time of attestation;
+- the signature or attribution mechanism;
+- supporting evidence references;
+- validity window;
+- revocation or supersession references;
+- integrity proof or audit reference, when relevant.
+
+---
+
+## 8. Verification
+
+### 8.1 Definition
+
+```text
+Verification = the process of evaluating whether a claim is supported.
+```
+
+Verification is an evaluation process, not a document, token, credential, or mere signature check.
+
+### 8.2 Evidence evaluation
+
+Evidence evaluation determines whether referenced evidence is authentic, relevant, sufficient, unmodified, and appropriate for the assertion and claim.
+
+Evidence evaluation may include:
+
+- artifact integrity checks;
+- content-address verification;
+- provenance evaluation;
+- timestamp evaluation;
+- audit trace inspection;
+- document review;
+- chain-of-custody review;
+- policy-specific sufficiency checks.
+
+### 8.3 Attestation validation
+
+Attestation validation determines whether the attestation is attributable, authentic, scoped, current, and issued by a recognized attester.
+
+Attestation validation may include:
+
+- signature verification;
+- attester identity verification;
+- issuer registry lookup;
+- validity window evaluation;
+- revocation check;
+- replay protection;
+- integrity proof validation;
+- delegation chain validation.
+
+### 8.4 Policy validation
+
+Policy validation determines whether the claim and its support satisfy the rules required for the relevant context.
+
+Policy may require:
+
+- a specific issuer;
+- a minimum assurance level;
+- multiple independent attestations;
+- human review;
+- governance approval;
+- active consent;
+- jurisdictional constraints;
+- relationship validation;
+- risk thresholds;
+- non-expired evidence.
+
+### 8.5 Chain validation
+
+Chain validation determines whether the full chain from evidence to standing is coherent.
+
+A verification result SHOULD explain:
+
+- what was evaluated;
+- what passed;
+- what failed;
+- which policies were applied;
+- which reasons support the outcome;
+- whether the claim can receive standing;
+- which standing states are possible.
+
+---
+
+## 9. Standing
+
+Standing is critical to RFC-005.
+
+### 9.1 Definition
+
+```text
+Standing = the current validity state of a claim.
+```
+
+Standing is not the same as verification. Verification may establish that a claim was properly supported at a point in time. Standing determines whether that claim is currently usable.
+
+### 9.2 Canonical standing states
+
+RFC-005 defines the following canonical standing states:
+
+| Standing | Meaning |
+|---|---|
+| `Verified` | The claim has been evaluated and found supported, but may still require activation or contextual checks before use. |
+| `Active` | The claim is currently valid and usable for its permitted purposes. |
+| `Expired` | The claim passed its validity window and is no longer currently usable. |
+| `Suspended` | The claim is temporarily disabled pending review, remediation, appeal, or additional verification. |
+| `Revoked` | The claim has been invalidated by an authorized revocation process. |
+| `Superseded` | The claim has been replaced by a newer claim, policy, authority, credential, or governance decision. |
+| `Invalid` | The claim failed verification, violates protocol rules, or cannot be trusted for use. |
+| `Not Yet Active` | The claim is validly issued but its activation time has not arrived. |
+
+Future standing engines MAY define additional implementation states, but they MUST map them to these canonical states for protocol-level interpretation.
+
+### 9.3 Historical truth vs active standing
+
+A claim may be historically true but no longer active.
+
+Examples:
+
+- A professional license was valid in 2024 but expired in 2025.
+- A budget authority claim was active until the board revoked it.
+- A security certification was valid until superseded by a newer version requirement.
+- A delegated authority was valid until the parent authority was revoked.
+- An identity credential was valid until the issuer became inactive.
+
+Systems MUST distinguish historical verification from current standing.
+
+### 9.4 Standing and authority
+
+Only claims with standing acceptable under applicable policy may participate in capability derivation or authority recognition.
+
+A policy may permit `Verified` standing for some low-risk decisions, require `Active` standing for consequential decisions, or reject suspended, expired, revoked, superseded, invalid, or not-yet-active claims.
+
+---
+
+## 10. Capabilities
+
+### 10.1 Definition
+
+```text
+Capability = a permission derived from standing claims.
+```
+
+Capabilities operationalize trust into bounded permissions.
+
+### 10.2 Capability examples
+
+Examples include:
+
+- `CanApproveBudget`
+- `CanDeploySystem`
+- `CanIssueCredential`
+- `CanGrantAuthority`
+- `CanAccessData`
+- `CanDelegateCapability`
+- `CanPerformHumanReview`
+- `CanRunAutonomousExecution`
+
+### 10.3 Capability derivation
+
+A capability SHOULD be derived from:
+
+- one or more standing claims;
+- applicable governance or authorization policy;
+- scope constraints;
+- permission constraints;
+- temporal constraints;
+- delegation constraints;
+- subject and grantee constraints;
+- revocation and suspension state;
+- risk and assurance requirements.
+
+### 10.4 Capability constraints
+
+Capabilities MUST be bounded. A capability without scope, time, subject, policy, or revocation semantics creates unbounded authority and is incompatible with RFC-005.
+
+Capabilities SHOULD be explainable by identifying the standing claims and policies that produced them.
+
+---
+
+## 11. Authority
+
+### 11.1 Definition
+
+```text
+Authority = recognized ability to make a decision.
+```
+
+Authority is contextual. A principal may have authority for one decision and lack authority for another.
+
+### 11.2 Authority is derived
+
+Authority is derived from:
+
+- standing claims;
+- capabilities;
+- governance policy;
+- delegation rules;
+- relationship context;
+- consent state;
+- risk controls;
+- temporal bounds;
+- jurisdictional or enterprise constraints, when applicable.
+
+### 11.3 Authority is not assumed
+
+Authority MUST NOT be assumed from:
+
+- identity alone;
+- role title alone;
+- token possession alone;
+- prior decision alone;
+- self-asserted claim alone;
+- UI access alone;
+- organizational hierarchy alone;
+- AI agent configuration alone.
+
+### 11.4 Authority must be explainable
+
+An authority determination MUST be explainable by reference to the capabilities, standing claims, verification results, attestations, claims, assertions, and evidence that support it.
+
+If a system cannot explain an authority determination, it SHOULD fail closed for consequential decisions.
+
+---
+
+## 12. Decisions
+
+### 12.1 Definition
+
+```text
+Decision = an action taken under authority.
+```
+
+A decision is the endpoint of the trust and authority model.
+
+### 12.2 Decision examples
+
+Examples include:
+
+- approve a budget;
+- deploy software;
+- grant access;
+- issue a credential;
+- revoke a credential;
+- approve a governance proposal;
+- deny a data access request;
+- escalate to human review;
+- authorize an AI agent action;
+- validate a delegation;
+- suspend a capability.
+
+### 12.3 Traceability requirement
+
+Every consequential decision MUST be traceable.
+
+A decision trace SHOULD identify:
+
+- the decision actor;
+- the decision subject or target;
+- the requested action;
+- the authority used;
+- the capability or capabilities invoked;
+- standing claims relied upon;
+- verification outcomes;
+- attestations relied upon;
+- claims evaluated;
+- assertions and evidence references;
+- policies applied;
+- reasons for allow, deny, escalation, or condition;
+- timestamp;
+- audit or evidence record.
+
+---
+
+## 13. Credentials
+
+### 13.1 Definition
+
+```text
+Credential = a collection of claims.
+```
+
+A credential packages claims for presentation, recognition, verification, or governance use.
+
+### 13.2 Credential examples
+
+Examples include:
+
+- PMP Credential;
+- Security Certification;
+- Professional License;
+- KYC Credential;
+- Employment Credential;
+- Training Completion Credential;
+- Governance Delegate Credential;
+- AI Runtime Compliance Credential.
+
+### 13.3 Credential semantics
+
+A credential may contain multiple claims with different standing states.
+
+For example, a professional credential may include:
+
+- identity claim;
+- issuer claim;
+- certification claim;
+- expiration claim;
+- scope claim;
+- continuing education claim;
+- revocation status claim.
+
+The credential itself may be recognized only if required claims have acceptable standing under policy.
+
+### 13.4 Credential does not equal authority
+
+A credential does not automatically grant authority. It may support claims that, if verified and active, may contribute to capability derivation and authority recognition.
+
+---
+
+## 14. Explainability
+
+Every consequential decision must be explainable through the full constitutional chain:
+
+```text
+Decision
+  ↓
+Authority
+  ↓
+Capability
+  ↓
+Standing
+  ↓
+Verification
+  ↓
+Attestation
+  ↓
+Claim
+  ↓
+Assertion
+  ↓
+Evidence
+```
+
+### 14.1 Explainability as backward reconstruction
+
+Explainability is the ability to reconstruct why a decision was made by walking backward from the decision to the evidence.
+
+A complete explanation answers:
+
+1. What decision was made?
+2. Who or what had authority to make it?
+3. Which capability enabled that authority?
+4. Which standing claims supported the capability?
+5. How were those claims verified?
+6. Which attestations supported those claims?
+7. What claims were being supported?
+8. What assertions led to those claims?
+9. What evidence supported those assertions?
+
+### 14.2 Example: budget approval
+
+```text
+Decision:
+  Approve Growth Division operating budget of USD 180,000.
+
+Authority:
+  Victor recognized as authorized budget approver for Growth Division budgets below USD 250,000.
+
+Capability:
+  CanApproveBudget(scope=Growth Division, limit=USD 250,000).
+
+Standing:
+  Budget Approval Authority Claim is Active.
+
+Verification:
+  Signature, board authority, amount scope, division scope, and revocation registry verified.
+
+Attestation:
+  Corporate Secretary attested to board resolution interpretation.
+
+Claim:
+  Victor has budget approval authority up to USD 250,000 for Growth Division.
+
+Assertion:
+  Board resolution grants Victor that authority.
+
+Evidence:
+  Signed board resolution and meeting minutes.
+```
+
+### 14.3 Example: production deployment
+
+```text
+Decision:
+  Deploy release v4.2 to production.
+
+Authority:
+  Release manager has authority under production deployment policy.
+
+Capability:
+  CanDeploySystem(system=JAPI, environment=production).
+
+Standing:
+  Security Certification Claim Active; Release Manager Role Claim Active; Change Approval Claim Active.
+
+Verification:
+  Credential issuer, HR role source, change approval workflow, and policy trace verified.
+
+Attestation:
+  Certification provider, HR system, and change-control board attestations.
+
+Claim:
+  Principal is certified, assigned release manager, and approved for this change.
+
+Assertion:
+  Records indicate principal satisfies deployment prerequisites.
+
+Evidence:
+  Certification record, HR assignment record, change approval record, policy trace.
+```
+
+### 14.4 Example: credential issuance
+
+```text
+Decision:
+  Issue Professional License Credential.
+
+Authority:
+  Licensing board officer recognized as authorized issuer.
+
+Capability:
+  CanIssueCredential(type=ProfessionalLicense).
+
+Standing:
+  Licensing Officer Claim Active; Board Mandate Claim Active.
+
+Verification:
+  Officer appointment, board registry, mandate, and revocation state verified.
+
+Attestation:
+  Licensing board attests officer appointment and mandate.
+
+Claim:
+  Officer may issue professional license credentials.
+
+Assertion:
+  Appointment record authorizes officer to issue licenses.
+
+Evidence:
+  Appointment order, board charter, credential issuance policy.
+```
+
+---
+
+## 15. Constitutional Principles
+
+RFC-005 aligns with existing AOC constitutional and protocol principles.
+
+### 15.1 Alignment with GA-01
+
+For purposes of RFC-005, **GA-01** is treated as the ecosystem governance axiom that protocol authority must be explicit, governed, auditable, and non-arbitrary. RFC-005 operationalizes GA-01 by requiring that authority emerge from standing claims and policy rather than from assumption, hierarchy, or opaque runtime behavior.
+
+RFC-005 supports GA-01 by requiring:
+
+- explicit trust chains;
+- explicit authority chains;
+- explainable decisions;
+- traceable governance actions;
+- non-retroactive interpretation of standing where future policy changes occur;
+- auditable justification for allow, deny, escalation, suspension, or revocation.
+
+### 15.2 Alignment with the AOC Charter
+
+RFC-005 supports the AOC Charter by reinforcing:
+
+- **Self-Sovereignty** — identity, claims, credentials, and evidence cannot be captured by opaque institutional trust.
+- **Consent-First Architecture** — authority over data access must be derived from explicit, standing consent and policy.
+- **Local First, Global Compatible** — trust chains can be implemented locally while preserving globally understandable concepts.
+- **Minimal Trust Surfaces** — trust comes from evidence, attestations, verification, standing, policy, and explainability rather than institutional promises.
+- **Market Neutrality** — any market or product may implement the model if it preserves the canonical chain.
+- **Open Source Commitment** — public, auditable definitions make trust and authority inspectable.
+- **Governance Philosophy** — transparent proposals and public history are reinforced by traceable decisions.
+
+### 15.3 Alignment with RFC-004 Evidence Layer
+
+RFC-005 builds on RFC-004 by defining how evidence participates in trust and authority. RFC-004 defines evidentiary value; RFC-005 defines how evidence supports assertions, claims, attestations, verification, standing, capabilities, authority, and decisions.
+
+### 15.4 Alignment with Protocol Invariants
+
+RFC-005 adds conceptual invariants:
+
+- claim presence is not authority;
+- evidence is not interpretation;
+- attestation is not verification;
+- verification is not standing;
+- standing is required for capability derivation;
+- capability is bounded permission, not unlimited authority;
+- authority is derived and contextual;
+- decisions must be explainable.
+
+These conceptual invariants complement object-level authorization, integrity, lifecycle, security, and audit invariants.
+
+### 15.5 Alignment with Governance Compliance
+
+RFC-005 supports governance compliance by requiring decisions to preserve protocol invariants, respect authority chains, and generate auditable explanations. Market makers, enterprise runtimes, AI agents, credential issuers, and governance systems must not weaken the trust chain when implementing product-specific logic.
+
+---
+
+## 16. Non-Goals
+
+RFC-005 does not define:
+
+- storage systems;
+- database schemas;
+- APIs;
+- runtime implementations;
+- package exports;
+- credential serialization formats;
+- cryptographic algorithms;
+- trust registry implementation details;
+- user interfaces;
+- legal compliance procedures;
+- jurisdiction-specific authority rules;
+- business workflows;
+- product-specific authorization engines.
+
+RFC-005 defines concepts.
+
+Implementations may vary, but they must preserve the constitutional relationships defined here.
+
+---
+
+## 17. Future RFC Dependencies
+
+Future RFCs may build on RFC-005 to define implementation-level models.
+
+### 17.1 Claim Schema
+
+A future Claim Schema RFC should define canonical claim fields, claim identifiers, subject references, issuer references, values, evidence links, assertion references, temporal fields, and claim type registry semantics.
+
+### 17.2 Verification Engine
+
+A future Verification Engine RFC should define verification inputs, outputs, reason codes, assurance levels, policy hooks, attestation validation, evidence evaluation, and deterministic verification semantics.
+
+### 17.3 Standing Engine
+
+A future Standing Engine RFC should define standing state transitions, revocation, suspension, expiration, supersession, appeals, reinstatement, temporal queries, and historical validity semantics.
+
+### 17.4 Authority Engine
+
+A future Authority Engine RFC should define how standing claims and capabilities are evaluated into authority determinations for specific decision contexts.
+
+### 17.5 Credential Framework
+
+A future Credential Framework RFC should define credentials as portable bundles of claims, attestations, evidence references, issuer metadata, holder semantics, presentation rules, and standing metadata.
+
+### 17.6 Trust Graph
+
+A future Trust Graph RFC should define graph semantics connecting principals, identities, claims, assertions, evidence, attestations, verification outcomes, standing states, capabilities, authorities, policies, credentials, and decisions.
+
+### 17.7 Runtime Authorization
+
+A future Runtime Authorization RFC should map the constitutional authority model to enforcement engines, policy decision points, runtime grants, capability tokens, audit traces, and fail-closed decision behavior.
+
+---
+
+## 18. Conformance
+
+A future implementation conforms to RFC-005 when it preserves the following rules:
+
+1. It does not treat evidence as authority without assertion, claim, attestation, verification, standing, capability, and policy evaluation.
+2. It distinguishes assertions from claims.
+3. It distinguishes claims from attestations.
+4. It distinguishes verification from standing.
+5. It does not treat claims as automatically true.
+6. It does not treat credentials as automatically authoritative.
+7. It derives capabilities from standing claims and policy.
+8. It derives authority from capabilities, standing claims, governance context, and policy.
+9. It records or can reconstruct the explanation chain for consequential decisions.
+10. It fails closed when required authority cannot be established for consequential decisions.
+
+---
+
+## 19. Conclusion
+
+RFC-005 establishes the constitutional foundation for identity, trust, authority, governance, runtime authorization, enterprise governance, and future AOC ecosystem products.
+
+The canonical model is:
+
+```text
+Evidence → Assertion → Claim → Attestation → Verification → Standing → Capability → Authority → Decision
+```
+
+All future AOC protocol specifications, runtime implementations, enterprise products, market-maker integrations, AI governance systems, credential frameworks, and trust registries should conform to this model.
+
+RFC-005 establishes the canonical trust and authority model for the AOC ecosystem.


### PR DESCRIPTION
### Motivation
- Provide a single constitutional RFC that unifies scattered claim, evidence, attestation, verification, standing, capability, authority, and decision concepts into a canonical model. 
- The repository audit showed ~70–80% of building blocks exist but lacked a protocol-level specification tying them together, with Assertion and Standing notably absent as first-class concepts. 
- Define a concept-first, implementation-neutral foundation to ensure future runtime/engine RFCs and implementations preserve explainability, provenance, and protocol invariants.

### Description
- Added `docs/rfcs/RFC-005-Claims-Framework.md` which defines the canonical chain: `Evidence → Assertion → Claim → Attestation → Verification → Standing → Capability → Authority → Decision`, provides concise canonical definitions, explains transitions, and specifies conformance rules and non-goals. 
- Added `docs/audits/rfc005-source-audit.md` documenting the repository audit scope, locations reviewed, findings, identified gaps (including missing Assertion/Standing), and recommended follow-up RFCs (Claim Schema, Verification Engine, Standing Engine, Authority Engine, Credential Framework, Trust Graph, Runtime Authorization). 
- This PR is documentation-only and concept-first: it does not change code, APIs, storage, runtime, or package exports; it maps RFC-005 to GA-01, RFC-004, Protocol Invariants, and Governance Compliance for constitutional alignment. 
- Conformance & explainability requirements were included (canonical standing states, capability derivation rules, decision traceability) to guide future implementation RFCs and enforcement engines.

### Testing
- Ran `git diff --cached --check` to validate staged changes and reported no issues. (passed)
- Performed repository searches (`rg`) to confirm RFC and audit content presence and key anchors (Evidence→Assertion, Standing, Constitutional sections); results matched expectations. (passed)
- Verified repository status with `git status --short` and committed the new files; this is a documentation-only change so no unit or runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f5f7bff908325b63572a0e432fc53)