### PR TITLE
PR-06: migrate Protocol consumers to canonical imports

### DIFF
--- a/__tests__/contracts/contract-fixtures.ts
+++ b/__tests__/contracts/contract-fixtures.ts
@@ -24,7 +24,7 @@ import type {
   ConsentGrant,
   PolicyDecision,
 } from '@aoc/protocol/contracts';
-import { CAPABILITY_CLAIM_VERSION, type CapabilityClaim } from '../../src/contracts/capability-claims';
+import { CAPABILITY_CLAIM_VERSION, type CapabilityClaim } from '@aoc/protocol/claims';
 import type { ReasonCodeRegistryEntry } from '../../runtime/governance/reason-codes';
 import type { ExecutionRequest } from '../../protocol/execution';
 

--- a/docs/architecture/protocol-consumer-migration-report.md
+++ b/docs/architecture/protocol-consumer-migration-report.md
@@ -1,0 +1,61 @@
+# Protocol Consumer Migration Report
+
+## Scope
+
+PR-06 Phase 1 rewrites consumer imports only. Protocol implementations, file locations, runtime behavior, ownership, and legacy compatibility exports remain unchanged.
+
+The repository contains `docs/architecture/protocol-symbol-parity-report.md`, which confirms canonical export readiness. The two other named PR-04 inputs, `protocol-consumer-inventory.md` and `protocol-deep-import-report.md`, were not present in this checkout, so the migration baseline was reconstructed from TypeScript import declarations that resolve to the audited legacy surfaces or directly into `packages/protocol/src`.
+
+## Migration metrics
+
+| Metric | Result |
+|---|---:|
+| Consumers migrated | 7 |
+| Imports rewritten | 16 |
+| Violations removed | 16 |
+| Violations remaining | 0 |
+| Compilation failures | 0 |
+| Boundary violations | 0 |
+
+`Imports rewritten` counts each previous import declaration. The six legacy re-exports in `src/sdk/types.ts` were consolidated into one canonical type re-export after migration.
+
+## Consumer migrations
+
+| Consumer | Previous import | New import | Migration status | Compilation status | Risk level |
+|---|---|---|---|---|---|
+| `src/agents/types.ts` | `../capabilities/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/policies/types.ts` | `../capabilities/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/delegations/types.ts` | `../capabilities/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/adapters/interfaces.ts` | `../agents/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/adapters/interfaces.ts` | `../audit/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/adapters/interfaces.ts` | `../capabilities/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/adapters/interfaces.ts` | `../delegations/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/adapters/interfaces.ts` | `../decisions/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — type-only structural parity |
+| `src/sdk/types.ts` | `../capabilities/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — compatibility export retained |
+| `src/sdk/types.ts` | `../agents/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — compatibility export retained |
+| `src/sdk/types.ts` | `../policies/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — compatibility export retained |
+| `src/sdk/types.ts` | `../decisions/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — compatibility export retained |
+| `src/sdk/types.ts` | `../delegations/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — compatibility export retained |
+| `src/sdk/types.ts` | `../audit/types` | `@aoc/protocol/contracts` | Migrated | Pass | Low — compatibility export retained |
+| `__tests__/contracts/contract-fixtures.ts` | `../../src/contracts/capability-claims` | `@aoc/protocol/claims` | Migrated | Pass | Low — canonical symbol parity verified |
+| `tests/contracts/symbol-parity.test.ts` | `../../packages/protocol/src/contracts` | `@aoc/protocol/contracts` | Migrated | Pass | Low — test-only type import |
+
+## Enforcement
+
+`tests/contracts/consumer-import-enforcement.test.ts` audits static imports, re-exports, dynamic imports, and `require` calls outside the Protocol package. The root `src/index.ts` compatibility barrel is excluded because retaining legacy exports is an explicit non-goal of this phase. It inventories:
+
+- non-approved `@aoc/protocol/*` subpaths;
+- textual or resolved imports into `packages/protocol/src`;
+- relative imports of the audited legacy Protocol implementation files.
+
+Phase 1 is intentionally report-only: findings are emitted as warnings and do not fail the build. The current inventory is zero. A future Phase 2 change can replace the report-mode assertion with a zero-violation assertion.
+
+## Validation
+
+- `npm run check:aoc-boundaries`: pass
+- `npm run check:symbol-parity`: pass; report-only parity remains 100%
+- `npm run typecheck`: pass
+- `npm run build`: pass
+- `npm test`: pass
+
+No Protocol implementation was moved or redesigned, and no legacy export was removed.

--- a/src/adapters/interfaces.ts
+++ b/src/adapters/interfaces.ts
@@ -1,8 +1,13 @@
-import type { Agent, AgentScope } from "../agents/types";
-import type { AuditTimelineItem } from "../audit/types";
-import type { CapabilityGrant, CapabilityRequest } from "../capabilities/types";
-import type { Delegation } from "../delegations/types";
-import type { DecisionContext, PolicyDecision } from "../decisions/types";
+import type {
+  Agent,
+  AgentScope,
+  AuditTimelineItem,
+  CapabilityGrant,
+  CapabilityRequest,
+  DecisionContext,
+  Delegation,
+  PolicyDecision,
+} from '@aoc/protocol/contracts';
 
 // Protocol boundary: implementations of these interfaces belong in Enterprise/runtime repos.
 export interface PolicyDecisionAdapter {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,4 +1,4 @@
-import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from "../capabilities/types";
+import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from '@aoc/protocol/contracts';
 
 export type AgentId = string;
 

--- a/src/delegations/types.ts
+++ b/src/delegations/types.ts
@@ -1,4 +1,4 @@
-import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from "../capabilities/types";
+import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from '@aoc/protocol/contracts';
 
 export type PrincipalType = "human" | "agent" | "service";
 

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -1,4 +1,4 @@
-import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from "../capabilities/types";
+import type { CapabilityPermission, CapabilityResourceType, WorkspaceId } from '@aoc/protocol/contracts';
 
 export type PolicyEffect = "allow" | "deny" | "require_approval" | "conditional_allow";
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -1,9 +1,35 @@
-export type { WorkspaceId, ProjectId, CapabilityPermission, CapabilityResourceType, CapabilityRequestStatus, CapabilityGrantStatus, CapabilityRequest, CapabilityGrant } from "../capabilities/types";
-export type { AgentId, AgentRiskLevel, Agent, AgentScope } from "../agents/types";
-export type { Policy, PolicyEffect } from "../policies/types";
-export type { PolicyDecision, DecisionContext, PolicyReference, EvaluationSource } from "../decisions/types";
-export type { Delegation, DelegationStatus, DelegationPrincipal, DelegationLineage, DelegationRevocation, PrincipalType } from "../delegations/types";
-export type { AuditTimelineItem, AuditActor, AuditSubject, AuditEventCategory, AuditEventType, AuditSeverity } from "../audit/types";
+export type {
+  Agent,
+  AgentId,
+  AgentRiskLevel,
+  AgentScope,
+  AuditActor,
+  AuditEventCategory,
+  AuditEventType,
+  AuditSeverity,
+  AuditSubject,
+  AuditTimelineItem,
+  CapabilityGrant,
+  CapabilityGrantStatus,
+  CapabilityPermission,
+  CapabilityRequest,
+  CapabilityRequestStatus,
+  CapabilityResourceType,
+  DecisionContext,
+  Delegation,
+  DelegationLineage,
+  DelegationPrincipal,
+  DelegationRevocation,
+  DelegationStatus,
+  EvaluationSource,
+  Policy,
+  PolicyDecision,
+  PolicyEffect,
+  PolicyReference,
+  PrincipalType,
+  ProjectId,
+  WorkspaceId,
+} from '@aoc/protocol/contracts';
 
 export type AocClientConfig = {
   baseUrl: string;

--- a/tests/contracts/consumer-import-enforcement.test.ts
+++ b/tests/contracts/consumer-import-enforcement.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import ts from 'typescript';
+
+const repositoryRoot = resolve(__dirname, '../..');
+const approvedProtocolImports = new Set([
+  '@aoc/protocol/adapters',
+  '@aoc/protocol/claims',
+  '@aoc/protocol/contracts',
+  '@aoc/protocol/errors',
+]);
+const ignoredDirectories = new Set(['.git', 'coverage', 'dist', 'node_modules']);
+const sourceExtensions = /\.(?:[cm]?[jt]sx?)$/;
+const legacyImplementationFiles = new Set(
+  [
+    'src/adapters/interfaces.ts',
+    'src/agents/types.ts',
+    'src/audit/types.ts',
+    'src/capabilities/types.ts',
+    'src/consent/types.ts',
+    'src/contracts/capability-claims.ts',
+    'src/decisions/types.ts',
+    'src/delegations/types.ts',
+    'src/errors/contracts.ts',
+    'src/policies/types.ts',
+  ].map((path) => resolve(repositoryRoot, path)),
+);
+
+type ImportViolation = {
+  consumer: string;
+  line: number;
+  importPath: string;
+  reason: string;
+};
+
+function collectSourceFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    if (ignoredDirectories.has(entry)) return [];
+    const path = join(directory, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) return collectSourceFiles(path);
+    return sourceExtensions.test(entry) ? [path] : [];
+  });
+}
+
+function resolveRelativeImport(consumer: string, importPath: string): string | undefined {
+  if (!importPath.startsWith('.')) return undefined;
+  const base = resolve(dirname(consumer), importPath);
+  const candidates = [base, `${base}.ts`, `${base}.tsx`, `${base}.js`, join(base, 'index.ts'), join(base, 'index.tsx')];
+  return candidates.find((candidate) => {
+    try {
+      return statSync(candidate).isFile();
+    } catch {
+      return false;
+    }
+  });
+}
+
+function violationReason(consumer: string, importPath: string): string | undefined {
+  if (importPath.startsWith('@aoc/protocol/') && !approvedProtocolImports.has(importPath)) {
+    return 'Protocol package import is not an approved ownership surface';
+  }
+  if (/^(?:\.\.?\/)*(?:packages\/)?protocol\/src(?:\/|$)/.test(importPath)) {
+    return 'Protocol source deep import';
+  }
+
+  const resolvedImport = resolveRelativeImport(consumer, importPath);
+  if (resolvedImport?.startsWith(resolve(repositoryRoot, 'packages/protocol/src') + '/')) {
+    return 'Relative Protocol package source import';
+  }
+  if (resolvedImport && legacyImplementationFiles.has(resolvedImport)) {
+    return 'Legacy Protocol implementation import';
+  }
+  return undefined;
+}
+
+function collectImportSpecifiers(file: string): Array<{ importPath: string; line: number }> {
+  const source = ts.createSourceFile(file, readFileSync(file, 'utf8'), ts.ScriptTarget.Latest, true);
+  const imports: Array<{ importPath: string; line: number }> = [];
+
+  function visit(node: ts.Node): void {
+    let specifier: ts.StringLiteralLike | undefined;
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifier = node.moduleSpecifier;
+    } else if (ts.isCallExpression(node) && node.arguments.length === 1 && ts.isStringLiteralLike(node.arguments[0])) {
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword || (ts.isIdentifier(node.expression) && node.expression.text === 'require')) {
+        specifier = node.arguments[0];
+      }
+    }
+
+    if (specifier) {
+      imports.push({
+        importPath: specifier.text,
+        line: source.getLineAndCharacterOfPosition(specifier.getStart(source)).line + 1,
+      });
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+  return imports;
+}
+
+function auditConsumerImports(): ImportViolation[] {
+  return collectSourceFiles(repositoryRoot)
+    .filter(
+      (file) =>
+        !file.startsWith(resolve(repositoryRoot, 'packages/protocol') + '/') &&
+        file !== resolve(repositoryRoot, 'src/index.ts'),
+    )
+    .flatMap((consumer) =>
+      collectImportSpecifiers(consumer).flatMap(({ importPath, line }) => {
+        const reason = violationReason(consumer, importPath);
+        return reason
+          ? [{ consumer: relative(repositoryRoot, consumer), line, importPath, reason }]
+          : [];
+      }),
+    );
+}
+
+describe('consumer Protocol imports', () => {
+  it('reports deep and legacy imports without enforcing them in phase 1', () => {
+    const violations = auditConsumerImports();
+    if (violations.length > 0) {
+      console.warn(
+        `Protocol consumer import report (${violations.length} violation${violations.length === 1 ? '' : 's'}):\n` +
+          violations
+            .map(({ consumer, line, importPath, reason }) => `- ${consumer}:${line} ${importPath} (${reason})`)
+            .join('\n'),
+      );
+    }
+
+    // Phase 1 deliberately remains report-only. A future migration PR can
+    // replace this assertion with expect(violations).toHaveLength(0).
+    expect(Array.isArray(violations)).toBe(true);
+  });
+});

--- a/tests/contracts/symbol-parity.test.ts
+++ b/tests/contracts/symbol-parity.test.ts
@@ -4,7 +4,7 @@ import type {
   AgentScope as CanonicalAgentScope,
   AuditEventEnvelope as CanonicalAuditEventEnvelope,
   PolicyDecision as CanonicalPolicyDecision,
-} from '../../packages/protocol/src/contracts';
+} from '@aoc/protocol/contracts';
 
 import type { CapabilityToken as FacadeCapabilityToken } from '../../packages/capability-tokens/src';
 import type { ConsentGrant as FacadeConsentGrant } from '../../packages/consent-engine/src';


### PR DESCRIPTION
### Motivation

- Eliminate consumer deep imports into Protocol internals by migrating consumers to the canonical ownership surfaces (`@aoc/protocol/contracts`, `@aoc/protocol/claims`, `@aoc/protocol/errors`, `@aoc/protocol/adapters`).
- Phase 1 is report-only: perform import-only rewrites without moving implementations, changing runtime behavior, or removing legacy compatibility barrels.
- Add a light-weight enforcement mechanism (report-mode) to prevent future regressions while the full fail-mode enforcement is planned for a later phase.

### Description

- Rewrote consumer imports to the canonical Protocol surfaces in consumer files including `src/adapters/interfaces.ts`, `src/sdk/types.ts`, `src/agents/types.ts`, `src/delegations/types.ts`, and `src/policies/types.ts` to stop importing local Protocol implementation files.
- Updated test and fixture imports to use the canonical surfaces by changing `__tests__/contracts/contract-fixtures.ts` and `tests/contracts/symbol-parity.test.ts` to import from `@aoc/protocol/claims` and `@aoc/protocol/contracts` respectively.
- Added a report-mode enforcement test `tests/contracts/consumer-import-enforcement.test.ts` that audits static exports, re-exports, dynamic imports, `require` calls, and resolved relative imports for legacy Protocol implementation paths without failing CI in Phase 1.
- Added a migration report `docs/architecture/protocol-consumer-migration-report.md` summarizing the reconstructed baseline, per-consumer migration status, metrics, and validation results; no Protocol implementation movement or behavior changes were performed.

### Testing

- Ran boundary and symbol-parity checks with `npm run check:aoc-boundaries` and `npm run check:symbol-parity`, both passed.
- Ran TypeScript checks and build with `npm run typecheck` and `npm run build`, both passed and targeted compilation of migrated files also passed using a focused `tsc` invocation.
- Ran the full test suite with `npm test -- --runInBand` and the targeted enforcement test with `npx jest tests/contracts/consumer-import-enforcement.test.ts`, and all tests passed (12 suites, 32 tests, snapshots included).
- Result: 16 imports rewritten across 7 consumers, 16 violations removed, 0 remaining, and no compilation or boundary failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24daac221c8325ae0e5fb67c76793e)