### PR TITLE
Add AOC Assurance institutional footer, research bridge, and support/legal pages

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { AocLandingPage } from './landing/AocLandingPage';
 import { renderAssurancePage } from './landing/AssurancePage';
 import { AssuranceProfilePage } from './landing/AssuranceProfilePage';
+import { AboutPage, MethodologyPage, PrivacyPage, ResearchPage, TermsPage } from './landing/AssuranceSupportPages';
 import { renderEnterprisePage } from './landing/EnterprisePage';
 import { renderDocsPage } from './landing/DocsPage';
 import { renderContactPage } from './landing/ContactPage';
@@ -13,7 +14,8 @@ function getView() {
 
 export default function App() {
   const [view, setView] = useState(getView());
-  const assuranceProfileMatch = window.location.pathname.match(
+  const pathname = window.location.pathname;
+  const assuranceProfileMatch = pathname.match(
     /^\/assurance\/index\/([^/]+)\/?$/
   );
 
@@ -30,6 +32,11 @@ export default function App() {
   if (assuranceProfileMatch) {
     return <AssuranceProfilePage slug={decodeURIComponent(assuranceProfileMatch[1])} />;
   }
+  if (pathname === '/assurance/privacy') return <PrivacyPage />;
+  if (pathname === '/assurance/terms') return <TermsPage />;
+  if (pathname === '/assurance/methodology') return <MethodologyPage />;
+  if (pathname === '/assurance/research') return <ResearchPage />;
+  if (pathname === '/assurance/about') return <AboutPage />;
   if (view === 'assurance') return renderAssurancePage();
   if (view === 'docs') return renderDocsPage();
   if (view === 'enterprise') return renderEnterprisePage();

--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -21,6 +21,95 @@ const FOUNDER_PROGRAM_CHECKOUT_URL = 'https://buy.stripe.com/3cI7sL88D5xLbs76lAe
 const ENTERPRISE_INTAKE_FORM_URL = 'https://tally.so/r/2ER1M9';
 const FOUNDER_ESSAY_URL = 'https://www.linkedin.com/pulse/i-started-looking-sovereignty-found-constitutional-valverde-checa-hnpye/';
 
+
+const FOOTER_LINK_GROUPS = [
+  {
+    title: 'Assessments',
+    links: [
+      { label: 'Public Constitutional Assessment', href: '#assessments' },
+      { label: 'Founder Constitutional Assessment', href: '#assessments' },
+      { label: 'Enterprise Constitutional Assessment', href: '#assessments' },
+      { label: 'Constitutional Index', href: '#index' },
+    ],
+  },
+  {
+    title: 'Research',
+    links: [
+      { label: 'Constitutional Matrix', href: '#map' },
+      { label: 'Constitutional Index Methodology', href: '/assurance/methodology' },
+      { label: 'Founder Essay', href: FOUNDER_ESSAY_URL, external: true },
+      { label: 'Public Research Initiative', href: '/assurance/research' },
+    ],
+  },
+  {
+    title: 'Company',
+    links: [
+      { label: 'About AOC Assurance', href: '/assurance/about' },
+      { label: 'About AOC Protocol', href: '/' },
+      { label: 'Privacy Policy', href: '/assurance/privacy' },
+      { label: 'Terms of Service', href: '/assurance/terms' },
+    ],
+  },
+  {
+    title: 'Connect',
+    links: [
+      { label: 'LinkedIn', href: 'https://www.linkedin.com/company/architects-of-change-protocol/', external: true },
+      { label: 'X (@archofchange)', href: 'https://x.com/archofchange', external: true },
+      { label: 'GitHub', href: 'https://github.com/Architects-of-Change-Protocol/Architects_of_Change_Protocol', external: true },
+      { label: 'Contact Us', href: 'mailto:vicvalch@onchainfest.xyz' },
+    ],
+  },
+];
+
+function PublicResearchBridge() {
+  return (
+    <section className="assurance-research-bridge px-6 py-16" aria-labelledby="research-bridge-heading">
+      <div className="max-w-7xl mx-auto assurance-research-bridge-card">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">PUBLIC RESEARCH INITIATIVE</p>
+          <h2 id="research-bridge-heading">Mapping the constitutional posture of the AI industry.</h2>
+          <p>AOC Assurance continuously evaluates AI organizations using publicly observable evidence to better understand the evolving relationship between Governance and Sovereignty across the industry.</p>
+        </div>
+        <a href="/assurance/research" className="assurance-research-bridge-link">Explore the Research Initiative</a>
+      </div>
+    </section>
+  );
+}
+
+function AssuranceFooter() {
+  return (
+    <footer className="assurance-footer px-6" aria-labelledby="assurance-footer-title">
+      <div className="max-w-7xl mx-auto assurance-footer-inner">
+        <div className="assurance-footer-brand">
+          <h2 id="assurance-footer-title">AOC Assurance</h2>
+          <p>A constitutional assessment framework developed by AOC Protocol.</p>
+          <p className="assurance-footer-tagline">Measure Governance.<br />Measure Sovereignty.<br />Understand the Balance.</p>
+          <p className="assurance-footer-institutional">AOC Assurance and AOC Protocol are initiatives of OnchainFest LLC.</p>
+        </div>
+        <nav className="assurance-footer-links" aria-label="AOC Assurance footer navigation">
+          {FOOTER_LINK_GROUPS.map((group) => (
+            <section key={group.title} aria-labelledby={`footer-${group.title.toLowerCase()}`}>
+              <h3 id={`footer-${group.title.toLowerCase()}`}>{group.title}</h3>
+              <ul>
+                {group.links.map((link) => (
+                  <li key={link.label}>
+                    <a href={link.href} target={link.external ? '_blank' : undefined} rel={link.external ? 'noopener noreferrer' : undefined}>{link.label}</a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </nav>
+        <div className="assurance-footer-legal">
+          <p>© 2026 OnchainFest LLC. All rights reserved.</p>
+          <p>AOC Assurance does not certify organizations as safe, secure, compliant, trustworthy, or risk-free.</p>
+          <p>The Constitutional Index is an evidence-based assessment framework designed to evaluate governance and sovereignty characteristics using publicly observable and/or supplied evidence. Constitutional scores represent analytical assessments and should not be interpreted as guarantees, certifications, or endorsements.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
 const ASSESSMENT_OFFERINGS = [
   {
     key: 'foundation',
@@ -773,6 +862,9 @@ const AssurancePage = () => {
           Request Assessment
         </a>
       </section>
+
+      <PublicResearchBridge />
+      <AssuranceFooter />
 
     </main>
   );

--- a/frontend/app/src/landing/AssuranceSupportPages.tsx
+++ b/frontend/app/src/landing/AssuranceSupportPages.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from 'react';
+import { LogoRotating } from '../components/logo/LogoRotating';
+import { CONSTITUTIONAL_INDEX_ORGANIZATIONS } from './assuranceIndexData';
+import './assurance.css';
+
+const CONTACT_MAILTO = 'mailto:vicvalch@onchainfest.xyz';
+const FOUNDER_ESSAY_URL = 'https://www.linkedin.com/pulse/i-started-looking-sovereignty-found-constitutional-valverde-checa-hnpye/';
+
+type Section = { title: string; body?: string[]; bullets?: string[] };
+
+function SupportLayout({ title, subtitle, updated, children }: { title: string; subtitle: string; updated: string; children: ReactNode }) {
+  return (
+    <main className="assurance-support-page min-h-screen bg-[#070d0b] text-white font-sans">
+      <nav className="assurance-support-nav" aria-label="Support page navigation">
+        <a href="/?view=assurance" className="assurance-support-brand" aria-label="Back to AOC Assurance">
+          <LogoRotating size={28} inverted />
+          <span>AOC Assurance</span>
+        </a>
+        <a href="/?view=assurance" className="assurance-support-back">← Back to Assurance</a>
+      </nav>
+      <article className="assurance-support-shell">
+        <header className="assurance-support-header">
+          <p className="assurance-support-eyebrow">{updated}</p>
+          <h1>{title}</h1>
+          <p>{subtitle}</p>
+        </header>
+        {children}
+      </article>
+    </main>
+  );
+}
+
+function TextSections({ sections }: { sections: Section[] }) {
+  return (
+    <div className="assurance-support-content">
+      {sections.map((section, index) => (
+        <section key={section.title} className="assurance-support-section" aria-labelledby={`support-section-${index}`}>
+          <h2 id={`support-section-${index}`}>{index + 1}. {section.title}</h2>
+          {section.body?.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          {section.bullets && <ul>{section.bullets.map((bullet) => <li key={bullet}>{bullet}</li>)}</ul>}
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function ContactCta({ secondary }: { secondary?: React.ReactNode }) {
+  return <div className="assurance-support-actions"><a className="assurance-support-primary" href={CONTACT_MAILTO}>Contact Us</a>{secondary}</div>;
+}
+
+const privacySections: Section[] = [
+  { title: 'Overview', body: ['AOC Assurance is a constitutional assessment framework developed by AOC Protocol. This Privacy Policy explains how information may be collected, used, and protected when users interact with AOC Assurance pages, assessment offerings, forms, communications, and related services.'] },
+  { title: 'Information We Collect', body: ['We may collect information that users voluntarily submit, including name, organization, role, email address, assessment requests, submitted evidence, comments, and communications.', 'We may also collect limited technical information such as browser type, device information, page interactions, referral source, and general usage analytics.'] },
+  { title: 'Assessment Information', body: ['Assessment-related information may include publicly observable evidence, submitted documentation, website references, repository references, governance materials, policies, disclosures, and other materials relevant to evaluating governance and sovereignty characteristics.'] },
+  { title: 'Payment Processing', body: ['Payments may be processed through third-party payment providers such as Stripe. AOC Assurance does not store full payment card details.'] },
+  { title: 'Third-Party Services', body: ['AOC Assurance may use third-party services for forms, payments, analytics, hosting, communications, and external content. These services may process information according to their own privacy policies.'] },
+  { title: 'How We Use Information', body: ['Information may be used to deliver assessments, communicate with users, improve methodology, respond to inquiries, process requests, maintain records, and improve AOC Assurance services.'] },
+  { title: 'Data Retention', body: ['Information may be retained for as long as reasonably necessary to provide services, maintain assessment records, comply with legal obligations, resolve disputes, and improve the framework.'] },
+  { title: 'Public Evidence', body: ['Public Constitutional Assessments may rely on publicly observable evidence. Publicly available information may be referenced in assessment outputs, index listings, or research materials.'] },
+  { title: 'Confidential Materials', body: ['If non-public materials are submitted, AOC Assurance will treat them as assessment materials and will not intentionally publish confidential materials without permission, unless otherwise agreed.'] },
+  { title: 'Contact', body: ['Questions about this Privacy Policy can be submitted through the Contact Us link.'] },
+];
+
+const termsSections: Section[] = [
+  { title: 'Overview', body: ['AOC Assurance provides constitutional assessment, research, indexing, and advisory materials related to AI governance and sovereignty.'] },
+  { title: 'Nature of Assessments', body: ['AOC Assurance assessments are analytical evaluations based on publicly observable evidence and/or submitted materials. They are intended to help organizations understand constitutional posture, identify limiting factors, and improve governance and sovereignty characteristics.'] },
+  { title: 'No Certification', body: ['AOC Assurance does not certify organizations as safe, secure, compliant, trustworthy, or risk-free. Scores, findings, rankings, and reports are analytical opinions based on available evidence and should not be interpreted as guarantees, certifications, legal advice, compliance determinations, or endorsements.'] },
+  { title: 'Evidence Limitations', body: ['Assessment outputs depend on the quality, availability, completeness, and accuracy of evidence. Public assessments may be limited by what is publicly observable.'] },
+  { title: 'User Responsibilities', body: ['Users are responsible for ensuring that any materials they submit are accurate, authorized for sharing, and do not violate third-party rights or confidentiality obligations.'] },
+  { title: 'Intellectual Property', body: ['AOC Assurance, AOC Protocol, the Constitutional Index, Constitutional Matrix, methodology, scoring model, reports, copy, designs, and related materials are owned by or licensed to OnchainFest LLC unless otherwise stated.'] },
+  { title: 'Payments and Refunds', body: ['Paid assessments are purchased through third-party payment providers. Unless otherwise stated in writing, assessment fees are non-refundable once work has begun.'] },
+  { title: 'Third-Party Links', body: ['AOC Assurance pages may link to external websites, services, repositories, articles, and payment providers. AOC Assurance is not responsible for third-party content, policies, or services.'] },
+  { title: 'Limitation of Liability', body: ['To the maximum extent permitted by applicable law, OnchainFest LLC and related AOC initiatives are not liable for indirect, incidental, consequential, special, or punitive damages arising from use of AOC Assurance materials or services.'] },
+  { title: 'Contact', body: ['Questions about these Terms can be submitted through the Contact Us link.'] },
+];
+
+export function PrivacyPage() { return <SupportLayout title="Privacy Policy" subtitle="How AOC Assurance handles information submitted through assessments, forms, communications, and related services." updated="Last updated: June 2026"><TextSections sections={privacySections} /><ContactCta /></SupportLayout>; }
+export function TermsPage() { return <SupportLayout title="Terms of Service" subtitle="Terms governing access to AOC Assurance assessments, research, pages, and related services." updated="Last updated: June 2026"><TextSections sections={termsSections} /><ContactCta /></SupportLayout>; }
+
+export function MethodologyPage() {
+  const sections: Section[] = [
+    { title: 'Purpose', body: ['The AOC Constitutional Index evaluates how AI organizations balance two independent dimensions: Governance and Sovereignty. The goal is not only to produce a score, but to understand where an organization sits, why it sits there, and what would need to change to improve its constitutional posture.'] },
+    { title: 'Governance Dimension', body: ['Governance evaluates how an AI system, organization, or capability is supervised, controlled, made accountable, and aligned with responsible operating principles.'], bullets: ['Oversight', 'Accountability', 'Auditability', 'Transparency', 'Risk Management'] },
+    { title: 'Sovereignty Dimension', body: ['Sovereignty evaluates who truly controls the capability, who can operate it independently, who can move or replace it, and how much dependency exists over time.'], bullets: ['Ownership', 'Portability', 'Runtime Control', 'Exit Feasibility', 'Authority'] },
+    { title: 'Constitutional Matrix', body: ['The Constitutional Matrix positions organizations using Governance and Sovereignty as independent axes.'], bullets: ['High Governance / High Sovereignty: Constitutional Leaders', 'High Governance / Low Sovereignty: Trusted Custodians', 'Low Governance / High Sovereignty: Sovereignty Pioneers', 'Low Governance / Low Sovereignty: Dependency Platforms'] },
+    { title: 'Scoring Philosophy', body: ['Scores are based on evidence, not claims alone. A higher score indicates stronger observable or submitted evidence for a given dimension. Scores may change as new evidence becomes available.'] },
+    { title: 'Evidence Model', body: ['AOC Assurance may evaluate:'], bullets: ['Public websites', 'Documentation', 'Security pages', 'Trust centers', 'Repositories', 'Policies', 'Product architecture disclosures', 'Terms and privacy materials', 'Governance disclosures', 'Customer control and portability signals', 'Submitted evidence for paid assessments'] },
+    { title: 'Public vs Submitted Evidence', body: ['Public Constitutional Assessments rely on publicly observable evidence. Founder and Enterprise assessments may include submitted materials, interviews, internal documentation, architecture details, or operational evidence.'] },
+    { title: 'Interpretation', body: ['A strong Governance score does not guarantee Sovereignty. A strong Sovereignty score does not guarantee Governance. Constitutional position is determined by the relationship between both dimensions.'] },
+    { title: 'Limitations', body: ['The Constitutional Index is not a certification, compliance opinion, security guarantee, or endorsement. It is an analytical framework designed to support understanding, comparison, and improvement.'] },
+    { title: 'Roadmap Orientation', body: ['The deeper purpose of the methodology is to guide organizations toward a roadmap of change: stronger governance, stronger sovereignty, or both.'] },
+  ];
+  return <SupportLayout title="Constitutional Index Methodology" subtitle="How AOC Assurance evaluates Governance, Sovereignty, and Constitutional Position." updated="Methodology v1.0 — June 2026"><TextSections sections={sections} /><div className="assurance-support-actions"><a className="assurance-support-primary" href="/?view=assurance">Explore AOC Assurance</a><a className="assurance-support-secondary" href={CONTACT_MAILTO}>Contact Us</a></div></SupportLayout>;
+}
+
+export function ResearchPage() {
+  return <SupportLayout title="Public Research Initiative" subtitle="Tracking how AI organizations balance Governance and Sovereignty over time." updated="Research status: Early and evolving"><div className="assurance-support-content"><section className="assurance-support-section"><p>AOC Assurance is building a public research initiative to evaluate the constitutional posture of AI organizations using publicly observable evidence.</p><p>The objective is to understand the structural trade-offs behind AI business models, deployment patterns, operating models, and control surfaces.</p></section><section className="assurance-support-section"><h2>Research Focus</h2><ul>{['Governance maturity','Sovereignty maturity','Dependency patterns','Portability and exit feasibility','Auditability and accountability','Constitutional trade-offs','Roadmaps toward stronger constitutional posture'].map((item)=><li key={item}>{item}</li>)}</ul></section><section className="assurance-support-section"><h2>Current Index Coverage</h2><div className="assurance-research-grid">{CONSTITUTIONAL_INDEX_ORGANIZATIONS.map((org)=><a key={org.id} href={`/assurance/index/${org.slug}`} className="assurance-research-card"><strong>{org.name}</strong><span>{org.quadrantLabel}</span></a>)}</div></section><section className="assurance-support-section"><h2>Research Status</h2><p>This initiative is early and evolving. Scores and findings may be updated as new evidence becomes available.</p></section></div><div className="assurance-support-actions"><a className="assurance-support-primary" href="/?view=assurance#index">Explore the Constitutional Index</a><a className="assurance-support-secondary" href={FOUNDER_ESSAY_URL} target="_blank" rel="noopener noreferrer">Read the Founder Essay ↗</a></div></SupportLayout>;
+}
+
+export function AboutPage() {
+  return <SupportLayout title="About AOC Assurance" subtitle="A constitutional assessment framework for understanding AI Governance, Sovereignty, and the balance between them." updated="AOC Assurance"><div className="assurance-support-content"><section className="assurance-support-section"><p>AOC Assurance is a constitutional assessment framework developed by AOC Protocol.</p><p>It was created to help organizations understand where AI companies, platforms, and systems sit across two dimensions that are often discussed separately but rarely measured together: Governance and Sovereignty.</p><p>Governance shows how a system is supervised, controlled, audited, and made accountable.</p><p>Sovereignty shows who truly controls the capability, who can operate it, move it, replace it, and preserve independence over time.</p></section><section className="assurance-support-section"><h2>AOC Assurance exists to help organizations:</h2><ul>{['Measure constitutional posture','Understand limiting factors','Compare governance and sovereignty trade-offs','Build roadmaps toward stronger constitutional maturity','Avoid confusing trust with governance alone'].map((item)=><li key={item}>{item}</li>)}</ul></section><section className="assurance-support-section"><p><strong>AOC Assurance and AOC Protocol are initiatives of OnchainFest LLC.</strong></p></section></div><div className="assurance-support-actions"><a className="assurance-support-primary" href="/?view=assurance#index">Explore the Constitutional Index</a><a className="assurance-support-secondary" href={CONTACT_MAILTO}>Contact Us</a></div></SupportLayout>;
+}

--- a/frontend/app/src/landing/assurance.css
+++ b/frontend/app/src/landing/assurance.css
@@ -914,3 +914,51 @@
     justify-content: center;
   }
 }
+
+/* ── Institutional Research Bridge and Footer ── */
+.assurance-research-bridge { background: radial-gradient(circle at 50% 0%, rgba(52, 211, 153, 0.055), transparent 28rem); }
+.assurance-research-bridge-card { display: flex; align-items: center; justify-content: space-between; gap: 2rem; padding: clamp(1.5rem, 4vw, 2.5rem); border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 1.5rem; background: rgba(255, 255, 255, 0.022); }
+.assurance-research-bridge-card h2 { max-width: 42rem; color: #fff; font-size: clamp(1.75rem, 4vw, 2.75rem); font-weight: 600; letter-spacing: -0.04em; line-height: 1.08; }
+.assurance-research-bridge-card p:not(:first-child) { max-width: 48rem; margin-top: 1rem; color: rgba(255, 255, 255, 0.6); line-height: 1.75; }
+.assurance-research-bridge-link, .assurance-support-primary, .assurance-support-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 3rem; padding: 0.8rem 1rem; border-radius: 0.875rem; font-size: 0.875rem; font-weight: 700; white-space: nowrap; transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease; }
+.assurance-research-bridge-link, .assurance-support-secondary { border: 1px solid rgba(52, 211, 153, 0.28); color: #d1fae5; }
+.assurance-research-bridge-link:hover, .assurance-research-bridge-link:focus-visible, .assurance-support-secondary:hover, .assurance-support-secondary:focus-visible { border-color: rgba(110, 231, 183, 0.62); background: rgba(52, 211, 153, 0.09); color: #fff; }
+.assurance-footer { border-top: 1px solid rgba(255, 255, 255, 0.09); background: linear-gradient(180deg, rgba(7, 13, 11, 0.96), #050907); }
+.assurance-footer-inner { display: grid; grid-template-columns: minmax(15rem, 0.9fr) minmax(0, 1.6fr); gap: clamp(2rem, 6vw, 5rem); padding: clamp(3rem, 7vw, 5.5rem) 0 2rem; }
+.assurance-footer-brand h2 { font-size: 1.5rem; font-weight: 650; letter-spacing: -0.03em; }
+.assurance-footer-brand p, .assurance-footer-legal p { margin-top: 1rem; color: rgba(255, 255, 255, 0.55); line-height: 1.7; }
+.assurance-footer-tagline { color: rgba(209, 250, 229, 0.86) !important; font-weight: 650; }
+.assurance-footer-institutional { font-size: 0.8125rem; }
+.assurance-footer-links { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1.5rem; }
+.assurance-footer-links h3 { color: rgba(255, 255, 255, 0.88); font-size: 0.75rem; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; }
+.assurance-footer-links ul { display: grid; gap: 0.75rem; margin-top: 1rem; }
+.assurance-footer a, .assurance-support-page a { outline-offset: 4px; }
+.assurance-footer-links a, .assurance-support-back { color: rgba(255, 255, 255, 0.58); font-size: 0.875rem; transition: color 0.2s ease; }
+.assurance-footer-links a:hover, .assurance-footer-links a:focus-visible, .assurance-support-back:hover, .assurance-support-back:focus-visible { color: #fff; }
+.assurance-footer-legal { grid-column: 1 / -1; padding-top: 2rem; border-top: 1px solid rgba(255, 255, 255, 0.08); font-size: 0.8125rem; }
+.assurance-support-page { background: radial-gradient(circle at 50% 0%, rgba(52, 211, 153, 0.08), transparent 30rem), #070d0b; }
+.assurance-support-nav { display: flex; align-items: center; justify-content: space-between; width: min(100% - 3rem, 72rem); margin: 0 auto; padding: 1.25rem 0; }
+.assurance-support-brand { display: inline-flex; align-items: center; gap: 0.75rem; color: #fff; font-weight: 700; }
+.assurance-support-shell { width: min(100% - 3rem, 72rem); margin: 0 auto; padding: clamp(3rem, 8vw, 6rem) 0 7rem; }
+.assurance-support-header { max-width: 56rem; padding-bottom: 2.5rem; border-bottom: 1px solid rgba(255, 255, 255, 0.09); }
+.assurance-support-eyebrow { color: #34d399; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; }
+.assurance-support-header h1 { margin-top: 1rem; font-size: clamp(3rem, 8vw, 5.75rem); font-weight: 650; letter-spacing: -0.06em; line-height: 0.95; }
+.assurance-support-header > p:last-child { margin-top: 1.25rem; color: rgba(255, 255, 255, 0.62); font-size: clamp(1rem, 2vw, 1.25rem); line-height: 1.7; }
+.assurance-support-content { display: grid; gap: 1rem; margin-top: 2rem; }
+.assurance-support-section { padding: clamp(1.25rem, 3vw, 2rem); border: 1px solid rgba(255, 255, 255, 0.09); border-radius: 1.25rem; background: rgba(255, 255, 255, 0.02); }
+.assurance-support-section h2 { margin-bottom: 0.75rem; color: #fff; font-size: 1.2rem; font-weight: 650; }
+.assurance-support-section p, .assurance-support-section li { color: rgba(255, 255, 255, 0.66); line-height: 1.78; }
+.assurance-support-section p + p { margin-top: 0.85rem; }
+.assurance-support-section ul { display: grid; gap: 0.55rem; margin-top: 0.9rem; padding-left: 1.2rem; }
+.assurance-support-section li::marker { color: #34d399; }
+.assurance-support-section strong { color: rgba(255, 255, 255, 0.9); }
+.assurance-support-actions { display: flex; flex-wrap: wrap; gap: 0.8rem; margin-top: 2rem; }
+.assurance-support-primary { background: #10b981; color: #06110d; }
+.assurance-support-primary:hover, .assurance-support-primary:focus-visible { background: #34d399; }
+.assurance-research-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr)); gap: 0.75rem; margin-top: 1rem; }
+.assurance-research-card { display: grid; gap: 0.35rem; padding: 1rem; border: 1px solid rgba(52, 211, 153, 0.16); border-radius: 1rem; background: rgba(52, 211, 153, 0.04); }
+.assurance-research-card strong { color: #fff; }
+.assurance-research-card span { color: rgba(255, 255, 255, 0.48); font-size: 0.8125rem; }
+.assurance-research-card:hover, .assurance-research-card:focus-visible { border-color: rgba(110, 231, 183, 0.5); }
+@media (max-width: 900px) { .assurance-footer-inner { grid-template-columns: 1fr; } .assurance-research-bridge-card { display: grid; } .assurance-footer-links { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 640px) { .assurance-footer-links, .assurance-research-grid { grid-template-columns: 1fr; } .assurance-support-nav { width: min(100% - 2rem, 72rem); align-items: flex-start; flex-direction: column; gap: 1rem; } .assurance-support-shell { width: min(100% - 2rem, 72rem); } .assurance-research-bridge-link, .assurance-support-primary, .assurance-support-secondary { width: 100%; white-space: normal; text-align: center; } }


### PR DESCRIPTION
### Motivation
- Provide a complete institutional footer and a compact Public Research Initiative bridge at the bottom of the AOC Assurance landing experience to surface legal and research resources. 
- Add canonical support pages (Privacy, Terms, Methodology, Research, About) so users can access legal/research content via stable routes. 
- Preserve the existing Assurance visual language and ensure accessibility, responsiveness, and safe external links. 
- Keep all pricing, checkout URLs, and assessment CTAs unchanged and continue to support the existing `/?view=assurance` behavior.

### Description
- Added a compact Public Research Initiative bridge and an institutional footer to the Assurance landing page, implemented as `PublicResearchBridge` and `AssuranceFooter` and rendered after the final CTA. 
- Introduced `AssuranceSupportPages.tsx` which implements reusable support layout and the five support pages (`/assurance/privacy`, `/assurance/terms`, `/assurance/methodology`, `/assurance/research`, `/assurance/about`) with back navigation to Assurance and contact CTAs using a mailto link labeled “Contact Us” (email not displayed). 
- Updated routing in `App.tsx` to serve the new direct paths while preserving `/?view=assurance` and existing profile routes. 
- Added footer link groups and wiring for external links to open in a new tab with `rel="noopener noreferrer"` where applicable, and added responsive/accessibility-focused styles in `assurance.css` (hover and focus-visible states, semantic landmarks, stacked mobile layouts). 
- Used existing AOC Assurance data (`assuranceIndexData`) to render research coverage cards and preserved all existing pricing, checkout URLs, and assessment CTAs unchanged.

### Testing
- Ran `npm run typecheck` and it passed. 
- Ran `npm run build` and it passed. 
- Ran `npm run lint`; lint failures were reported but they are pre-existing unrelated issues in other files (`src/app/router.tsx`, `src/auth/session.tsx`, `src/hooks/useAccessRequests.ts`, `src/hooks/useGrants.ts`, and `src/landing/ContactPage.tsx`) and no new lint errors were introduced in modified files. 
- Started the dev server and verified HTTP 200 responses for `/?view=assurance`, `/assurance/privacy`, `/assurance/terms`, `/assurance/methodology`, `/assurance/research`, and `/assurance/about`. 
- No browser/screenshot validation was captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32ce9d58788325861303c4f58b8be6)