### PR TITLE
Refactor AOC Constitutional Index into reusable data model

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useState } from 'react';
 import { LogoRotating } from '../components/logo/LogoRotating';
+import { ASSURANCE_INDEX_ORGANIZATIONS } from './assuranceIndexData';
 import './assurance.css';
 
 const MOBILE_NAVIGATION_ITEMS = [
@@ -14,20 +15,6 @@ const FOUNDATION_CHECKOUT_URL = 'https://buy.stripe.com/aFa5kD1Kfgcp67N11gejK01'
 const FOUNDER_PROGRAM_CHECKOUT_URL = 'https://buy.stripe.com/3cI7sL88D5xLbs76lAejK00';
 const ENTERPRISE_INTAKE_FORM_URL = 'https://tally.so/r/2ER1M9';
 const CONTINUOUS_ASSURANCE_WAITLIST_URL = 'https://tally.so/r/yP7oN4';
-
-const CONSTITUTIONAL_INDEX = [
-  { rank: 1, organization: 'AnythingLLM', score: 82, tier: 'Gold', tierClass: 'gold' },
-  { rank: 2, organization: 'Ollama', score: 81, tier: 'Gold', tierClass: 'gold' },
-  { rank: 3, organization: 'Writer', score: 64, tier: 'Silver', tierClass: 'silver' },
-  {
-    rank: 4,
-    organization: 'Harvey AI',
-    score: 58,
-    tier: 'Silver Conditional',
-    tierClass: 'silver-conditional',
-  },
-  { rank: 5, organization: 'Anthropic', score: 48, tier: 'Bronze', tierClass: 'bronze' },
-];
 
 const MATRIX_DIMENSIONS = [
   {
@@ -371,37 +358,39 @@ const AssurancePage = () => {
                 <span className="sr-only" role="columnheader">Public profile</span>
               </div>
 
-              {CONSTITUTIONAL_INDEX.map((entry) => (
-                <div className="assurance-index-row" role="row" key={entry.organization}>
+              {ASSURANCE_INDEX_ORGANIZATIONS.map((organization, index) => (
+                <div className="assurance-index-row" role="row" key={organization.id}>
                   <div className="assurance-index-rank" role="cell">
                     <span className="md:hidden">Rank</span>
-                    <strong>{String(entry.rank).padStart(2, '0')}</strong>
+                    <strong>{String(index + 1).padStart(2, '0')}</strong>
                   </div>
                   <div className="assurance-index-organization" role="cell">
                     <span className="assurance-index-monogram" aria-hidden="true">
-                      {entry.organization.charAt(0)}
+                      {organization.name.charAt(0)}
                     </span>
-                    <strong>{entry.organization}</strong>
+                    <strong>{organization.name}</strong>
                   </div>
                   <div className="assurance-index-score" role="cell">
                     <div className="assurance-index-score-copy">
                       <span className="md:hidden">Sovereignty Score</span>
-                      <strong>{entry.score}</strong>
+                      <strong>{organization.sovereigntyScore}</strong>
                     </div>
                     <div className="assurance-index-score-track" aria-hidden="true">
-                      <span style={{ width: `${entry.score}%` }} />
+                      <span style={{ width: `${organization.sovereigntyScore}%` }} />
                     </div>
                   </div>
                   <div role="cell">
-                    <span className={`assurance-index-tier assurance-index-tier--${entry.tierClass}`}>
-                      {entry.tier}
+                    <span
+                      className={`assurance-index-tier assurance-index-tier--${organization.certificationClass}`}
+                    >
+                      {organization.certification}
                     </span>
                   </div>
                   <div className="assurance-index-action" role="cell">
                     <button
                       type="button"
                       className="assurance-index-profile-button"
-                      aria-label={`View ${entry.organization} public profile`}
+                      aria-label={`View ${organization.name} public profile`}
                     >
                       View Public Profile
                     </button>

--- a/frontend/app/src/landing/assuranceIndexData.ts
+++ b/frontend/app/src/landing/assuranceIndexData.ts
@@ -1,0 +1,117 @@
+export type AssuranceIndexOrganization = {
+  id: string;
+  name: string;
+  slug: string;
+  website: string;
+  assessmentNumber: string;
+  assessmentDate: string;
+  sovereigntyScore: number;
+  governanceScore: number | null;
+  certification: string;
+  certificationClass: string;
+  status: string;
+  summary: string;
+  strengths: string[];
+  constraints: string[];
+  fullAssessmentPrice: string;
+  fullAssessmentCtaLabel: string;
+  fullAssessmentCheckoutUrl: string;
+};
+
+export const ASSURANCE_INDEX_ORGANIZATIONS: AssuranceIndexOrganization[] = [
+  {
+    id: 'anythingllm',
+    name: 'AnythingLLM',
+    slug: 'anythingllm',
+    website: 'https://anythingllm.com',
+    assessmentNumber: 'AOC-001',
+    assessmentDate: '2026-06-15',
+    sovereigntyScore: 82,
+    governanceScore: null,
+    certification: 'Gold',
+    certificationClass: 'gold',
+    status: 'Assessed',
+    summary: 'A privacy-focused AI application with strong local deployment and data-control options.',
+    strengths: ['Local deployment support', 'Open-source availability', 'Flexible model selection'],
+    constraints: ['Governance evidence is based on publicly available materials'],
+    fullAssessmentPrice: '$149',
+    fullAssessmentCtaLabel: 'Request Full Assessment',
+    fullAssessmentCheckoutUrl: 'https://buy.stripe.com/3cI7sL88D5xLbs76lAejK00',
+  },
+  {
+    id: 'ollama',
+    name: 'Ollama',
+    slug: 'ollama',
+    website: 'https://ollama.com',
+    assessmentNumber: 'AOC-002',
+    assessmentDate: '2026-06-15',
+    sovereigntyScore: 81,
+    governanceScore: null,
+    certification: 'Gold',
+    certificationClass: 'gold',
+    status: 'Assessed',
+    summary: 'A local model runtime that gives users direct control over model execution and data.',
+    strengths: ['Local-first execution', 'Broad model support', 'Open-source tooling'],
+    constraints: ['Enterprise governance controls vary by implementation'],
+    fullAssessmentPrice: '$149',
+    fullAssessmentCtaLabel: 'Request Full Assessment',
+    fullAssessmentCheckoutUrl: 'https://buy.stripe.com/3cI7sL88D5xLbs76lAejK00',
+  },
+  {
+    id: 'writer',
+    name: 'Writer',
+    slug: 'writer',
+    website: 'https://writer.com',
+    assessmentNumber: 'AOC-003',
+    assessmentDate: '2026-06-15',
+    sovereigntyScore: 64,
+    governanceScore: null,
+    certification: 'Silver',
+    certificationClass: 'silver',
+    status: 'Assessed',
+    summary: 'An enterprise generative AI platform with documented security and governance controls.',
+    strengths: ['Enterprise control plane', 'Documented security posture', 'Configurable AI workflows'],
+    constraints: ['Hosted-service dependencies limit direct infrastructure control'],
+    fullAssessmentPrice: '$149',
+    fullAssessmentCtaLabel: 'Request Full Assessment',
+    fullAssessmentCheckoutUrl: 'https://buy.stripe.com/3cI7sL88D5xLbs76lAejK00',
+  },
+  {
+    id: 'harvey-ai',
+    name: 'Harvey AI',
+    slug: 'harvey-ai',
+    website: 'https://www.harvey.ai',
+    assessmentNumber: 'AOC-004',
+    assessmentDate: '2026-06-15',
+    sovereigntyScore: 58,
+    governanceScore: null,
+    certification: 'Silver Conditional',
+    certificationClass: 'silver-conditional',
+    status: 'Assessed',
+    summary: 'A professional AI platform designed for legal and other high-trust knowledge work.',
+    strengths: ['Domain-specific workflows', 'Enterprise focus', 'Professional-services use cases'],
+    constraints: ['Limited public technical detail constrains independent verification'],
+    fullAssessmentPrice: '$149',
+    fullAssessmentCtaLabel: 'Request Full Assessment',
+    fullAssessmentCheckoutUrl: 'https://buy.stripe.com/3cI7sL88D5xLbs76lAejK00',
+  },
+  {
+    id: 'anthropic',
+    name: 'Anthropic',
+    slug: 'anthropic',
+    website: 'https://www.anthropic.com',
+    assessmentNumber: 'AOC-005',
+    assessmentDate: '2026-06-15',
+    sovereigntyScore: 48,
+    governanceScore: null,
+    certification: 'Bronze',
+    certificationClass: 'bronze',
+    status: 'Assessed',
+    summary: 'A frontier AI provider with a public emphasis on model safety and responsible scaling.',
+    strengths: ['Published safety research', 'Documented responsible scaling policy', 'Enterprise offerings'],
+    constraints: ['Cloud-hosted models provide limited user control over core infrastructure'],
+    fullAssessmentPrice: '$149',
+    fullAssessmentCtaLabel: 'Request Full Assessment',
+    fullAssessmentCheckoutUrl: 'https://buy.stripe.com/3cI7sL88D5xLbs76lAejK00',
+  },
+];


### PR DESCRIPTION
### Motivation
- Make the AOC Constitutional Index a reusable, typed data model so the index can be consumed by other components and future UIs.  
- Centralize assessed-organization metadata (scores, certification, CTAs, summaries) to separate content from presentation.  
- Preserve the existing public table layout and accessibility while preparing for future profile pages and assessment flows.

### Description
- Add a typed data file `frontend/app/src/landing/assuranceIndexData.ts` that defines `AssuranceIndexOrganization` and exports `ASSURANCE_INDEX_ORGANIZATIONS` populated with the five organizations.  
- Populate entries for `AnythingLLM`, `Ollama`, `Writer`, `Harvey AI`, and `Anthropic` with fields requested including `id`, `name`, `slug`, `website`, `assessmentNumber`, `assessmentDate`, `sovereigntyScore`, `governanceScore` (set to `null`), `certification`, `certificationClass`, `status`, `summary`, `strengths`, `constraints`, `fullAssessmentPrice`, `fullAssessmentCtaLabel`, and `fullAssessmentCheckoutUrl`.  
- Refactor `frontend/app/src/landing/AssurancePage.tsx` to import `ASSURANCE_INDEX_ORGANIZATIONS` and render the existing Constitutional Index table from it, mapping rank, monogram, sovereignty score, and certification while preserving the original classes and markup.  
- Leave profile navigation, payment logic, and full-assessment report content unimplemented as requested.

### Testing
- Ran `npm run build` in `frontend/app` and the Vite build completed successfully.  
- Ran `git diff --check` and no whitespace or diff-check issues were reported.  
- Ran `npx eslint src/landing/AssurancePage.tsx src/landing/assuranceIndexData.ts` and the changed files passed linting.  
- Ran the repository lint (`npm run lint` in `frontend/app`) which surfaced seven pre-existing errors in unrelated files (`src/app/router.tsx`, `src/auth/session.tsx`, `src/hooks/useAccessRequests.ts`, `src/hooks/useGrants.ts`, and `src/landing/ContactPage.tsx`) and thus the global lint script failed while the changes themselves have no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a304658937c83258868a9443619edc7)