### PR TITLE
Update mobile navigation label from 'Map' to 'Matrix'

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -9,7 +9,7 @@ import {
 import './assurance.css';
 
 const MOBILE_NAVIGATION_ITEMS = [
-  { label: 'Map', href: '#map' },
+  { label: 'Matrix', href: '#map' },
   { label: 'Index', href: '#index' },
   { label: 'Leaders', href: '#leaders' },
   { label: 'Methodology', href: '#methodology' },


### PR DESCRIPTION
## Summary
Updated the mobile navigation menu label in the AssurancePage component to better reflect the content being referenced.

## Changes
- Changed the mobile navigation item label from 'Map' to 'Matrix' while keeping the anchor link (#map) unchanged

## Details
This change updates the user-facing label in the mobile navigation menu on the AssurancePage. The href remains pointing to '#map', suggesting this may be a terminology update to more accurately describe the section's content or purpose.

https://claude.ai/code/session_0147PmrC3nPq9eZwN4AGSW2H