### PR TITLE
Update AOC Assurance conversion CTAs

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -1,6 +1,10 @@
 import { LogoRotating } from '../components/logo/LogoRotating';
 import './assurance.css';
 
+const FOUNDATION_CHECKOUT_URL = 'REPLACE_WITH_STRIPE_FOUNDATION_CHECKOUT_URL';
+const FOUNDER_PROGRAM_CHECKOUT_URL = 'REPLACE_WITH_STRIPE_FOUNDER_PROGRAM_CHECKOUT_URL';
+const ENTERPRISE_INTAKE_FORM_URL = 'REPLACE_WITH_ENTERPRISE_INTAKE_FORM_URL';
+
 const MATRIX_DIMENSIONS = [
   {
     id: 'governance',
@@ -61,7 +65,7 @@ const ASSESSMENT_TIERS = [
       'Delivered within 72 hours',
     ],
     cta: 'Start Assessment — $49',
-    ctaHref: 'mailto:hello@aocprotocol.xyz?subject=Foundation%20Assessment%20%E2%80%94%20%2449',
+    ctaHref: FOUNDATION_CHECKOUT_URL,
     featured: false,
   },
   {
@@ -88,7 +92,7 @@ const ASSESSMENT_TIERS = [
       'Delivered within 5 business days',
     ],
     cta: 'Join Founder Program — $149',
-    ctaHref: 'mailto:hello@aocprotocol.xyz?subject=Founder%20Program%20%E2%80%94%20%24149',
+    ctaHref: FOUNDER_PROGRAM_CHECKOUT_URL,
     featured: true,
   },
   {
@@ -112,8 +116,8 @@ const ASSESSMENT_TIERS = [
       'Executive Workshops',
       'Enterprise Remediation Planning',
     ],
-    cta: 'Contact Sales',
-    ctaHref: 'mailto:hello@aocprotocol.xyz?subject=Deep%20Constitutional%20Audit',
+    cta: 'Start Enterprise Intake',
+    ctaHref: ENTERPRISE_INTAKE_FORM_URL,
     featured: false,
   },
   {
@@ -136,8 +140,8 @@ const ASSESSMENT_TIERS = [
       'Certification Maintenance',
       'Continuous Assurance Reporting',
     ],
-    cta: 'Join Waitlist',
-    ctaHref: 'mailto:hello@aocprotocol.xyz?subject=Continuous%20Constitutional%20Assurance%20Waitlist',
+    cta: 'Join Continuous Assurance Waitlist',
+    ctaHref: ENTERPRISE_INTAKE_FORM_URL,
     featured: false,
   },
 ];
@@ -173,10 +177,10 @@ export const renderAssurancePage = () => {
           </div>
 
           <a
-            href="mailto:hello@aocprotocol.xyz?subject=AOC%20Constitutional%20Assurance"
+            href="#assessments"
             className="px-5 py-2 bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold rounded-xl transition-colors"
           >
-            Request assessment
+            Request Assessment
           </a>
         </div>
       </nav>
@@ -198,7 +202,7 @@ export const renderAssurancePage = () => {
             href="#assessments"
             className="px-10 py-4 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold text-lg rounded-2xl transition-colors"
           >
-            View assessments →
+            Request Assessment
           </a>
           <a
             href="#matrix"
@@ -380,6 +384,8 @@ export const renderAssurancePage = () => {
 
                 <a
                   href={tier.ctaHref}
+                  target="_blank"
+                  rel="noreferrer"
                   className={`text-center py-3 rounded-xl text-sm font-semibold transition-colors ${
                     tier.featured
                       ? 'bg-emerald-500 hover:bg-emerald-400 text-black'
@@ -436,10 +442,10 @@ export const renderAssurancePage = () => {
           First response within one business day.
         </p>
         <a
-          href="mailto:hello@aocprotocol.xyz?subject=AOC%20Constitutional%20Assurance%20Enquiry"
+          href="#assessments"
           className="inline-flex items-center px-12 py-5 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold text-lg rounded-2xl transition-colors"
         >
-          Start your assessment →
+          Request Assessment
         </a>
       </section>
 


### PR DESCRIPTION
### Motivation
- Align the Assurance page CTAs with the commercial funnel so users reach the correct checkout or intake flows. 
- Prevent top-level CTAs from opening email and instead route users to the on-page assessment package selection. 

### Description
- Added explicit URL placeholders near the top of the file: `FOUNDATION_CHECKOUT_URL`, `FOUNDER_PROGRAM_CHECKOUT_URL`, and `ENTERPRISE_INTAKE_FORM_URL` in `frontend/app/src/landing/AssurancePage.tsx`. 
- Rewired package CTAs so `Foundation` uses `FOUNDATION_CHECKOUT_URL` and `Founder Program` uses `FOUNDER_PROGRAM_CHECKOUT_URL`. 
- Converted the `Deep Constitutional Audit` and `Continuous Constitutional Assurance` CTAs to use `ENTERPRISE_INTAKE_FORM_URL` and updated their labels to `Start Enterprise Intake` and `Join Continuous Assurance Waitlist`. 
- Updated navigation/hero/closing/mobile CTAs to point to `#assessments` (same-page scroll) and ensured package external links open in a new tab with `target="_blank"` and `rel="noreferrer"` while internal `#assessments` links do not use `target`. 
- Only the CTA hrefs/labels and new constants were changed; visuals, pricing, tier descriptions, matrix content, and navigation layout were left intact.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run typecheck` and TypeScript checks passed. 
- Ran `npx eslint src/landing/AssurancePage.tsx` which reported a pre-existing `react-refresh/only-export-components` violation on the exported `renderAssurancePage` function; no new lint issues were introduced by these CTA changes. 
- Ran `git diff --check` and it passed with no whitespace or diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d660239a88325a68775dc3b452393)