### PR TITLE
feat: add public constitutional profile pages

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { AocLandingPage } from './landing/AocLandingPage';
 import { renderAssurancePage } from './landing/AssurancePage';
+import { AssuranceProfilePage } from './landing/AssuranceProfilePage';
 import { renderEnterprisePage } from './landing/EnterprisePage';
 import { renderDocsPage } from './landing/DocsPage';
 import { renderContactPage } from './landing/ContactPage';
@@ -12,6 +13,9 @@ function getView() {
 
 export default function App() {
   const [view, setView] = useState(getView());
+  const assuranceProfileMatch = window.location.pathname.match(
+    /^\/assurance\/index\/([^/]+)\/?$/
+  );
 
   useEffect(() => {
     const sync = () => setView(getView());
@@ -23,6 +27,9 @@ export default function App() {
     };
   }, []);
 
+  if (assuranceProfileMatch) {
+    return <AssuranceProfilePage slug={decodeURIComponent(assuranceProfileMatch[1])} />;
+  }
   if (view === 'assurance') return renderAssurancePage();
   if (view === 'docs') return renderDocsPage();
   if (view === 'enterprise') return renderEnterprisePage();

--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -387,13 +387,13 @@ const AssurancePage = () => {
                     </span>
                   </div>
                   <div className="assurance-index-action" role="cell">
-                    <button
-                      type="button"
+                    <a
+                      href={`/assurance/index/${organization.slug}`}
                       className="assurance-index-profile-button"
                       aria-label={`View ${organization.name} public profile`}
                     >
                       View Public Profile
-                    </button>
+                    </a>
                   </div>
                 </div>
               ))}

--- a/frontend/app/src/landing/AssuranceProfilePage.tsx
+++ b/frontend/app/src/landing/AssuranceProfilePage.tsx
@@ -1,0 +1,183 @@
+import { LogoRotating } from '../components/logo/LogoRotating';
+import {
+  ASSURANCE_INDEX_ORGANIZATIONS,
+  type AssuranceIndexOrganization,
+} from './assuranceIndexData';
+import './assurance.css';
+
+const ENTERPRISE_URL = '/?view=enterprise';
+
+function formatAssessmentDate(date: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T00:00:00Z`));
+}
+
+function ScoreCard({
+  label,
+  score,
+}: {
+  label: string;
+  score: number | null;
+}) {
+  return (
+    <article className="assurance-profile-score-card">
+      <p>{label}</p>
+      {score === null ? (
+        <strong className="assurance-profile-score-pending">
+          Pending Public Governance Assessment
+        </strong>
+      ) : (
+        <>
+          <div className="assurance-profile-score-value">
+            <strong>{score}</strong>
+            <span>/ 100</span>
+          </div>
+          <div className="assurance-index-score-track" aria-hidden="true">
+            <span style={{ width: `${score}%` }} />
+          </div>
+        </>
+      )}
+    </article>
+  );
+}
+
+function ProfileContent({
+  organization,
+}: {
+  organization: AssuranceIndexOrganization;
+}) {
+  return (
+    <>
+      <header className="assurance-profile-header">
+        <div>
+          <a className="assurance-profile-back" href="/?view=assurance#index">
+            <span aria-hidden="true">←</span> Constitutional Index
+          </a>
+          <p className="assurance-profile-eyebrow">Public Constitutional Profile</p>
+          <h1>{organization.name}</h1>
+        </div>
+        <span
+          className={`assurance-index-tier assurance-index-tier--${organization.certificationClass}`}
+        >
+          {organization.certification} Certification
+        </span>
+        <dl className="assurance-profile-meta">
+          <div>
+            <dt>Assessment Number</dt>
+            <dd>{organization.assessmentNumber}</dd>
+          </div>
+          <div>
+            <dt>Assessment Date</dt>
+            <dd>{formatAssessmentDate(organization.assessmentDate)}</dd>
+          </div>
+        </dl>
+      </header>
+
+      <section className="assurance-profile-scores" aria-label="Public assessment scores">
+        <ScoreCard label="Sovereignty Score" score={organization.sovereigntyScore} />
+        <ScoreCard label="Governance Score" score={organization.governanceScore} />
+      </section>
+
+      <section className="assurance-profile-section">
+        <p className="assurance-profile-section-label">Executive Summary</p>
+        <h2>Constitutional posture at a glance</h2>
+        <p className="assurance-profile-summary">{organization.summary}</p>
+      </section>
+
+      <div className="assurance-profile-findings">
+        <section className="assurance-profile-section">
+          <p className="assurance-profile-section-label">Strengths</p>
+          <h2>Observed strengths</h2>
+          <ul>
+            {organization.strengths.map((strength) => (
+              <li key={strength}>
+                <span aria-hidden="true">✓</span>
+                {strength}
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section className="assurance-profile-section">
+          <p className="assurance-profile-section-label assurance-profile-section-label--muted">
+            Constraints
+          </p>
+          <h2>Public assessment constraints</h2>
+          <ul className="assurance-profile-constraints">
+            {organization.constraints.map((constraint) => (
+              <li key={constraint}>
+                <span aria-hidden="true">—</span>
+                {constraint}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <section className="assurance-profile-cta">
+        <div>
+          <p className="assurance-profile-section-label">Complete Assessment</p>
+          <h2>Represent this organization?</h2>
+          <p>
+            Unlock the complete AOC Constitutional Assessment including findings, evidence review,
+            domain analysis, and recommendations.
+          </p>
+        </div>
+        <div className="assurance-profile-cta-actions">
+          <a
+            className="assurance-profile-primary-cta"
+            href={organization.fullAssessmentCheckoutUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {organization.fullAssessmentCtaLabel}
+          </a>
+          <a className="assurance-profile-secondary-cta" href={ENTERPRISE_URL}>
+            Explore AOC Enterprise
+          </a>
+        </div>
+      </section>
+    </>
+  );
+}
+
+export function AssuranceProfilePage({ slug }: { slug: string }) {
+  const organization = ASSURANCE_INDEX_ORGANIZATIONS.find((entry) => entry.slug === slug);
+
+  return (
+    <main className="min-h-screen bg-[#070d0b] text-white font-sans">
+      <nav className="sticky top-0 z-30 backdrop-blur bg-[#070d0b]/80 border-b border-white/10">
+        <div className="max-w-7xl mx-auto h-16 px-6 flex items-center justify-between">
+          <a href="/?view=assurance" className="flex items-center gap-3">
+            <LogoRotating size={28} inverted />
+            <div className="flex items-baseline gap-2">
+              <span className="text-xl font-semibold tracking-tighter">AOC</span>
+              <span className="text-xs text-emerald-400 uppercase tracking-[0.2em]">Assurance</span>
+            </div>
+          </a>
+          <a className="assurance-profile-nav-link" href="/?view=assurance#index">
+            Constitutional Index
+          </a>
+        </div>
+      </nav>
+
+      <div className="assurance-profile-page">
+        {organization ? (
+          <ProfileContent organization={organization} />
+        ) : (
+          <section className="assurance-profile-not-found">
+            <p className="assurance-profile-eyebrow">Public Constitutional Profile</p>
+            <h1>Organization not found</h1>
+            <p>This organization does not have a public AOC Constitutional Index profile.</p>
+            <a className="assurance-profile-primary-cta" href="/?view=assurance#index">
+              Return to the Index
+            </a>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/src/landing/assurance.css
+++ b/frontend/app/src/landing/assurance.css
@@ -300,3 +300,290 @@
     width: 100%;
   }
 }
+
+.assurance-profile-page {
+  width: min(100% - 3rem, 72rem);
+  margin: 0 auto;
+  padding: 5rem 0 7rem;
+}
+
+.assurance-profile-nav-link,
+.assurance-profile-back {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.assurance-profile-nav-link:hover,
+.assurance-profile-back:hover {
+  color: #fff;
+}
+
+.assurance-profile-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2.5rem;
+  align-items: end;
+  padding-bottom: 3rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+.assurance-profile-back {
+  display: inline-flex;
+  gap: 0.5rem;
+  margin-bottom: 3rem;
+}
+
+.assurance-profile-eyebrow,
+.assurance-profile-section-label {
+  color: #34d399;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.assurance-profile-header h1 {
+  margin-top: 0.75rem;
+  font-size: clamp(3rem, 7vw, 5.5rem);
+  font-weight: 600;
+  letter-spacing: -0.055em;
+  line-height: 0.95;
+}
+
+.assurance-profile-meta {
+  display: flex;
+  grid-column: 1 / -1;
+  gap: 4rem;
+  margin-top: 1rem;
+}
+
+.assurance-profile-meta dt,
+.assurance-profile-score-card > p {
+  margin-bottom: 0.5rem;
+  color: rgba(255, 255, 255, 0.38);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.assurance-profile-meta dd {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.assurance-profile-scores {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 3rem 0 5rem;
+}
+
+.assurance-profile-score-card,
+.assurance-profile-section {
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(145deg, rgba(52, 211, 153, 0.045), transparent 45%),
+    rgba(255, 255, 255, 0.018);
+}
+
+.assurance-profile-score-card {
+  min-height: 10.5rem;
+  padding: 1.75rem;
+}
+
+.assurance-profile-score-value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.assurance-profile-score-value strong {
+  color: #6ee7b7;
+  font-size: 3.25rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.assurance-profile-score-value span {
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 0.875rem;
+}
+
+.assurance-profile-score-pending {
+  display: block;
+  max-width: 20rem;
+  margin-top: 1.25rem;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 1.125rem;
+  line-height: 1.45;
+}
+
+.assurance-profile-section {
+  padding: clamp(1.75rem, 5vw, 3.5rem);
+}
+
+.assurance-profile-section h2,
+.assurance-profile-cta h2 {
+  margin-top: 0.875rem;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+}
+
+.assurance-profile-summary {
+  max-width: 52rem;
+  margin-top: 1.5rem;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 1.125rem;
+  line-height: 1.8;
+}
+
+.assurance-profile-findings {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.assurance-profile-section ul {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.assurance-profile-section li {
+  display: flex;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.68);
+  line-height: 1.6;
+}
+
+.assurance-profile-section li span {
+  color: #34d399;
+}
+
+.assurance-profile-section-label--muted,
+.assurance-profile-constraints li span {
+  color: #94a3b8;
+}
+
+.assurance-profile-cta {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 3rem;
+  margin-top: 5rem;
+  padding: clamp(2rem, 6vw, 4rem);
+  border: 1px solid rgba(52, 211, 153, 0.2);
+  border-radius: 1.5rem;
+  background:
+    radial-gradient(circle at top left, rgba(16, 185, 129, 0.13), transparent 50%),
+    rgba(255, 255, 255, 0.025);
+}
+
+.assurance-profile-cta p:not(.assurance-profile-section-label) {
+  max-width: 42rem;
+  margin-top: 1.25rem;
+  color: rgba(255, 255, 255, 0.58);
+  line-height: 1.7;
+}
+
+.assurance-profile-cta-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.75rem;
+}
+
+.assurance-profile-primary-cta,
+.assurance-profile-secondary-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0.75rem 1.125rem;
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.assurance-profile-primary-cta {
+  background: #10b981;
+  color: #06110d;
+}
+
+.assurance-profile-primary-cta:hover {
+  background: #34d399;
+}
+
+.assurance-profile-secondary-cta {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.assurance-profile-secondary-cta:hover {
+  border-color: rgba(110, 231, 183, 0.35);
+  background: rgba(52, 211, 153, 0.06);
+}
+
+.assurance-profile-not-found {
+  padding: 8rem 0;
+  text-align: center;
+}
+
+.assurance-profile-not-found h1 {
+  margin-top: 1rem;
+  font-size: 3rem;
+  font-weight: 600;
+}
+
+.assurance-profile-not-found > p:not(.assurance-profile-eyebrow) {
+  margin: 1rem 0 2rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+@media (max-width: 767px) {
+  .assurance-profile-page {
+    width: min(100% - 2rem, 72rem);
+    padding-top: 3rem;
+  }
+
+  .assurance-profile-nav-link {
+    display: none;
+  }
+
+  .assurance-profile-header,
+  .assurance-profile-scores,
+  .assurance-profile-findings {
+    grid-template-columns: 1fr;
+  }
+
+  .assurance-profile-header {
+    align-items: start;
+    gap: 1.5rem;
+  }
+
+  .assurance-profile-header .assurance-index-tier {
+    grid-row: 2;
+  }
+
+  .assurance-profile-meta {
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .assurance-profile-cta {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .assurance-profile-cta-actions {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide public, read-only organization profile pages for the AOC Constitutional Index so visitors can view certification, high-level scores, and a short public summary without exposing sensitive assessment artifacts.
- Surface a clear conversion path for organizations to request the full assessment while keeping PDFs, evidence tables, domain scoring, and recommendations private.

### Description

- Add a new `AssuranceProfilePage` component that renders profiles at `/assurance/index/[slug]` using `ASSURANCE_INDEX_ORGANIZATIONS` and includes header metadata (name, certification badge, assessment number, formatted date).  
- Display a Sovereignty Score card and a Governance Score card that shows the required pending state `Pending Public Governance Assessment` when `governanceScore` is `null`.  
- Show Executive Summary, Strengths, Constraints, and a CTA area using the existing `fullAssessmentCtaLabel` and a secondary "Explore AOC Enterprise" link, explicitly not rendering PDFs, evidence tables, domain details, or recommendations.  
- Wire the Constitutional Index table so each row’s "View Public Profile" navigates to `/assurance/index/{slug}`, update lightweight router logic in `App.tsx` to detect and render profile pages, and add responsive profile styling in `assurance.css`.

### Testing

- Ran `npm run build` (TypeScript build + Vite) and the build completed successfully.  
- Ran targeted ESLint checks on the modified files with `npx eslint src/App.tsx src/landing/AssurancePage.tsx src/landing/AssuranceProfilePage.tsx` and there were no reported lint failures.  
- Performed automated HTTP checks against the preview server for all five slugs (`anythingllm`, `ollama`, `writer`, `harvey-ai`, `anthropic`) and each route returned HTTP 200.  
- Ran `git diff --check` to validate local diffs and no whitespace/check errors were reported; browser screenshot tooling was not available in the environment so visual screenshots were not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3047db86d08325a78597a9633fab6d)