### PR TITLE
Add AOC Constitutional Index section to Assurance page

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -15,6 +15,20 @@ const FOUNDER_PROGRAM_CHECKOUT_URL = 'https://buy.stripe.com/3cI7sL88D5xLbs76lAe
 const ENTERPRISE_INTAKE_FORM_URL = 'https://tally.so/r/2ER1M9';
 const CONTINUOUS_ASSURANCE_WAITLIST_URL = 'https://tally.so/r/yP7oN4';
 
+const CONSTITUTIONAL_INDEX = [
+  { rank: 1, organization: 'AnythingLLM', score: 82, tier: 'Gold', tierClass: 'gold' },
+  { rank: 2, organization: 'Ollama', score: 81, tier: 'Gold', tierClass: 'gold' },
+  { rank: 3, organization: 'Writer', score: 64, tier: 'Silver', tierClass: 'silver' },
+  {
+    rank: 4,
+    organization: 'Harvey AI',
+    score: 58,
+    tier: 'Silver Conditional',
+    tierClass: 'silver-conditional',
+  },
+  { rank: 5, organization: 'Anthropic', score: 48, tier: 'Bronze', tierClass: 'bronze' },
+];
+
 const MATRIX_DIMENSIONS = [
   {
     id: 'governance',
@@ -183,6 +197,7 @@ const AssurancePage = () => {
 
           <div className="hidden md:flex items-center gap-9 text-sm font-medium text-white/70">
             <a href="#matrix" className="hover:text-white transition-colors">Matrix</a>
+            <a href="#index" className="hover:text-white transition-colors">Index</a>
             <a href="#assessments" className="hover:text-white transition-colors">Assessments</a>
             <a href="#why" className="hover:text-white transition-colors">Why it matters</a>
             <a href="/" className="hover:text-white transition-colors">Protocol</a>
@@ -324,6 +339,98 @@ const AssurancePage = () => {
 
           <p className="mt-8 text-xs text-white/30 text-center">
             Scores shown are illustrative benchmarks from the AOC Constitutional Matrix v1.0.
+          </p>
+        </div>
+      </section>
+
+      <hr className="assurance-divider" />
+
+      {/* ── Constitutional Index ── */}
+      <section id="index" className="scroll-mt-20 py-28 px-6">
+        <div className="max-w-7xl mx-auto">
+          <header className="mb-12 max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+              Public Benchmark
+            </p>
+            <h2 className="text-4xl md:text-5xl font-semibold tracking-tight mb-5">
+              AOC Constitutional Index
+            </h2>
+            <p className="text-white/60 text-lg leading-relaxed">
+              A public ranking of AI organizations based on independently observed sovereignty
+              signals, governance posture, and constitutional readiness.
+            </p>
+          </header>
+
+          <div className="assurance-index-shell">
+            <div className="assurance-index-table" role="table" aria-label="AOC Constitutional Index">
+              <div className="assurance-index-header" role="row">
+                <span role="columnheader">Rank</span>
+                <span role="columnheader">Organization</span>
+                <span role="columnheader">Sovereignty Score</span>
+                <span role="columnheader">Classification</span>
+                <span className="sr-only" role="columnheader">Public profile</span>
+              </div>
+
+              {CONSTITUTIONAL_INDEX.map((entry) => (
+                <div className="assurance-index-row" role="row" key={entry.organization}>
+                  <div className="assurance-index-rank" role="cell">
+                    <span className="md:hidden">Rank</span>
+                    <strong>{String(entry.rank).padStart(2, '0')}</strong>
+                  </div>
+                  <div className="assurance-index-organization" role="cell">
+                    <span className="assurance-index-monogram" aria-hidden="true">
+                      {entry.organization.charAt(0)}
+                    </span>
+                    <strong>{entry.organization}</strong>
+                  </div>
+                  <div className="assurance-index-score" role="cell">
+                    <div className="assurance-index-score-copy">
+                      <span className="md:hidden">Sovereignty Score</span>
+                      <strong>{entry.score}</strong>
+                    </div>
+                    <div className="assurance-index-score-track" aria-hidden="true">
+                      <span style={{ width: `${entry.score}%` }} />
+                    </div>
+                  </div>
+                  <div role="cell">
+                    <span className={`assurance-index-tier assurance-index-tier--${entry.tierClass}`}>
+                      {entry.tier}
+                    </span>
+                  </div>
+                  <div className="assurance-index-action" role="cell">
+                    <button
+                      type="button"
+                      className="assurance-index-profile-button"
+                      aria-label={`View ${entry.organization} public profile`}
+                    >
+                      View Public Profile
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="assurance-index-footer">
+              <div>
+                <p className="text-sm font-semibold text-white">Go beyond the public signals.</p>
+                <p className="mt-1 text-sm text-white/45">
+                  Request an evidence-backed assessment for a complete constitutional view.
+                </p>
+              </div>
+              <a
+                href={ENTERPRISE_INTAKE_FORM_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="assurance-index-unlock-button"
+              >
+                Unlock Full Assessment
+              </a>
+            </div>
+          </div>
+
+          <p className="mt-6 text-xs text-white/30">
+            Initial rankings reflect publicly available information and are subject to change as
+            new evidence is assessed.
           </p>
         </div>
       </section>

--- a/frontend/app/src/landing/assurance.css
+++ b/frontend/app/src/landing/assurance.css
@@ -65,3 +65,238 @@
   border-top: 1px solid rgba(255, 255, 255, 0.07);
   margin: 0;
 }
+
+.assurance-index-shell {
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(145deg, rgba(52, 211, 153, 0.045), transparent 40%),
+    rgba(255, 255, 255, 0.018);
+}
+
+.assurance-index-header,
+.assurance-index-row {
+  display: grid;
+  grid-template-columns: 0.55fr 1.5fr 1.35fr 1.15fr auto;
+  align-items: center;
+  column-gap: 1.5rem;
+}
+
+.assurance-index-header {
+  padding: 0.875rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.assurance-index-row {
+  min-height: 5.5rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.065);
+  transition: background-color 0.2s ease;
+}
+
+.assurance-index-row:last-child {
+  border-bottom: 0;
+}
+
+.assurance-index-row:hover {
+  background: rgba(52, 211, 153, 0.035);
+}
+
+.assurance-index-rank strong {
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 0.875rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.assurance-index-organization {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+
+.assurance-index-monogram {
+  display: grid;
+  flex: 0 0 auto;
+  width: 2.25rem;
+  height: 2.25rem;
+  place-items: center;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+  border-radius: 0.75rem;
+  background: rgba(52, 211, 153, 0.07);
+  color: #6ee7b7;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.assurance-index-score-copy {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.assurance-index-score strong {
+  color: #6ee7b7;
+  font-size: 1.125rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.assurance-index-score-track {
+  width: 100%;
+  height: 3px;
+  margin-top: 0.5rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.assurance-index-score-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #10b981, #6ee7b7);
+}
+
+.assurance-index-tier {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.35rem 0.625rem;
+  border: 1px solid;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.assurance-index-tier--gold {
+  border-color: rgba(251, 191, 36, 0.25);
+  background: rgba(251, 191, 36, 0.08);
+  color: #fcd34d;
+}
+
+.assurance-index-tier--silver {
+  border-color: rgba(203, 213, 225, 0.2);
+  background: rgba(203, 213, 225, 0.07);
+  color: #cbd5e1;
+}
+
+.assurance-index-tier--silver-conditional {
+  border-color: rgba(148, 163, 184, 0.2);
+  background: rgba(148, 163, 184, 0.07);
+  color: #cbd5e1;
+}
+
+.assurance-index-tier--bronze {
+  border-color: rgba(251, 146, 60, 0.22);
+  background: rgba(251, 146, 60, 0.07);
+  color: #fdba74;
+}
+
+.assurance-index-profile-button,
+.assurance-index-unlock-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.assurance-index-profile-button {
+  padding: 0.625rem 0.875rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+}
+
+.assurance-index-profile-button:hover {
+  border-color: rgba(110, 231, 183, 0.35);
+  background: rgba(52, 211, 153, 0.06);
+  color: #fff;
+}
+
+.assurance-index-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.5rem;
+  border-top: 1px solid rgba(52, 211, 153, 0.12);
+  background: rgba(52, 211, 153, 0.035);
+}
+
+.assurance-index-unlock-button {
+  flex: 0 0 auto;
+  padding: 0.75rem 1rem;
+  background: #10b981;
+  color: #06110d;
+}
+
+.assurance-index-unlock-button:hover {
+  background: #34d399;
+}
+
+@media (max-width: 767px) {
+  .assurance-index-header {
+    display: none;
+  }
+
+  .assurance-index-row {
+    grid-template-columns: 1fr auto;
+    gap: 1rem;
+    padding: 1.25rem;
+  }
+
+  .assurance-index-rank {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    grid-column: 1 / -1;
+    color: rgba(255, 255, 255, 0.35);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .assurance-index-organization {
+    grid-column: 1;
+  }
+
+  .assurance-index-score {
+    grid-column: 1 / -1;
+  }
+
+  .assurance-index-score-copy span {
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .assurance-index-action {
+    grid-column: 1 / -1;
+  }
+
+  .assurance-index-profile-button {
+    width: 100%;
+  }
+
+  .assurance-index-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .assurance-index-unlock-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a public, first-pass benchmark for organizational sovereignty and constitutional readiness on the existing AOC Assurance page.
- Surface a concise ranking and classification so visitors can quickly compare sovereignty posture and follow up for full assessments.
- Preserve the existing AOC Assurance visual identity and reuse existing intake CTA flow without implementing payments.

### Description
- Added a `CONSTITUTIONAL_INDEX` data array and an `Index` nav link to the Assurance page to hold the five requested organizations and scores in `frontend/app/src/landing/AssurancePage.tsx`.
- Implemented a new `AOC Constitutional Index` section that renders a responsive ranking table with per-organization `View Public Profile` buttons and an `Unlock Full Assessment` CTA which points to the existing enterprise intake URL.
- Added styles in `frontend/app/src/landing/assurance.css` to match the Assurance emerald-on-dark visual system, including classification badges for `Gold`, `Silver`, `Silver Conditional`, and `Bronze`, plus mobile layout adjustments.
- Kept CTAs presentation-only and did not add any payment or profile routing logic in this iteration.

### Testing
- Built the frontend with `npm run build` and the production build completed successfully.
- Ran `git diff --check` to ensure the diff is clean and no whitespace or check failures were introduced.
- Ran `npm run lint`, which reported pre-existing repository-wide lint errors unrelated to the modified files; no new lint errors were introduced in the changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a304048fbe48325919376b53154c70b)