### PR TITLE
Add Governance Score and qualitative Governance Audit to public index and profiles

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -413,7 +413,7 @@ const AssurancePage = () => {
               <div className="assurance-index-header" role="row">
                 <span role="columnheader">Rank</span>
                 <span role="columnheader">Organization</span>
-                <span role="columnheader">Sovereignty Score</span>
+                <span role="columnheader">Scores</span>
                 <span role="columnheader">Classification</span>
                 <span className="sr-only" role="columnheader">Public profile</span>
               </div>
@@ -430,13 +430,24 @@ const AssurancePage = () => {
                     </span>
                     <strong>{organization.name}</strong>
                   </div>
-                  <div className="assurance-index-score" role="cell">
-                    <div className="assurance-index-score-copy">
-                      <span className="md:hidden">Sovereignty Score</span>
-                      <strong>{organization.sovereigntyScore}</strong>
+                  <div className="assurance-index-scores" role="cell">
+                    <div className="assurance-index-score assurance-index-score--sovereignty">
+                      <div className="assurance-index-score-copy">
+                        <span>Sovereignty Score</span>
+                        <strong>{organization.sovereigntyScore}</strong>
+                      </div>
+                      <div className="assurance-index-score-track" aria-hidden="true">
+                        <span style={{ width: `${organization.sovereigntyScore}%` }} />
+                      </div>
                     </div>
-                    <div className="assurance-index-score-track" aria-hidden="true">
-                      <span style={{ width: `${organization.sovereigntyScore}%` }} />
+                    <div className="assurance-index-score assurance-index-score--governance">
+                      <div className="assurance-index-score-copy">
+                        <span>Governance Score</span>
+                        <strong>{organization.governanceScore}</strong>
+                      </div>
+                      <div className="assurance-index-score-track" aria-hidden="true">
+                        <span style={{ width: `${organization.governanceScore}%` }} />
+                      </div>
                     </div>
                   </div>
                   <div role="cell">

--- a/frontend/app/src/landing/AssuranceProfilePage.tsx
+++ b/frontend/app/src/landing/AssuranceProfilePage.tsx
@@ -19,28 +19,22 @@ function formatAssessmentDate(date: string) {
 function ScoreCard({
   label,
   score,
+  tone = 'sovereignty',
 }: {
   label: string;
-  score: number | null;
+  score: number;
+  tone?: 'sovereignty' | 'governance';
 }) {
   return (
-    <article className="assurance-profile-score-card">
+    <article className={`assurance-profile-score-card assurance-profile-score-card--${tone}`}>
       <p>{label}</p>
-      {score === null ? (
-        <strong className="assurance-profile-score-pending">
-          Pending Public Governance Assessment
-        </strong>
-      ) : (
-        <>
-          <div className="assurance-profile-score-value">
-            <strong>{score}</strong>
-            <span>/ 100</span>
-          </div>
-          <div className="assurance-index-score-track" aria-hidden="true">
-            <span style={{ width: `${score}%` }} />
-          </div>
-        </>
-      )}
+      <div className="assurance-profile-score-value">
+        <strong>{score}</strong>
+        <span>/ 100</span>
+      </div>
+      <div className="assurance-index-score-track" aria-hidden="true">
+        <span style={{ width: `${score}%` }} />
+      </div>
     </article>
   );
 }
@@ -79,7 +73,11 @@ function ProfileContent({
 
       <section className="assurance-profile-scores" aria-label="Public assessment scores">
         <ScoreCard label="Sovereignty Score" score={organization.sovereigntyScore} />
-        <ScoreCard label="Governance Score" score={organization.governanceScore} />
+        <ScoreCard
+          label="Governance Score"
+          score={organization.governanceScore}
+          tone="governance"
+        />
       </section>
 
       <section className="assurance-profile-section">
@@ -116,6 +114,43 @@ function ProfileContent({
           </ul>
         </section>
       </div>
+
+      <section className="assurance-profile-section assurance-profile-audit-section">
+        <p className="assurance-profile-section-label assurance-profile-section-label--governance">
+          Governance Audit Details
+        </p>
+        <h2>Qualitative governance assessment</h2>
+        <div className="assurance-profile-audit-grid">
+          {organization.governanceAudit.map((audit) => (
+            <article className="assurance-profile-audit-card" key={audit.title}>
+              <div className="assurance-profile-audit-card-header">
+                <h3>{audit.title}</h3>
+                <span>{audit.status}</span>
+              </div>
+              <dl>
+                <div>
+                  <dt>Finding</dt>
+                  <dd>{audit.finding}</dd>
+                </div>
+                <div>
+                  <dt>Risk</dt>
+                  <dd>{audit.risk}</dd>
+                </div>
+                {audit.evidence ? (
+                  <div>
+                    <dt>Evidence Observed</dt>
+                    <dd>{audit.evidence}</dd>
+                  </div>
+                ) : null}
+                <div>
+                  <dt>Recommendation</dt>
+                  <dd>{audit.recommendation}</dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="assurance-profile-cta">
         <div>

--- a/frontend/app/src/landing/assurance.css
+++ b/frontend/app/src/landing/assurance.css
@@ -226,10 +226,24 @@
   font-weight: 700;
 }
 
+.assurance-index-scores {
+  display: grid;
+  gap: 0.85rem;
+}
+
 .assurance-index-score-copy {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  gap: 1rem;
+}
+
+.assurance-index-score-copy span {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
 .assurance-index-score strong {
@@ -252,6 +266,16 @@
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, #10b981, #6ee7b7);
+}
+
+.assurance-index-score--governance strong,
+.assurance-profile-score-card--governance .assurance-profile-score-value strong {
+  color: #fb7185;
+}
+
+.assurance-index-score--governance .assurance-index-score-track span,
+.assurance-profile-score-card--governance .assurance-index-score-track span {
+  background: linear-gradient(90deg, #ef4444, #fb7185);
 }
 
 .assurance-index-tier {
@@ -401,7 +425,7 @@
     grid-column: 1;
   }
 
-  .assurance-index-score {
+  .assurance-index-scores {
     grid-column: 1 / -1;
   }
 
@@ -603,6 +627,73 @@
   color: #94a3b8;
 }
 
+
+.assurance-profile-section-label--governance {
+  color: #fb7185;
+}
+
+.assurance-profile-audit-section {
+  margin-top: 1rem;
+}
+
+.assurance-profile-audit-grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.assurance-profile-audit-card {
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.assurance-profile-audit-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.assurance-profile-audit-card h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.assurance-profile-audit-card-header span {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid rgba(251, 113, 133, 0.24);
+  border-radius: 999px;
+  background: rgba(251, 113, 133, 0.08);
+  color: #fda4af;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.assurance-profile-audit-card dl {
+  display: grid;
+  gap: 1rem;
+}
+
+.assurance-profile-audit-card dt {
+  margin-bottom: 0.35rem;
+  color: rgba(255, 255, 255, 0.38);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.assurance-profile-audit-card dd {
+  color: rgba(255, 255, 255, 0.66);
+  line-height: 1.65;
+}
+
 .assurance-profile-cta {
   display: flex;
   align-items: end;
@@ -708,7 +799,8 @@
     gap: 1.25rem;
   }
 
-  .assurance-profile-cta {
+
+.assurance-profile-cta {
     align-items: stretch;
     flex-direction: column;
   }

--- a/frontend/app/src/landing/assuranceIndexData.ts
+++ b/frontend/app/src/landing/assuranceIndexData.ts
@@ -1,3 +1,12 @@
+export type GovernanceAuditSection = {
+  title: string;
+  status: 'Strong' | 'Partial' | 'Weak' | 'Missing';
+  finding: string;
+  risk: string;
+  recommendation: string;
+  evidence?: string;
+};
+
 export type AssuranceIndexOrganization = {
   id: string;
   name: string;
@@ -6,7 +15,8 @@ export type AssuranceIndexOrganization = {
   assessmentNumber: string;
   assessmentDate: string;
   sovereigntyScore: number;
-  governanceScore: number | null;
+  governanceScore: number;
+  governanceAudit: GovernanceAuditSection[];
   certification: string;
   certificationClass: string;
   status: string;
@@ -27,7 +37,24 @@ export const ASSURANCE_INDEX_ORGANIZATIONS: AssuranceIndexOrganization[] = [
     assessmentNumber: 'AOC-001',
     assessmentDate: '2026-06-15',
     sovereigntyScore: 82,
-    governanceScore: null,
+    governanceScore: 61,
+    governanceAudit: [
+      {
+        title: 'Human Oversight',
+        status: 'Partial',
+        finding: 'A privacy-focused deployment model supports user control, but public governance evidence remains incomplete.',
+        risk: 'Local deployment can reduce data exposure while leaving oversight duties to implementers.',
+        evidence: 'Observed from public product, policy, security, and documentation materials.',
+        recommendation: 'Publish role-specific oversight responsibilities, escalation paths, and review cadences for high-impact AI workflows.',
+      },
+      {
+        title: 'Accountability Evidence',
+        status: 'Partial',
+        finding: 'Public-facing materials provide directional governance signals but do not expose a complete independent audit evidence package.',
+        risk: 'External reviewers may be unable to distinguish implemented controls from policy or marketing claims.',
+        recommendation: 'Maintain an evidence-backed governance control summary with ownership, auditability, and exception-handling details.',
+      },
+    ],
     certification: 'Gold',
     certificationClass: 'gold',
     status: 'Assessed',
@@ -46,7 +73,24 @@ export const ASSURANCE_INDEX_ORGANIZATIONS: AssuranceIndexOrganization[] = [
     assessmentNumber: 'AOC-002',
     assessmentDate: '2026-06-15',
     sovereigntyScore: 81,
-    governanceScore: null,
+    governanceScore: 56,
+    governanceAudit: [
+      {
+        title: 'Human Oversight',
+        status: 'Partial',
+        finding: 'Local runtime design gives operators direct execution control, but public materials emphasize tooling more than organizational governance.',
+        risk: 'Implementers may assume runtime control is equivalent to governance oversight.',
+        evidence: 'Observed from public product, policy, security, and documentation materials.',
+        recommendation: 'Publish role-specific oversight responsibilities, escalation paths, and review cadences for high-impact AI workflows.',
+      },
+      {
+        title: 'Accountability Evidence',
+        status: 'Partial',
+        finding: 'Public-facing materials provide directional governance signals but do not expose a complete independent audit evidence package.',
+        risk: 'External reviewers may be unable to distinguish implemented controls from policy or marketing claims.',
+        recommendation: 'Maintain an evidence-backed governance control summary with ownership, auditability, and exception-handling details.',
+      },
+    ],
     certification: 'Gold',
     certificationClass: 'gold',
     status: 'Assessed',
@@ -65,7 +109,24 @@ export const ASSURANCE_INDEX_ORGANIZATIONS: AssuranceIndexOrganization[] = [
     assessmentNumber: 'AOC-003',
     assessmentDate: '2026-06-15',
     sovereigntyScore: 64,
-    governanceScore: null,
+    governanceScore: 74,
+    governanceAudit: [
+      {
+        title: 'Human Oversight',
+        status: 'Partial',
+        finding: 'Public enterprise materials describe security, administrative controls, and governed workflows for business users.',
+        risk: 'Hosted platform dependency requires customers to validate governance enforcement through contractual and audit evidence.',
+        evidence: 'Observed from public product, policy, security, and documentation materials.',
+        recommendation: 'Publish role-specific oversight responsibilities, escalation paths, and review cadences for high-impact AI workflows.',
+      },
+      {
+        title: 'Accountability Evidence',
+        status: 'Partial',
+        finding: 'Public-facing materials provide directional governance signals but do not expose a complete independent audit evidence package.',
+        risk: 'External reviewers may be unable to distinguish implemented controls from policy or marketing claims.',
+        recommendation: 'Maintain an evidence-backed governance control summary with ownership, auditability, and exception-handling details.',
+      },
+    ],
     certification: 'Silver',
     certificationClass: 'silver',
     status: 'Assessed',
@@ -84,7 +145,24 @@ export const ASSURANCE_INDEX_ORGANIZATIONS: AssuranceIndexOrganization[] = [
     assessmentNumber: 'AOC-004',
     assessmentDate: '2026-06-15',
     sovereigntyScore: 58,
-    governanceScore: null,
+    governanceScore: 69,
+    governanceAudit: [
+      {
+        title: 'Human Oversight',
+        status: 'Partial',
+        finding: 'Public positioning indicates high-trust professional workflows, with limited public detail on internal oversight mechanics.',
+        risk: 'Sensitive professional use cases may outpace independently observable governance evidence.',
+        evidence: 'Observed from public product, policy, security, and documentation materials.',
+        recommendation: 'Publish role-specific oversight responsibilities, escalation paths, and review cadences for high-impact AI workflows.',
+      },
+      {
+        title: 'Accountability Evidence',
+        status: 'Partial',
+        finding: 'Public-facing materials provide directional governance signals but do not expose a complete independent audit evidence package.',
+        risk: 'External reviewers may be unable to distinguish implemented controls from policy or marketing claims.',
+        recommendation: 'Maintain an evidence-backed governance control summary with ownership, auditability, and exception-handling details.',
+      },
+    ],
     certification: 'Silver Conditional',
     certificationClass: 'silver-conditional',
     status: 'Assessed',
@@ -103,7 +181,24 @@ export const ASSURANCE_INDEX_ORGANIZATIONS: AssuranceIndexOrganization[] = [
     assessmentNumber: 'AOC-005',
     assessmentDate: '2026-06-15',
     sovereigntyScore: 48,
-    governanceScore: null,
+    governanceScore: 82,
+    governanceAudit: [
+      {
+        title: 'Human Oversight',
+        status: 'Partial',
+        finding: 'Public safety, responsible scaling, and policy materials indicate a mature governance posture at the provider level.',
+        risk: 'Strong provider governance does not automatically give customers direct control over model operation or infrastructure dependency.',
+        evidence: 'Observed from public product, policy, security, and documentation materials.',
+        recommendation: 'Publish role-specific oversight responsibilities, escalation paths, and review cadences for high-impact AI workflows.',
+      },
+      {
+        title: 'Accountability Evidence',
+        status: 'Partial',
+        finding: 'Public-facing materials provide directional governance signals but do not expose a complete independent audit evidence package.',
+        risk: 'External reviewers may be unable to distinguish implemented controls from policy or marketing claims.',
+        recommendation: 'Maintain an evidence-backed governance control summary with ownership, auditability, and exception-handling details.',
+      },
+    ],
     certification: 'Bronze',
     certificationClass: 'bronze',
     status: 'Assessed',


### PR DESCRIPTION
### Motivation
- Surface a second company-level metric (Governance Score) on the public index so viewers can see governance posture alongside existing Sovereignty Score.
- Store qualitative governance audit details in the company model while avoiding per-area numeric scores in detailed audit pages.
- Keep the existing mobile-first, dark AOC Assurance visual style and avoid a broader redesign.

### Description
- Added a typed `governanceScore: number` and `governanceAudit: GovernanceAuditSection[]` to the organization model and populated all sample organizations with a `governanceScore` and qualitative `governanceAudit` entries (`frontend/app/src/landing/assuranceIndexData.ts`).
- Updated the public index cards to display both scores (Sovereignty on top with the existing green progress bar, Governance below with a red/coral progress bar) while preserving rank, avatar/initial, tier badge and the View Public Profile button (`frontend/app/src/landing/AssurancePage.tsx` and `frontend/app/src/landing/assurance.css`).
- Added a Governance Audit Details section to each public profile that renders only qualitative fields (title, status, finding, risk, evidence observed when available, and recommendation) and does not show per-area numeric scores (`frontend/app/src/landing/AssuranceProfilePage.tsx` and `frontend/app/src/landing/assurance.css`).
- Implemented small CSS additions for an accessible red/coral governance tone, stacked mobile-friendly score layout, and governance audit card styling while preserving the existing dark theme and Sovereignty green treatment (`frontend/app/src/landing/assurance.css`).

### Testing
- `npm run build` completed successfully (TypeScript and production build passed).
- `npm run lint` failed due to pre-existing, unrelated lint errors in other files (router/session/hooks/contact page); the changes introduced no new lint rules violations in the modified components.
- No automated test script was present in `frontend/app/package.json`, so no additional test suites were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308f89f7ac8325ab533729a414ad4e)