### PR TITLE
Add Founder Essay section and styles to AssurancePage

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -19,6 +19,7 @@ const MOBILE_NAVIGATION_ITEMS = [
 const FOUNDATION_CHECKOUT_URL = 'https://buy.stripe.com/aFa5kD1Kfgcp67N11gejK01';
 const FOUNDER_PROGRAM_CHECKOUT_URL = 'https://buy.stripe.com/3cI7sL88D5xLbs76lAejK00';
 const ENTERPRISE_INTAKE_FORM_URL = 'https://tally.so/r/2ER1M9';
+const FOUNDER_ESSAY_URL = 'https://www.linkedin.com/pulse/i-started-looking-sovereignty-found-constitutional-valverde-checa-hnpye/';
 
 const ASSESSMENT_OFFERINGS = [
   {
@@ -596,6 +597,64 @@ const AssurancePage = () => {
               Constitutional position is defined by the intersection of both dimensions.
               An organization may excel in one area while remaining constitutionally incomplete.
             </p>
+          </div>
+        </div>
+      </section>
+
+      <hr className="assurance-divider" />
+
+      {/* ── Founder Essay ── */}
+      <section id="founder-essay" className="assurance-editorial-section scroll-mt-20 py-28 px-6" aria-labelledby="founder-essay-heading">
+        <div className="max-w-7xl mx-auto">
+          <div className="assurance-editorial-grid">
+            <div className="assurance-editorial-copy">
+              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+                Why Governance Alone Is Not Enough
+              </p>
+              <h2 id="founder-essay-heading" className="text-4xl md:text-6xl font-semibold tracking-tight mb-6">
+                AI trust cannot be understood through governance alone.
+              </h2>
+              <div className="assurance-editorial-body">
+                <p>
+                  The AOC Constitutional Index was born from a simple realization: AI trust cannot be
+                  fully understood through governance alone.
+                </p>
+                <p>
+                  Governance shows how an AI system is supervised, controlled, and made accountable.
+                </p>
+                <p>
+                  Sovereignty shows who truly controls the capability, who can move it, replace it,
+                  operate it, and preserve independence over time.
+                </p>
+                <p>When one exists without the other, organizations become exposed.</p>
+              </div>
+              <div className="assurance-editorial-emphasis" aria-label="Governance and sovereignty balance principles">
+                <p>Governance without sovereignty creates dependency.</p>
+                <p>Sovereignty without governance creates chaos.</p>
+                <p>Trust emerges when both exist in balance.</p>
+              </div>
+            </div>
+
+            <aside className="assurance-founder-essay-card" aria-labelledby="founder-essay-card-title">
+              <p className="assurance-founder-essay-card-kicker">Founder Essay</p>
+              <h3 id="founder-essay-card-title">
+                I Started Looking for Sovereignty. I Found a Constitutional Problem.
+              </h3>
+              <p>
+                A founder essay on the origin of the AOC Constitutional Index and why the AI industry
+                may be measuring only half of the constitutional equation.
+              </p>
+              <a
+                href={FOUNDER_ESSAY_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="assurance-founder-essay-link"
+                aria-label="Read the founder essay on LinkedIn in a new tab"
+              >
+                Read the Founder Essay
+                <span aria-hidden="true">↗</span>
+              </a>
+            </aside>
           </div>
         </div>
       </section>

--- a/frontend/app/src/landing/assurance.css
+++ b/frontend/app/src/landing/assurance.css
@@ -783,3 +783,134 @@
 
   .assurance-profile-cta-actions { flex-direction: column; }
 }
+
+/* ── Founder Essay Editorial Bridge ── */
+
+.assurance-editorial-section {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 12% 15%, rgba(52, 211, 153, 0.06), transparent 28rem),
+    radial-gradient(circle at 88% 70%, rgba(56, 189, 248, 0.045), transparent 24rem);
+}
+
+.assurance-editorial-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.65fr);
+  gap: clamp(2rem, 6vw, 5rem);
+  align-items: center;
+}
+
+.assurance-editorial-copy {
+  max-width: 55rem;
+}
+
+.assurance-editorial-body {
+  display: grid;
+  gap: 1rem;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 1.0625rem;
+  line-height: 1.85;
+}
+
+.assurance-editorial-emphasis {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 2rem;
+  padding-left: 1.25rem;
+  border-left: 2px solid rgba(52, 211, 153, 0.55);
+}
+
+.assurance-editorial-emphasis p {
+  color: rgba(255, 255, 255, 0.92);
+  font-size: clamp(1rem, 2vw, 1.1875rem);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.assurance-founder-essay-card {
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.5rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.015)),
+    rgba(5, 15, 13, 0.72);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.22);
+}
+
+.assurance-founder-essay-card-kicker {
+  margin-bottom: 1.25rem;
+  color: #7dd3fc;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.assurance-founder-essay-card h3 {
+  color: #fff;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.1;
+}
+
+.assurance-founder-essay-card > p:not(.assurance-founder-essay-card-kicker) {
+  margin-top: 1rem;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.9375rem;
+  line-height: 1.75;
+}
+
+.assurance-founder-essay-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: fit-content;
+  margin-top: 1.75rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  border-radius: 0.875rem;
+  background: rgba(52, 211, 153, 0.08);
+  color: #d1fae5;
+  font-size: 0.875rem;
+  font-weight: 700;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.assurance-founder-essay-link:hover,
+.assurance-founder-essay-link:focus-visible {
+  border-color: rgba(110, 231, 183, 0.65);
+  background: rgba(52, 211, 153, 0.14);
+  color: #fff;
+}
+
+@media (max-width: 900px) {
+  .assurance-editorial-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .assurance-founder-essay-card {
+    max-width: 42rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .assurance-editorial-section {
+    background: radial-gradient(circle at 50% 0%, rgba(52, 211, 153, 0.07), transparent 22rem);
+  }
+
+  .assurance-editorial-body {
+    font-size: 1rem;
+    line-height: 1.75;
+  }
+
+  .assurance-editorial-emphasis {
+    padding-left: 1rem;
+  }
+
+  .assurance-founder-essay-link {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
### Motivation
- Add an editorial bridge to the Assurance landing to explain why sovereignty complements governance and to surface a founder essay link. 
- Provide an accessible, styled card that directs users to the founder's LinkedIn essay about the origins of the AOC Constitutional Index. 

### Description
- Add `FOUNDER_ESSAY_URL` constant and a new `section` with id `founder-essay` in `frontend/app/src/landing/AssurancePage.tsx` that includes copy, emphasis blocks, and a linked founder card opening in a new tab. 
- Insert horizontal separators around the new editorial section to match page flow. 
- Add CSS rules in `frontend/app/src/landing/assurance.css` for `.assurance-editorial-section`, `.assurance-editorial-grid`, `.assurance-editorial-copy`, `.assurance-editorial-body`, `.assurance-editorial-emphasis`, `.assurance-founder-essay-card`, and `.assurance-founder-essay-link`, including responsive breakpoints for `900px` and `640px`. 

### Testing
- Ran the project build (`yarn build`) locally and the build succeeded. 
- Ran the linter (`yarn lint`) and no new linter errors were produced. 
- Ran the test suite (`yarn test`) and existing tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3209e506f483259dbeb60642399398)