### PR TITLE
Update AssurancePage terminology from "Map" to "Matrix"

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -308,7 +308,7 @@ const AssurancePage = () => {
             href="#map"
             className="px-10 py-4 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold text-lg rounded-2xl transition-colors"
           >
-            Explore the Map
+            Explore the Matrix
           </a>
           <a
             href="#assessments"
@@ -326,7 +326,7 @@ const AssurancePage = () => {
         <div className="max-w-7xl mx-auto">
           <header className="mb-12 max-w-2xl">
             <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-              Constitutional Map
+              Constitutional Matrix
             </p>
             <h2 className="text-4xl md:text-5xl font-semibold tracking-tight mb-5">
               Where organizations stand.


### PR DESCRIPTION
## Summary
Updated terminology on the AssurancePage component to replace "Map" with "Matrix" for improved clarity and consistency in user-facing language.

## Key Changes
- Changed CTA button text from "Explore the Map" to "Explore the Matrix"
- Updated section header label from "Constitutional Map" to "Constitutional Matrix"

## Implementation Details
These are straightforward text updates in the AssurancePage component that maintain all existing styling and functionality while improving the semantic accuracy of the feature naming.

https://claude.ai/code/session_01XAu5o5eMoYjQbmx2wjPXdD