### PR TITLE
Add canonical credential contracts for RFC-005

### DIFF
--- a/.changeset/credential-contracts.md
+++ b/.changeset/credential-contracts.md
@@ -1,0 +1,5 @@
+---
+"@aoc/protocol": patch
+---
+
+Add canonical credential contracts for RFC-005 trust model portability and explainability.

--- a/docs/audits/credential-contract-compliance-audit.md
+++ b/docs/audits/credential-contract-compliance-audit.md
@@ -1,0 +1,124 @@
+# Credential Contract Compliance Audit
+
+Date: 2026-06-03
+
+## Summary
+
+The canonical credential contracts align with the RFC-005 trust model by defining portable descriptors that bundle references to claims, evidence, attestations, proofs, registries, issuers, subjects, and credential status. They deliberately avoid verification, standing, authority, and decision behavior.
+
+## Alignment with RFC-005 Claims Framework
+
+RFC-005 separates evidence, assertions, claims, attestations, verification, standing, capability, authority, and decisions. The credential contracts preserve that separation by making a credential a portable container of references, not a truth engine. `CanonicalCredential.claimRefs` references canonical claims rather than embedding or replacing them. Credential status is a descriptor, not claim standing.
+
+## Alignment with RFC-004 Evidence Layer
+
+RFC-004 treats evidence as support material rather than a conclusion or action. Credential contracts align with that model by allowing `evidenceRefs` and `proofRefs` while avoiding evidence interpretation, proof validation, storage, or enforcement behavior.
+
+## Alignment with A2 Canonical Contracts
+
+The A2 trust model contracts remain authoritative for evidence, assertions, claims, attestations, verifications, standing, capabilities, authorities, and decisions. Credentials add portability around those artifacts. Optional `credentialRefs` were added only to evidence, claims, attestations, verifications, and proof envelopes because those artifacts can reference portable credential descriptors without collapsing into standing, capability, authority, or decision layers.
+
+## Alignment with A3 References
+
+Credential subjects, issuers, holders, and recipients can point to `CanonicalPrincipalRef`. Credential status sources can use canonical source descriptors. This preserves reference portability without proving identity, standing, or authority.
+
+## Alignment with A4 Proofs
+
+Credentials and credential references can include `CanonicalProofRef` values. This supports signature, hash, attestation, integrity, chain, audit, and trace proof portability without implementing proof verification.
+
+## Alignment with A5 Registries
+
+Credential subjects, issuers, references, status references, manifests, attestations, and presentations can include registry entry references. This supports credential registries, issuer registries, status registries, and proof registries without adding lookup, storage, indexing, sync, or registry trust evaluation to AOC Main.
+
+## Why Credential Is Not Claim
+
+A claim is a formal statement about a subject. A credential is a package that references one or more claims and supporting artifacts. A credential can carry a claim reference, but it does not make the claim true or currently usable.
+
+## Why Credential Is Not Proof
+
+A proof is a cryptographic, audit, integrity, chain, attestation, or trace artifact. A credential may reference proofs, but the credential does not validate, compute, or verify proof material.
+
+## Why Credential Is Not Verification
+
+Verification evaluates whether a claim or artifact is supported. Credential contracts contain no verifier behavior, validation methods, signature checking, DID resolution, revocation checking, or VC verification logic.
+
+## Why Credential Is Not Standing
+
+Standing is the current usability state of a claim. A credential status reference can state `Active`, `Revoked`, `Expired`, or another descriptor, but it does not decide whether related claims have standing.
+
+## Why Credential Is Not Authority
+
+Authority is derived from standing claims, capabilities, delegation rules, governance policy, and constraints. Possession or presentation of a credential does not grant authority by itself.
+
+## Why Credential Is Not Decision
+
+A decision is a consequential action taken under authority. Credential presentation can be evidence for later evaluation, but it does not approve, deny, execute, revoke, suspend, escalate, or authorize anything by itself.
+
+## Why Credential Supports Explainability
+
+Credentials improve explainability by preserving portable links among claims, evidence, attestations, proofs, registries, issuers, subjects, and statuses. Auditors and governance systems can inspect which artifacts a credential pointed to without relying on hidden runtime state. Because the contracts are reference-based, explanations can cite the exact claim, proof, registry, issuer, and subject descriptors used by downstream engines.
+
+## Public/Private Boundary
+
+Public Main may define:
+
+- Credential references.
+- Credential descriptors.
+- Credential subjects.
+- Credential issuers.
+- Credential status references.
+- Credential manifests.
+- Credential attestations.
+- Credential presentations.
+
+Private/Enterprise should own:
+
+- Credential issuance.
+- Credential verification.
+- Credential revocation checking.
+- Credential wallet flows.
+- Credential selective disclosure.
+- Credential trust scoring.
+- Credential standing evaluation.
+- Authority derived from credentials.
+- Decision authorization based on credentials.
+
+No private credential logic is implemented in AOC Main.
+
+## Migration Guidance
+
+### Identity
+
+Identity packages may map identity records, actor references, and issuer references into `CanonicalCredentialSubject`, `CanonicalCredentialIssuer`, and `CanonicalCredentialRef`. Identity verification and actor resolution should remain in identity/runtime packages.
+
+### Claims
+
+Claims can reference credentials through optional `credentialRefs` when a portable credential supports the claim. Claims should not embed full credentials or rely on credential possession as proof of truth.
+
+### Proofs
+
+Proof envelopes can reference credentials when proof artifacts are associated with a credential bundle. Signature, hash, chain, audit, and trace validation should remain outside protocol contracts.
+
+### Registries
+
+Registry packages can register or locate credential descriptors using registry entry references and manifests. Lookup, storage, indexing, synchronization, and trust ranking are implementation responsibilities.
+
+### Runtime
+
+Runtime trust services can adapt existing credential records to canonical descriptors at boundaries. Registration, storage, verification, consent checks, revocation checks, and audit emission remain runtime behavior.
+
+### Governance
+
+Governance systems can consume credential references as part of explainable evidence trails. They must still derive standing, capability, authority, and decisions through governance policy and standing evaluation.
+
+### Enterprise
+
+Enterprise systems can implement issuance, wallet, VC, DID, revocation, selective disclosure, trust scoring, and credential lifecycle systems behind the public contracts. Those systems should emit canonical references and descriptors at public boundaries.
+
+## Future Work
+
+- Define optional credential profile guidance for common identity, certification, professional, organization, and system credential descriptors.
+- Define registry profile examples for credential registries and status registries.
+- Define mapping guidance from W3C Verifiable Credentials into canonical descriptors without implementing VC verification.
+- Define enterprise adapter patterns for runtime credential issuance and revocation services.
+- Add examples showing how a credential supports a claim without granting standing or authority.

--- a/docs/audits/credential-contract-source-audit.md
+++ b/docs/audits/credential-contract-source-audit.md
@@ -1,0 +1,201 @@
+# Credential Contract Source Audit
+
+Date: 2026-06-03
+
+## Purpose
+
+This audit reviews existing credential-like concepts before adding public canonical credential contracts for the RFC-005 claims trust model. The review confirms that AOC Main should define portable credential descriptors only: references, subject and issuer descriptors, status references, manifests, attestations, and presentations. Issuance, storage, wallet, revocation checking, verification, standing evaluation, authority derivation, trust scoring, and decision authorization remain outside public protocol contracts.
+
+## Reviewed Files and Directories
+
+- `packages/protocol/src/claims/`
+- `packages/protocol/src/claims/proofs/`
+- `packages/protocol/src/claims/registries/`
+- `packages/protocol/src/contracts/`
+- `packages/identity/`
+- `packages/shared-types/`
+- `runtime/trust/`
+- `runtime/attestations/`
+- `runtime/governance/`
+- `protocol/identity/`
+- `protocol/identity-policy/`
+- `protocol/audit/`
+- `protocol/policy/`
+- `docs/rfcs/RFC-004-evidence-layer-v1.md`
+- `docs/rfcs/RFC-005-Claims-Framework.md`
+- `docs/audits/claim-schema-source-audit.md`
+- `docs/audits/principal-reference-source-audit.md`
+- `docs/audits/proof-envelope-source-audit.md`
+- `docs/audits/registry-interface-source-audit.md`
+
+## Existing Credential-Like Concepts
+
+### Claims and Trust Chain
+
+`packages/protocol/src/claims/` already defines canonical evidence, assertions, claims, attestations, verifications, standing, capabilities, authorities, and decisions. The `ClaimType.Credential` value confirms that credentials are already named in the claims vocabulary, but the current contract surface did not yet provide portable credential containers. Existing claim contracts provide reusable IDs, timestamps, metadata, subject, issuer, attester, verifier, proof references, and registry references.
+
+### Proof References
+
+`packages/protocol/src/claims/proofs/` defines proof references and proof envelopes for hash, signature, attestation, integrity, chain, audit, and trace proof artifacts. These files are reusable because credentials should reference proof artifacts without validating them. Proof contracts also set the precedent that protocol contracts describe proof material without executing signature verification or chain validation.
+
+### Registry References
+
+`packages/protocol/src/claims/registries/` defines registry references, registry entry references, lookup requests/results, registry attestations, and manifests. Credential contracts should reuse registry entry references so credentials can identify issuer registries, subject registries, credential registries, status lists, and proof registries without implementing registry lookup or storage.
+
+### Base Contracts
+
+`packages/protocol/src/contracts/` defines reusable primitives such as `CanonicalId`, `UtcDateTime`, capability token shapes, consent grants, audit event envelopes, and trust domain identifiers. Credential contracts should reuse `CanonicalId` and `UtcDateTime` while avoiding capability-token, consent, and audit-envelope behavior.
+
+### Identity Package
+
+`packages/identity/` provides identity descriptors, identity status, identity source, trust level, verification level, actor relationships, delegation, and identity claims. These concepts are credential-adjacent but are package-specific identity contracts rather than RFC-005 credential containers. They are suitable migration candidates for future adapters that emit canonical credential references or credential subjects.
+
+### Shared Types
+
+`packages/shared-types/` includes actor, identity, capability, consent, audit, governance, authority, delegation, and revocation-like fields such as `revokedAt`. These are operational or cross-runtime data structures, not canonical credential contracts. Reusable public ideas include issuer IDs, subject IDs, capability references, revocation descriptors, and audit correlation references.
+
+### Runtime Trust
+
+`runtime/trust/types.ts` includes identity issuers, identity credential records, consent records, identity verification results, and trust audit events. `runtime/trust/service.ts` registers credentials, stores credential records in maps, verifies identity, checks expiration/revocation, and emits audit events. This is the clearest existing credential runtime implementation and must remain private/runtime. Reusable public ideas include credential references, issuer identity, subject identity, issued/expires timestamps, revoked status descriptors, wallet/source locators, and audit references.
+
+### Runtime Attestations
+
+`runtime/attestations/` includes attestation chains, capability attestations, governance attestations, remote attestations, AI attestations, and integrity proof structures. These establish useful attester, statement, issued-at, proof, chain, federation, and remote audit concepts. Runtime chain evaluation and attestation construction remain non-goals for canonical credential contracts.
+
+### Runtime Governance
+
+`runtime/governance/` includes governance sessions, obligations, escalation, reason codes, authority profiles, grants, decisions, machine capability envelopes, and runtime state. These concepts show where credentials may later feed runtime policy, but credential contracts must not derive authority, grant capabilities, evaluate standing, or authorize decisions.
+
+### Protocol Identity, Policy, and Audit
+
+`protocol/identity/` includes actor objects, identity references, delegation, actor registry adapters, and trust chains. `protocol/identity-policy/` binds identity context to policy evaluation. `protocol/policy/` and `protocol/audit/` include decision traces, PDP contracts, policy objects, audit events, and query/correlation models. These should remain separate from credential descriptors because they implement actor resolution, policy evaluation, audit normalization, and decision tracing.
+
+### RFCs and Prior Audits
+
+RFC-004 establishes an evidence layer where evidence is distinct from interpretation and execution. RFC-005 establishes the trust chain and explicitly distinguishes credentials from claims, verification, standing, authority, and decisions. Prior audits established canonical claim contracts, principal references, proof envelopes, and registry interfaces; credential contracts should compose those canonical artifacts rather than duplicate them.
+
+## Reusable Credential Concepts
+
+- Credential IDs and locators.
+- Credential issuer descriptors.
+- Credential subject descriptors.
+- Credential status descriptors such as draft, issued, active, suspended, revoked, expired, superseded, archived, and unknown.
+- Claim references instead of embedded claims.
+- Evidence, attestation, proof, and registry references.
+- Issued and expiration timestamps.
+- Portable manifests describing what credential descriptors represent.
+- Credential attestations that declare support for a descriptor without evaluating it.
+- Credential presentations as portable presentation events without wallet or selective-disclosure behavior.
+
+## Existing Identity Credential Concepts
+
+- `runtime/trust` identity credential records include subject hashes, issuer IDs, credential hashes, KYC levels, wallet addresses, issued timestamps, expiration timestamps, and revocation timestamps.
+- `packages/identity` identity contracts include identity source, status, trust level, verification level, and actor relationship concepts.
+- `protocol/identity` references identities, actors, trust chains, and delegation.
+
+Canonical credential contracts should not import KYC-specific or wallet-specific semantics, but they should support generic subject, issuer, locator, status, proof, and registry references.
+
+## Capability-Token Credential Concepts
+
+- `packages/protocol/src/contracts` and `packages/shared-types` include capability tokens, capability references, scopes, issuers, subjects, proofs, expirations, and revocation-related fields.
+- `runtime/governance` and `packages/shared-types` include authority profiles and machine grants with issued/expires/revoked timestamps.
+
+These are credential-like in portability and subject/issuer shape, but they represent permissions or authority-bearing runtime artifacts. Canonical credential contracts may include `CapabilityCredential` as a descriptor type, but must not grant capability or authority.
+
+## Certification and License Concepts
+
+- `ClaimType.Certification` and `EvidenceType.Certification` already name certification concepts.
+- RFC-005 describes claims that may include certification, authorization, role, governance, and compliance facts.
+- Governance and policy files include approval, escalation, and authority concepts that may be backed by certification or license credentials.
+
+Canonical credential contracts should support `CertificationCredential`, `ProfessionalCredential`, and `OrganizationCredential` without implementing license verification or compliance scoring.
+
+## Issuer and Subject Concepts
+
+- Canonical claims already use `CanonicalSubject` and `CanonicalIssuer`.
+- Principal references distinguish humans, organizations, systems, AI, runtimes, governance bodies, market makers, credential issuers, and unknown principals.
+- Runtime trust records use issuer IDs, subject hashes, and consumer IDs.
+- Identity and registry contracts provide actor/principal and registry references.
+
+Credential contracts should define credential-specific issuer and subject descriptors that may point to `CanonicalPrincipalRef` and registry entries, while clearly avoiding identity proof and issuer-authority verification.
+
+## Revocation and Status Concepts
+
+- Runtime trust credential records include `revoked_at` and verification reason codes such as `EXPIRED` and `REVOKED`.
+- Shared types include `revokedAt` across consent, capability, delegation, and governance structures.
+- Claim contracts include verification status, standing status, authority status, and decision status.
+- Registry contracts include registry entry statuses.
+
+Credential status must remain a descriptor. `CredentialStatus.Revoked` can declare or observe a state, but only a verification, standing, governance, or enterprise engine can evaluate what that state means.
+
+## Proof and Registry References Related to Credentials
+
+- Canonical proof references can point to signatures, hashes, attestation proofs, integrity proofs, audit proofs, chain proofs, and trace proofs.
+- Canonical registry entry references can point to credential registries, issuer registries, subject registries, status registries, and proof registries.
+- Existing claims and evidence already accept proof and registry references; optional credential references can be added to claims, evidence, attestations, verifications, and proof envelopes to support portability.
+
+## Duplicate Concepts
+
+- `credential_ref`, `identity_ref`, `CapabilityRef`, `ResourceRef`, and registry entry locators all represent reference-like concepts with different scopes.
+- `issuer`, `issuer_id`, `issuedByActorId`, and `identity_issuer` describe issuer-like concepts across protocol and runtime boundaries.
+- `subject`, `subjectActorId`, `subject_hash`, `principalRef`, and actor IDs describe subjects at different abstraction levels.
+- `revoked_at`, `revokedAt`, standing status, authority status, verification status, and registry entry status all use status terminology with different meanings.
+- Audit events and proof/audit references both describe evidence trails but should not be collapsed.
+
+## Conflicting Terminology
+
+- `status` may mean credential lifecycle, registry entry lifecycle, claim standing, verification result, authority state, decision state, runtime obligation state, or identity state.
+- `credential` may mean a portable descriptor, a runtime database record, a KYC identity record, a Verifiable Credential, or a capability token.
+- `issuer` may identify a declarative issuer, an issuer registry record, a governance authority, a runtime identity provider, or a signing key controller.
+- `verification` may mean claim verification, identity verification, signature verification, credential format validation, or revocation checking.
+- `authority` may be confused with credential issuance authority; canonical credentials must not grant authority by themselves.
+
+## Migration Candidates
+
+- Runtime trust identity credential records can expose public descriptors as `CanonicalCredential`, `CanonicalCredentialIssuer`, `CanonicalCredentialSubject`, and `CanonicalCredentialStatusRef` while retaining verification and storage logic in runtime services.
+- Identity package contracts can map identity and actor references to `CanonicalCredentialSubject` and `CanonicalCredentialIssuer` where portable credentials are needed.
+- Capability-token and governance grants can reference `CanonicalCredentialRef` when a credential supports a claim, while preserving actual capability and authority derivation in existing runtime packages.
+- Registry implementations can register credential descriptors using `CanonicalRegistryEntryRef` and `CanonicalCredentialManifest` without moving lookup/storage logic into protocol contracts.
+- Proof envelope producers can attach optional `credentialRefs` when a proof envelope supports credential portability.
+
+## Concepts That Should Remain Runtime or Private
+
+- Credential issuance workflows.
+- Credential storage, database tables, indexes, and persistence.
+- Credential APIs, adapters, and service classes.
+- Wallet integration and presentation exchange protocols.
+- DID resolution and Verifiable Credential verification.
+- Signature verification and proof validation.
+- Revocation checking and status-list resolution.
+- KYC policy evaluation and consent checking.
+- Standing evaluation, authority derivation, trust scoring, and decision authorization.
+- Runtime audit-event emission and governance decision execution.
+
+## Concepts Suitable for Public Canonical Contracts
+
+- `CanonicalCredentialId`, `CanonicalCredentialNamespace`, and `CanonicalCredentialLocator`.
+- `CredentialType`, `CredentialFormat`, `CredentialStatus`, `CredentialSubjectKind`, and `CredentialIssuerKind`.
+- `CanonicalCredentialSubject`.
+- `CanonicalCredentialIssuer`.
+- `CanonicalCredentialStatusRef`.
+- `CanonicalCredentialRef`.
+- `CanonicalCredential`.
+- `CanonicalCredentialManifest`.
+- `CanonicalCredentialAttestation`.
+- `CanonicalCredentialPresentation`.
+- Optional `credentialRefs` on evidence, claims, attestations, verifications, and proof envelopes.
+
+## Non-Goals
+
+- No issuance runtime.
+- No credential persistence or database schema.
+- No credential API.
+- No wallet protocol.
+- No DID resolution.
+- No Verifiable Credential verification.
+- No signature verification.
+- No revocation checking.
+- No standing evaluation.
+- No authority derivation.
+- No trust scoring.
+- No decision authorization.

--- a/packages/protocol/src/claims/attestation.ts
+++ b/packages/protocol/src/claims/attestation.ts
@@ -1,4 +1,5 @@
 import type { AttestationType } from './claim-enums';
+import type { CanonicalCredentialRef } from './credentials/credential-reference';
 import type { CanonicalProofRef } from './proofs';
 import type { CanonicalRegistryEntryRef } from './registries/registry-entry-reference';
 import type {
@@ -16,6 +17,7 @@ export interface CanonicalAttestation {
   readonly claimRef: CanonicalClaimId;
   readonly statement: string;
   readonly issuedAt: CanonicalTimestamp;
+  readonly credentialRefs?: readonly CanonicalCredentialRef[];
   readonly proofRefs?: readonly CanonicalProofRef[];
   readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
   readonly metadata?: CanonicalMetadata;

--- a/packages/protocol/src/claims/claim.ts
+++ b/packages/protocol/src/claims/claim.ts
@@ -1,4 +1,5 @@
 import type { ClaimType } from './claim-enums';
+import type { CanonicalCredentialRef } from './credentials/credential-reference';
 import type { CanonicalProofRef } from './proofs';
 import type { CanonicalRegistryEntryRef } from './registries/registry-entry-reference';
 import type {
@@ -20,6 +21,7 @@ export interface CanonicalClaim {
   readonly assertionRef: CanonicalAssertionId;
   readonly evidenceRefs: readonly CanonicalEvidenceId[];
   readonly attestationRefs: readonly CanonicalAttestationId[];
+  readonly credentialRefs?: readonly CanonicalCredentialRef[];
   readonly proofRefs?: readonly CanonicalProofRef[];
   readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
   readonly issuedAt: CanonicalTimestamp;

--- a/packages/protocol/src/claims/credentials/README.md
+++ b/packages/protocol/src/claims/credentials/README.md
@@ -1,0 +1,33 @@
+# Canonical Credential Contracts
+
+Canonical credential contracts define the public RFC-005 protocol surface for portable credential descriptors.
+
+A credential is a portable bundle or container of claim references, evidence references, attestation references, proof references, registry references, issuer information, subject information, and status references. It can be carried across systems so that a separate verifier, standing evaluator, authority resolver, or decision engine can inspect the trust-chain artifacts it references.
+
+## What a credential is not
+
+A credential is not an implementation engine. These contracts do not issue credentials, store credentials, resolve DIDs, integrate wallets, verify signatures, check revocation, evaluate standing, derive authority, score trust, or authorize decisions.
+
+## Credential vs claim
+
+A claim is a formal statement about a subject. A credential is a package that references one or more claims and related trust-chain artifacts. Canonical credentials use `claimRefs` instead of embedding full claims so claim semantics remain governed by the RFC-005 claim contracts.
+
+## Credential vs proof
+
+A proof is an artifact or reference used to support integrity, signature, chain, audit, trace, or related evidence. A credential may reference proofs, but it is not itself a proof and does not validate proof material.
+
+## Credential vs verification
+
+Verification evaluates whether a claim or credential-related artifact is supported. A credential may contain status descriptors and proof references, but it does not verify itself.
+
+## Credential vs standing
+
+Standing is the current usability state of a claim for trust, capability, authority, or decision purposes. A credential status reference is only a descriptor; it is not standing and does not decide whether a credential or claim is currently usable.
+
+## Credential vs authority
+
+Authority is derived from standing claims, capabilities, delegation rules, governance policy, and applicable constraints. Possessing a credential does not grant authority by itself.
+
+## Credential vs decision
+
+A decision is a consequential action taken under authority. Presenting or referencing a credential does not authorize a decision; decision authorization remains the responsibility of policy, standing, authority, and runtime governance systems.

--- a/packages/protocol/src/claims/credentials/credential-attestation.ts
+++ b/packages/protocol/src/claims/credentials/credential-attestation.ts
@@ -1,0 +1,19 @@
+import type { CanonicalId } from '../../contracts';
+import type { CanonicalAttester, CanonicalMetadata, CanonicalTimestamp } from '../primitives';
+import type { CanonicalProofRef } from '../proofs/proof-reference';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CanonicalCredentialRef } from './credential-reference';
+
+/**
+ * Attests to a credential descriptor without evaluating that attestation.
+ */
+export interface CanonicalCredentialAttestation {
+  readonly id: CanonicalId;
+  readonly credentialRef: CanonicalCredentialRef;
+  readonly attester: CanonicalAttester;
+  readonly statement: string;
+  readonly issuedAt: CanonicalTimestamp;
+  readonly proofRefs?: readonly CanonicalProofRef[];
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/credential-enums.ts
+++ b/packages/protocol/src/claims/credentials/credential-enums.ts
@@ -1,0 +1,61 @@
+export const CredentialType = {
+  IdentityCredential: 'IdentityCredential',
+  CapabilityCredential: 'CapabilityCredential',
+  CertificationCredential: 'CertificationCredential',
+  AuthorizationCredential: 'AuthorizationCredential',
+  RoleCredential: 'RoleCredential',
+  GovernanceCredential: 'GovernanceCredential',
+  ProfessionalCredential: 'ProfessionalCredential',
+  OrganizationCredential: 'OrganizationCredential',
+  SystemCredential: 'SystemCredential',
+  Custom: 'Custom',
+} as const;
+export type CredentialType = (typeof CredentialType)[keyof typeof CredentialType];
+
+export const CredentialFormat = {
+  JSON: 'JSON',
+  JWT: 'JWT',
+  VC: 'VC',
+  LinkedData: 'LinkedData',
+  Document: 'Document',
+  RegistryEntry: 'RegistryEntry',
+  Custom: 'Custom',
+} as const;
+export type CredentialFormat = (typeof CredentialFormat)[keyof typeof CredentialFormat];
+
+export const CredentialStatus = {
+  Draft: 'Draft',
+  Issued: 'Issued',
+  Active: 'Active',
+  Suspended: 'Suspended',
+  Revoked: 'Revoked',
+  Expired: 'Expired',
+  Superseded: 'Superseded',
+  Archived: 'Archived',
+  Unknown: 'Unknown',
+} as const;
+export type CredentialStatus = (typeof CredentialStatus)[keyof typeof CredentialStatus];
+
+export const CredentialSubjectKind = {
+  Principal: 'Principal',
+  Organization: 'Organization',
+  System: 'System',
+  AI: 'AI',
+  Runtime: 'Runtime',
+  GovernanceBody: 'GovernanceBody',
+  CredentialIssuer: 'CredentialIssuer',
+  Custom: 'Custom',
+} as const;
+export type CredentialSubjectKind = (typeof CredentialSubjectKind)[keyof typeof CredentialSubjectKind];
+
+export const CredentialIssuerKind = {
+  Human: 'Human',
+  Organization: 'Organization',
+  System: 'System',
+  GovernanceBody: 'GovernanceBody',
+  CredentialIssuer: 'CredentialIssuer',
+  Protocol: 'Protocol',
+  External: 'External',
+  Custom: 'Custom',
+} as const;
+export type CredentialIssuerKind = (typeof CredentialIssuerKind)[keyof typeof CredentialIssuerKind];

--- a/packages/protocol/src/claims/credentials/credential-identifiers.ts
+++ b/packages/protocol/src/claims/credentials/credential-identifiers.ts
@@ -1,0 +1,5 @@
+import type { CanonicalId } from '../../contracts';
+
+export type CanonicalCredentialId = CanonicalId;
+export type CanonicalCredentialNamespace = string;
+export type CanonicalCredentialLocator = string;

--- a/packages/protocol/src/claims/credentials/credential-issuer.ts
+++ b/packages/protocol/src/claims/credentials/credential-issuer.ts
@@ -1,0 +1,16 @@
+import type { CanonicalId } from '../../contracts';
+import type { CanonicalMetadata } from '../primitives';
+import type { CanonicalPrincipalRef } from '../references';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CredentialIssuerKind } from './credential-enums';
+
+/**
+ * Identifies the issuer of a credential without verifying issuer authority.
+ */
+export interface CanonicalCredentialIssuer {
+  readonly id: CanonicalId;
+  readonly kind: CredentialIssuerKind;
+  readonly principalRef?: CanonicalPrincipalRef;
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/credential-manifest.ts
+++ b/packages/protocol/src/claims/credentials/credential-manifest.ts
@@ -1,0 +1,24 @@
+import type { CanonicalId } from '../../contracts';
+import type { ClaimType } from '../claim-enums';
+import type { CanonicalMetadata, CanonicalTimestamp } from '../primitives';
+import type { CanonicalProofRef } from '../proofs/proof-reference';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CanonicalCredentialIssuer } from './credential-issuer';
+import type { CanonicalCredentialRef } from './credential-reference';
+
+/**
+ * Portable declaration of what a credential represents without issuing it or
+ * discovering runtime services.
+ */
+export interface CanonicalCredentialManifest {
+  readonly id: CanonicalId;
+  readonly credentialRef: CanonicalCredentialRef;
+  readonly name: string;
+  readonly description?: string;
+  readonly supportedClaimTypes?: readonly ClaimType[];
+  readonly issuer: CanonicalCredentialIssuer;
+  readonly issuedAt: CanonicalTimestamp;
+  readonly proofRefs?: readonly CanonicalProofRef[];
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/credential-presentation.ts
+++ b/packages/protocol/src/claims/credentials/credential-presentation.ts
@@ -1,0 +1,21 @@
+import type { CanonicalId } from '../../contracts';
+import type { CanonicalMetadata, CanonicalTimestamp } from '../primitives';
+import type { CanonicalPrincipalRef } from '../references';
+import type { CanonicalProofRef } from '../proofs/proof-reference';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CanonicalCredentialRef } from './credential-reference';
+
+/**
+ * Represents a portable credential presentation event without wallet behavior,
+ * selective disclosure, or presentation verification.
+ */
+export interface CanonicalCredentialPresentation {
+  readonly id: CanonicalId;
+  readonly credentialRefs: readonly CanonicalCredentialRef[];
+  readonly holder: CanonicalPrincipalRef;
+  readonly presentedTo?: CanonicalPrincipalRef;
+  readonly presentedAt: CanonicalTimestamp;
+  readonly proofRefs?: readonly CanonicalProofRef[];
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/credential-reference.ts
+++ b/packages/protocol/src/claims/credentials/credential-reference.ts
@@ -1,0 +1,24 @@
+import type { CanonicalMetadata } from '../primitives';
+import type { CanonicalProofRef } from '../proofs/proof-reference';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CredentialFormat, CredentialType } from './credential-enums';
+import type { CanonicalCredentialId, CanonicalCredentialLocator } from './credential-identifiers';
+import type { CanonicalCredentialIssuer } from './credential-issuer';
+import type { CanonicalCredentialStatusRef } from './credential-status-reference';
+import type { CanonicalCredentialSubject } from './credential-subject';
+
+/**
+ * References a credential without embedding or verifying the full credential.
+ */
+export interface CanonicalCredentialRef {
+  readonly id: CanonicalCredentialId;
+  readonly type: CredentialType;
+  readonly format?: CredentialFormat;
+  readonly locator?: CanonicalCredentialLocator;
+  readonly issuer?: CanonicalCredentialIssuer;
+  readonly subject?: CanonicalCredentialSubject;
+  readonly status?: CanonicalCredentialStatusRef;
+  readonly proofRefs?: readonly CanonicalProofRef[];
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/credential-status-reference.ts
+++ b/packages/protocol/src/claims/credentials/credential-status-reference.ts
@@ -1,0 +1,17 @@
+import type { CanonicalMetadata, CanonicalSource, CanonicalTimestamp } from '../primitives';
+import type { CanonicalProofRef } from '../proofs/proof-reference';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CredentialStatus } from './credential-enums';
+
+/**
+ * Describes a declared or observed credential status without checking revocation,
+ * evaluating standing, or verifying the credential.
+ */
+export interface CanonicalCredentialStatusRef {
+  readonly status: CredentialStatus;
+  readonly statusSource?: CanonicalSource;
+  readonly observedAt?: CanonicalTimestamp;
+  readonly proofRefs?: readonly CanonicalProofRef[];
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/credential-subject.ts
+++ b/packages/protocol/src/claims/credentials/credential-subject.ts
@@ -1,0 +1,16 @@
+import type { CanonicalId } from '../../contracts';
+import type { CanonicalMetadata } from '../primitives';
+import type { CanonicalPrincipalRef } from '../references';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CredentialSubjectKind } from './credential-enums';
+
+/**
+ * Identifies the subject of a credential without verifying identity or standing.
+ */
+export interface CanonicalCredentialSubject {
+  readonly id: CanonicalId;
+  readonly kind: CredentialSubjectKind;
+  readonly principalRef?: CanonicalPrincipalRef;
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/credential.ts
+++ b/packages/protocol/src/claims/credentials/credential.ts
@@ -1,0 +1,35 @@
+import type {
+  CanonicalAttestationId,
+  CanonicalClaimId,
+  CanonicalEvidenceId,
+  CanonicalMetadata,
+  CanonicalTimestamp,
+} from '../primitives';
+import type { CanonicalProofRef } from '../proofs/proof-reference';
+import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
+import type { CredentialFormat, CredentialType } from './credential-enums';
+import type { CanonicalCredentialId } from './credential-identifiers';
+import type { CanonicalCredentialIssuer } from './credential-issuer';
+import type { CanonicalCredentialStatusRef } from './credential-status-reference';
+import type { CanonicalCredentialSubject } from './credential-subject';
+
+/**
+ * Portable credential descriptor that bundles references to trust-chain artifacts.
+ * It does not embed claims or evaluate verification, standing, authority, or decisions.
+ */
+export interface CanonicalCredential {
+  readonly id: CanonicalCredentialId;
+  readonly type: CredentialType;
+  readonly format: CredentialFormat;
+  readonly issuer: CanonicalCredentialIssuer;
+  readonly subject: CanonicalCredentialSubject;
+  readonly claimRefs: readonly CanonicalClaimId[];
+  readonly evidenceRefs?: readonly CanonicalEvidenceId[];
+  readonly attestationRefs?: readonly CanonicalAttestationId[];
+  readonly proofRefs?: readonly CanonicalProofRef[];
+  readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
+  readonly status?: CanonicalCredentialStatusRef;
+  readonly issuedAt: CanonicalTimestamp;
+  readonly expiresAt?: CanonicalTimestamp;
+  readonly metadata?: CanonicalMetadata;
+}

--- a/packages/protocol/src/claims/credentials/index.ts
+++ b/packages/protocol/src/claims/credentials/index.ts
@@ -1,0 +1,10 @@
+export * from './credential-enums';
+export type * from './credential-identifiers';
+export type * from './credential-subject';
+export type * from './credential-issuer';
+export type * from './credential-status-reference';
+export type * from './credential-reference';
+export type * from './credential';
+export type * from './credential-manifest';
+export type * from './credential-attestation';
+export type * from './credential-presentation';

--- a/packages/protocol/src/claims/evidence.ts
+++ b/packages/protocol/src/claims/evidence.ts
@@ -1,4 +1,5 @@
 import type { EvidenceType } from './claim-enums';
+import type { CanonicalCredentialRef } from './credentials/credential-reference';
 import type { CanonicalProofRef } from './proofs';
 import type { CanonicalRegistryEntryRef } from './registries/registry-entry-reference';
 import type {
@@ -18,6 +19,7 @@ export interface CanonicalEvidence {
   readonly source: CanonicalSource;
   readonly description: string;
   readonly createdAt: CanonicalTimestamp;
+  readonly credentialRefs?: readonly CanonicalCredentialRef[];
   readonly proofRefs?: readonly CanonicalProofRef[];
   readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
   readonly metadata?: CanonicalMetadata;

--- a/packages/protocol/src/claims/index.ts
+++ b/packages/protocol/src/claims/index.ts
@@ -3,6 +3,7 @@ export * from './claim-enums';
 export * from './references';
 export * from './proofs';
 export * from './registries';
+export * from './credentials';
 export type * from './evidence';
 export type * from './assertion';
 export type * from './claim';

--- a/packages/protocol/src/claims/proofs/proof-envelope.ts
+++ b/packages/protocol/src/claims/proofs/proof-envelope.ts
@@ -1,4 +1,5 @@
 import type { CanonicalId } from '../../contracts';
+import type { CanonicalCredentialRef } from '../credentials/credential-reference';
 import type { CanonicalIssuer, CanonicalMetadata, CanonicalSubject, CanonicalTimestamp } from '../primitives';
 import type { CanonicalRegistryEntryRef } from '../registries/registry-entry-reference';
 import type { ProofType } from './proof-enums';
@@ -12,6 +13,7 @@ export interface CanonicalProofEnvelope {
   readonly id: CanonicalId;
   readonly proofType: ProofType;
   readonly proofRefs: readonly CanonicalProofRef[];
+  readonly credentialRefs?: readonly CanonicalCredentialRef[];
   readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
   readonly subject: CanonicalSubject;
   readonly issuer: CanonicalIssuer;

--- a/packages/protocol/src/claims/verification.ts
+++ b/packages/protocol/src/claims/verification.ts
@@ -1,4 +1,5 @@
 import type { VerificationStatus } from './claim-enums';
+import type { CanonicalCredentialRef } from './credentials/credential-reference';
 import type { CanonicalProofRef } from './proofs';
 import type { CanonicalRegistryEntryRef } from './registries/registry-entry-reference';
 import type {
@@ -15,6 +16,7 @@ export interface CanonicalVerification {
   readonly verifier: CanonicalVerifier;
   readonly verifiedAt: CanonicalTimestamp;
   readonly findings: readonly string[];
+  readonly credentialRefs?: readonly CanonicalCredentialRef[];
   readonly proofRefs?: readonly CanonicalProofRef[];
   readonly registryRefs?: readonly CanonicalRegistryEntryRef[];
   readonly confidence?: number;

--- a/tests/contracts/credential-contract.test.ts
+++ b/tests/contracts/credential-contract.test.ts
@@ -1,0 +1,362 @@
+import {
+  ClaimType,
+  CredentialFormat,
+  CredentialIssuerKind,
+  CredentialStatus,
+  CredentialSubjectKind,
+  CredentialType,
+  EvidenceType,
+  ProofType,
+  RegistryAuthorityLevel,
+  RegistryEntryStatus,
+  RegistryEntryType,
+  RegistryType,
+  VerificationStatus,
+  type CanonicalAttestation,
+  type CanonicalClaim,
+  type CanonicalCredential,
+  type CanonicalCredentialAttestation,
+  type CanonicalCredentialIssuer,
+  type CanonicalCredentialManifest,
+  type CanonicalCredentialPresentation,
+  type CanonicalCredentialRef,
+  type CanonicalCredentialStatusRef,
+  type CanonicalCredentialSubject,
+  type CanonicalEvidence,
+  type CanonicalPrincipalRef,
+  type CanonicalProofEnvelope,
+  type CanonicalProofRef,
+  type CanonicalRegistryEntryRef,
+  type CanonicalRegistryRef,
+  type CanonicalVerification,
+} from '@aoc/protocol/claims';
+
+type AssertAssignable<Expected, Actual extends Expected> = true;
+type AssertNoKey<T, K extends PropertyKey> = K extends keyof T ? never : true;
+
+const principalRef: CanonicalPrincipalRef = {
+  id: 'principal-1',
+  kind: 'Human',
+  displayName: 'AOC Principal',
+};
+
+const registryRef: CanonicalRegistryRef = {
+  id: 'credential-registry-1',
+  type: RegistryType.CredentialRegistry,
+  namespace: 'aoc.credentials',
+  authorityLevel: RegistryAuthorityLevel.ProtocolRecognized,
+};
+
+const registryEntryRef: CanonicalRegistryEntryRef = {
+  id: 'credential-entry-1',
+  registryRef,
+  entryType: RegistryEntryType.Credential,
+  locator: 'urn:aoc:credential:credential-1',
+  status: RegistryEntryStatus.Active,
+};
+
+const proofRef: CanonicalProofRef = {
+  id: 'proof-1',
+  type: ProofType.SignatureProof,
+  source: 'signature-envelope-1',
+};
+
+const credentialIssuer: CanonicalCredentialIssuer = {
+  id: 'issuer-1',
+  kind: CredentialIssuerKind.Organization,
+  principalRef,
+  registryRefs: [registryEntryRef],
+};
+
+const credentialSubject: CanonicalCredentialSubject = {
+  id: 'subject-1',
+  kind: CredentialSubjectKind.Principal,
+  principalRef,
+  registryRefs: [registryEntryRef],
+};
+
+const credentialStatusRef: CanonicalCredentialStatusRef = {
+  status: CredentialStatus.Active,
+  statusSource: 'credential-status-list-1',
+  observedAt: '2026-06-03T00:00:00.000Z',
+  proofRefs: [proofRef],
+  registryRefs: [registryEntryRef],
+};
+
+const credentialRef: CanonicalCredentialRef = {
+  id: 'credential-1',
+  type: CredentialType.IdentityCredential,
+  format: CredentialFormat.JSON,
+  locator: 'urn:aoc:credential:credential-1',
+  issuer: credentialIssuer,
+  subject: credentialSubject,
+  status: credentialStatusRef,
+  proofRefs: [proofRef],
+  registryRefs: [registryEntryRef],
+};
+
+type _CredentialSubjectCompiles = AssertAssignable<
+  CanonicalCredentialSubject,
+  {
+    readonly id: 'subject-1';
+    readonly kind: typeof CredentialSubjectKind.Principal;
+    readonly principalRef: CanonicalPrincipalRef;
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialIssuerCompiles = AssertAssignable<
+  CanonicalCredentialIssuer,
+  {
+    readonly id: 'issuer-1';
+    readonly kind: typeof CredentialIssuerKind.Organization;
+    readonly principalRef: CanonicalPrincipalRef;
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialStatusRefCompiles = AssertAssignable<
+  CanonicalCredentialStatusRef,
+  {
+    readonly status: typeof CredentialStatus.Active;
+    readonly statusSource: 'status-list-1';
+    readonly observedAt: '2026-06-03T00:00:00.000Z';
+    readonly proofRefs: readonly CanonicalProofRef[];
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialRefCompiles = AssertAssignable<
+  CanonicalCredentialRef,
+  {
+    readonly id: 'credential-1';
+    readonly type: typeof CredentialType.IdentityCredential;
+    readonly format: typeof CredentialFormat.JSON;
+    readonly locator: 'urn:aoc:credential:credential-1';
+    readonly issuer: CanonicalCredentialIssuer;
+    readonly subject: CanonicalCredentialSubject;
+    readonly status: CanonicalCredentialStatusRef;
+    readonly proofRefs: readonly CanonicalProofRef[];
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialCompiles = AssertAssignable<
+  CanonicalCredential,
+  {
+    readonly id: 'credential-1';
+    readonly type: typeof CredentialType.IdentityCredential;
+    readonly format: typeof CredentialFormat.JSON;
+    readonly issuer: CanonicalCredentialIssuer;
+    readonly subject: CanonicalCredentialSubject;
+    readonly claimRefs: readonly ['claim-1'];
+    readonly evidenceRefs: readonly ['evidence-1'];
+    readonly attestationRefs: readonly ['attestation-1'];
+    readonly proofRefs: readonly CanonicalProofRef[];
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly status: CanonicalCredentialStatusRef;
+    readonly issuedAt: '2026-06-03T00:00:00.000Z';
+    readonly expiresAt: '2027-06-03T00:00:00.000Z';
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialManifestCompiles = AssertAssignable<
+  CanonicalCredentialManifest,
+  {
+    readonly id: 'credential-manifest-1';
+    readonly credentialRef: CanonicalCredentialRef;
+    readonly name: 'AOC Identity Credential';
+    readonly description: 'Portable credential declaration.';
+    readonly supportedClaimTypes: readonly [typeof ClaimType.Identity];
+    readonly issuer: CanonicalCredentialIssuer;
+    readonly issuedAt: '2026-06-03T00:00:00.000Z';
+    readonly proofRefs: readonly CanonicalProofRef[];
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialAttestationCompiles = AssertAssignable<
+  CanonicalCredentialAttestation,
+  {
+    readonly id: 'credential-attestation-1';
+    readonly credentialRef: CanonicalCredentialRef;
+    readonly attester: 'governance-body-1';
+    readonly statement: 'Descriptor matches approved credential profile.';
+    readonly issuedAt: '2026-06-03T00:00:00.000Z';
+    readonly proofRefs: readonly CanonicalProofRef[];
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialPresentationCompiles = AssertAssignable<
+  CanonicalCredentialPresentation,
+  {
+    readonly id: 'credential-presentation-1';
+    readonly credentialRefs: readonly CanonicalCredentialRef[];
+    readonly holder: CanonicalPrincipalRef;
+    readonly presentedTo: CanonicalPrincipalRef;
+    readonly presentedAt: '2026-06-03T00:00:00.000Z';
+    readonly proofRefs: readonly CanonicalProofRef[];
+    readonly registryRefs: readonly CanonicalRegistryEntryRef[];
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CanonicalClaimAcceptsCredentialRefs = AssertAssignable<
+  CanonicalClaim,
+  {
+    readonly id: 'claim-1';
+    readonly type: typeof ClaimType.Identity;
+    readonly subject: 'principal-1';
+    readonly issuer: 'issuer-1';
+    readonly assertionRef: 'assertion-1';
+    readonly evidenceRefs: readonly ['evidence-1'];
+    readonly attestationRefs: readonly ['attestation-1'];
+    readonly credentialRefs: readonly CanonicalCredentialRef[];
+    readonly issuedAt: '2026-06-03T00:00:00.000Z';
+  }
+>;
+
+type _CanonicalEvidenceAcceptsCredentialRefs = AssertAssignable<
+  CanonicalEvidence,
+  {
+    readonly id: 'evidence-1';
+    readonly type: typeof EvidenceType.Document;
+    readonly subject: 'principal-1';
+    readonly issuer: 'issuer-1';
+    readonly source: 'source-1';
+    readonly description: 'Identity document';
+    readonly createdAt: '2026-06-03T00:00:00.000Z';
+    readonly credentialRefs: readonly CanonicalCredentialRef[];
+  }
+>;
+
+type _CanonicalAttestationAcceptsCredentialRefs = AssertAssignable<
+  CanonicalAttestation,
+  {
+    readonly id: 'attestation-1';
+    readonly type: 'Governance';
+    readonly attester: 'governance-body-1';
+    readonly claimRef: 'claim-1';
+    readonly statement: 'Credential descriptor is supported.';
+    readonly issuedAt: '2026-06-03T00:00:00.000Z';
+    readonly credentialRefs: readonly CanonicalCredentialRef[];
+  }
+>;
+
+type _CanonicalVerificationAcceptsCredentialRefs = AssertAssignable<
+  CanonicalVerification,
+  {
+    readonly id: 'verification-1';
+    readonly claimRef: 'claim-1';
+    readonly status: typeof VerificationStatus.Verified;
+    readonly verifier: 'verifier-1';
+    readonly verifiedAt: '2026-06-03T00:00:00.000Z';
+    readonly findings: readonly ['credential referenced'];
+    readonly credentialRefs: readonly CanonicalCredentialRef[];
+  }
+>;
+
+type _CanonicalProofEnvelopeAcceptsCredentialRefs = AssertAssignable<
+  CanonicalProofEnvelope,
+  {
+    readonly id: 'proof-envelope-1';
+    readonly proofType: typeof ProofType.SignatureProof;
+    readonly proofRefs: readonly CanonicalProofRef[];
+    readonly credentialRefs: readonly CanonicalCredentialRef[];
+    readonly subject: 'principal-1';
+    readonly issuer: 'issuer-1';
+    readonly issuedAt: '2026-06-03T00:00:00.000Z';
+    readonly metadata: Readonly<Record<string, unknown>>;
+  }
+>;
+
+type _CredentialHasNoVerificationResults = AssertNoKey<CanonicalCredential, 'verificationResults'>;
+type _CredentialHasNoStanding = AssertNoKey<CanonicalCredential, 'standing'>;
+type _CredentialHasNoAuthority = AssertNoKey<CanonicalCredential, 'authority'>;
+type _CredentialHasNoDecisions = AssertNoKey<CanonicalCredential, 'decisions'>;
+type _CredentialHasNoIssueBehavior = AssertNoKey<CanonicalCredential, 'issueCredential'>;
+type _CredentialHasNoRevokeBehavior = AssertNoKey<CanonicalCredential, 'revokeCredential'>;
+type _CredentialHasNoVerifyBehavior = AssertNoKey<CanonicalCredential, 'verifyCredential'>;
+
+describe('credential contract integrity', () => {
+  it('exports credential enum values from @aoc/protocol/claims', () => {
+    expect(CredentialType.IdentityCredential).toBe('IdentityCredential');
+    expect(CredentialType.CapabilityCredential).toBe('CapabilityCredential');
+    expect(CredentialType.Custom).toBe('Custom');
+    expect(CredentialFormat.JSON).toBe('JSON');
+    expect(CredentialFormat.VC).toBe('VC');
+    expect(CredentialStatus.Revoked).toBe('Revoked');
+    expect(CredentialSubjectKind.GovernanceBody).toBe('GovernanceBody');
+    expect(CredentialIssuerKind.Protocol).toBe('Protocol');
+  });
+
+  it('compiles portable credential descriptors and references', () => {
+    const credential: CanonicalCredential = {
+      id: 'credential-1',
+      type: CredentialType.IdentityCredential,
+      format: CredentialFormat.JSON,
+      issuer: credentialIssuer,
+      subject: credentialSubject,
+      claimRefs: ['claim-1'],
+      evidenceRefs: ['evidence-1'],
+      attestationRefs: ['attestation-1'],
+      proofRefs: [proofRef],
+      registryRefs: [registryEntryRef],
+      status: credentialStatusRef,
+      issuedAt: '2026-06-03T00:00:00.000Z',
+      expiresAt: '2027-06-03T00:00:00.000Z',
+    };
+
+    const manifest: CanonicalCredentialManifest = {
+      id: 'credential-manifest-1',
+      credentialRef,
+      name: 'AOC Identity Credential',
+      supportedClaimTypes: [ClaimType.Identity],
+      issuer: credentialIssuer,
+      issuedAt: '2026-06-03T00:00:00.000Z',
+      proofRefs: [proofRef],
+      registryRefs: [registryEntryRef],
+    };
+
+    const attestation: CanonicalCredentialAttestation = {
+      id: 'credential-attestation-1',
+      credentialRef,
+      attester: 'governance-body-1',
+      statement: 'Descriptor matches approved credential profile.',
+      issuedAt: '2026-06-03T00:00:00.000Z',
+    };
+
+    const presentation: CanonicalCredentialPresentation = {
+      id: 'credential-presentation-1',
+      credentialRefs: [credentialRef],
+      holder: principalRef,
+      presentedTo: principalRef,
+      presentedAt: '2026-06-03T00:00:00.000Z',
+    };
+
+    expect(credential.claimRefs).toEqual(['claim-1']);
+    expect(manifest.credentialRef).toBe(credentialRef);
+    expect(attestation.credentialRef).toBe(credentialRef);
+    expect(presentation.credentialRefs).toEqual([credentialRef]);
+  });
+
+  it('keeps credential contracts free of verification, standing, authority, and decision behavior', () => {
+    expect('verifyCredential' in credentialRef).toBe(false);
+    expect('issueCredential' in credentialRef).toBe(false);
+    expect('revokeCredential' in credentialRef).toBe(false);
+    expect('credentialWallet' in credentialRef).toBe(false);
+    expect('selectiveDisclosure' in credentialRef).toBe(false);
+    expect('credentialTrustScore' in credentialRef).toBe(false);
+    expect('standingEvaluator' in credentialRef).toBe(false);
+    expect('authorityResolver' in credentialRef).toBe(false);
+    expect('authorizeDecision' in credentialRef).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation

- Define a public, implementation-neutral canonical credential surface for RFC-005 so credentials can be portable containers of claim/evidence/attestation/proof/registry references without performing verification, standing, authority, or decision work. 
- Preserve the RFC-005 separation of concerns by providing descriptor contracts only and avoiding any runtime/issuance/wallet/revocation behavior.

### Description

- Added a credential package under `packages/protocol/src/claims/credentials/` including `credential-enums.ts`, `credential-identifiers.ts`, `credential-subject.ts`, `credential-issuer.ts`, `credential-status-reference.ts`, `credential-reference.ts`, `credential.ts`, `credential-manifest.ts`, `credential-attestation.ts`, `credential-presentation.ts`, `index.ts`, and `README.md` that describe canonical credential shapes and enums (const-object enums + types).
- Exposed credential contracts from the claims barrel by adding `export * from './credentials';` to `packages/protocol/src/claims/index.ts` so consumers can import from `@aoc/protocol/claims`.
- Added optional portability references `credentialRefs?: readonly CanonicalCredentialRef[]` to existing canonical artifacts where architecturally useful: `CanonicalEvidence`, `CanonicalClaim`, `CanonicalAttestation`, `CanonicalVerification`, and `CanonicalProofEnvelope`.
- Added contract-only compliance and source audits at `docs/audits/credential-contract-compliance-audit.md` and `docs/audits/credential-contract-source-audit.md` explaining public/private boundaries, alignment with RFC-004/005, and migration guidance.
- Added compile-time contract coverage at `tests/contracts/credential-contract.test.ts` validating exports, assignability, and that credential contracts contain no verification/issuance/authority/decision behavior.
- Added a patch changeset for `@aoc/protocol` to record the change.

### Testing

- Ran `npm run typecheck` and the type-check completed successfully.
- Ran the test suite with `npm test -- --runInBand` and all contract tests passed (6 test suites, 11 tests) including the new `credential-contract.test.ts`.
- Ran `npm run build` which completed successfully.
- Performed targeted searches to ensure no credential implementation behavior was added (no `verifyCredential`, `issueCredential`, `revokeCredential`, wallet, selective-disclosure, trust-scoring, standing-evaluator, authority-resolver, or decision-authorization APIs introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa06990d483258528f3bb4f3c2fcf)