### PR TITLE
Hide standalone 'Request Assessment' CTA on mobile (AssurancePage)

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -189,7 +189,7 @@ const AssurancePage = () => {
 
           <a
             href="#assessments"
-            className="px-5 py-2 bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold rounded-xl transition-colors"
+            className="hidden md:inline-block px-5 py-2 bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold rounded-xl transition-colors"
           >
             Request Assessment
           </a>


### PR DESCRIPTION
### Motivation
- Prevent header crowding on small screens by removing the standalone "Request Assessment" CTA from the header below the `md` breakpoint while keeping the action available inside the mobile menu.

### Description
- Updated `frontend/app/src/landing/AssurancePage.tsx` to add `hidden md:inline-block` to the standalone `Request Assessment` anchor at `href="#assessments"`, preserving its styling, destination, and desktop layout and leaving the mobile menu contents and hamburger behavior unchanged.

### Testing
- `npm run typecheck` completed successfully.
- `npx eslint src/landing/AssurancePage.tsx` (targeted lint) passed successfully.
- `npm run build` completed successfully and produced a production build.
- `npm run lint` (repository-wide) reported pre-existing unrelated errors in router, auth, hooks, and contact page files but did not indicate issues with the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d8158129c8325931cd2369401e32f)