### PR TITLE
Refactor Assurance page navigation and add sticky CTA with Learn More accordion

### DIFF
--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { LogoRotating } from '../components/logo/LogoRotating';
 import {
   CONSTITUTIONAL_INDEX_ORGANIZATIONS,
@@ -11,9 +11,8 @@ import './assurance.css';
 
 const NAV_ITEMS = [
   { label: 'Risk', href: '#risk' },
-  { label: 'Framework', href: '#framework' },
-  { label: 'Index', href: '#index' },
   { label: 'Assessments', href: '#assessments' },
+  { label: 'Learn More', href: '#learn-more' },
   { label: 'FAQ', href: '#faq' },
   { label: 'Protocol', href: '/' },
 ];
@@ -223,15 +222,47 @@ function AssuranceFooter() {
   );
 }
 
+type LearnMoreId = 'framework' | 'founder-essay' | 'index';
+
 const AssurancePage = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [openLearnMore, setOpenLearnMore] = useState<LearnMoreId | null>(null);
+  const [showStickyCta, setShowStickyCta] = useState(false);
+
+  useEffect(() => {
+    const hero = document.querySelector('.assurance-hero-glow');
+    if (!hero) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowStickyCta(!entry.isIntersecting),
+      { threshold: 0 },
+    );
+    observer.observe(hero);
+    return () => observer.disconnect();
+  }, []);
 
   const emergingCandidates = CONSTITUTIONAL_INDEX_ORGANIZATIONS.filter(
     (o) => o.quadrant === 'sovereignty-pioneers',
   ).sort((a, b) => (b.governanceScore + b.sovereigntyScore) - (a.governanceScore + a.sovereigntyScore));
 
+  const toggleLearnMore = (id: LearnMoreId) =>
+    setOpenLearnMore((prev) => (prev === id ? null : id));
+
   return (
     <main className="min-h-screen bg-[#070d0b] text-white font-sans">
+
+      {/* ── Sticky CTA (desktop only, appears after Hero) ── */}
+      <div
+        aria-hidden={!showStickyCta}
+        className={`fixed bottom-6 right-6 z-50 hidden md:block transition-all duration-300 ${showStickyCta ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'}`}
+      >
+        <a
+          href="#assessments"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold text-sm rounded-2xl shadow-[0_8px_32px_rgba(52,211,153,0.35)] transition-colors"
+        >
+          Assess Intelligence Risk
+          <span aria-hidden="true">↑</span>
+        </a>
+      </div>
 
       {/* ── Navigation ── */}
       <nav className="sticky top-0 z-30 backdrop-blur bg-[#070d0b]/80 border-b border-white/10">
@@ -313,7 +344,7 @@ const AssurancePage = () => {
             Assess Intelligence Risk
           </a>
           <a
-            href="#framework"
+            href="#learn-more"
             className="px-10 py-4 border border-white/15 hover:border-white/30 text-white font-semibold text-lg rounded-2xl transition-colors"
           >
             Explore the Constitutional Framework
@@ -347,157 +378,6 @@ const AssurancePage = () => {
                 <p className="text-white/60 text-sm leading-relaxed">{card.body}</p>
               </div>
             ))}
-          </div>
-        </div>
-      </section>
-
-      <hr className="assurance-divider" />
-
-      {/* ── Framework Section ── */}
-      <section id="framework" className="scroll-mt-20 py-28 px-6">
-        <div className="max-w-7xl mx-auto">
-          <header className="mb-12 max-w-3xl">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-              AOC Constitutional Framework
-            </p>
-            <h2 className="text-4xl md:text-5xl font-semibold tracking-tight mb-5">
-              These are not just knowledge problems. They are constitutional failures.
-            </h2>
-            <p className="text-white/60 text-lg leading-relaxed">
-              Most organizations do not have a data problem. They have a continuity problem. Intelligence
-              cannot survive without governance. Learning cannot scale without accountability. Resilience
-              cannot exist without sovereignty. AOC Assurance evaluates the constitutional conditions that
-              determine whether organizational intelligence remains durable, traceable, and usable through change.
-            </p>
-          </header>
-
-          <div className="grid md:grid-cols-3 gap-6 mb-14">
-            {FRAMEWORK_CARDS.map((card) => (
-              <div key={card.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-7">
-                <h3 className="text-lg font-semibold mb-3">{card.title}</h3>
-                <p className="text-white/60 text-sm leading-relaxed">{card.body}</p>
-              </div>
-            ))}
-          </div>
-
-          {/* Measurement dimensions */}
-          <div className="mb-4 max-w-3xl">
-            <h3 className="text-2xl md:text-3xl font-semibold tracking-tight mb-5">
-              AOC Assurance measures whether your intelligence can survive change.
-            </h3>
-          </div>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
-            {ASSESSMENT_DIMENSIONS.map((dim) => (
-              <div key={dim.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
-                <p className="text-emerald-400 text-sm font-semibold mb-2">{dim.title}</p>
-                <p className="text-white/55 text-sm leading-relaxed">{dim.body}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <hr className="assurance-divider" />
-
-      {/* ── Founder Essay Section ── */}
-      <section className="scroll-mt-20 py-28 px-6">
-        <div className="max-w-4xl mx-auto">
-          <header className="mb-10">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-              Founder Essay
-            </p>
-            <h2 className="text-4xl md:text-5xl font-semibold tracking-tight mb-5">
-              Why Governance Alone Is Not Enough
-            </h2>
-            <p className="text-2xl md:text-3xl font-medium text-white/70 leading-snug">
-              I Started Looking for Sovereignty. I Found a Constitutional Problem.
-            </p>
-          </header>
-          <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 md:p-10">
-            <p className="text-white/70 text-base leading-relaxed mb-6">
-              Most organizations believe that if they govern their data well enough, they will be resilient. They invest in policies, frameworks, and tools. They document decisions. They deploy knowledge management systems. They add governance layers on top of governance layers.
-            </p>
-            <p className="text-white/70 text-base leading-relaxed mb-6">
-              And yet critical intelligence keeps disappearing. Key employees leave and take context with them. Strategic decisions are made again because nobody can reconstruct why the original decision was made. AI systems are deployed but cannot understand the business they are supposed to serve. Organizations grow but do not learn.
-            </p>
-            <p className="text-white/70 text-base leading-relaxed mb-6">
-              When I started investigating why this keeps happening, I expected to find a data problem. What I found instead was a constitutional problem.
-            </p>
-            <p className="text-white/70 text-base leading-relaxed mb-8">
-              Governance defines who owns a decision. Accountability defines who is responsible when it fails. Sovereignty defines whether the organization actually controls its intelligence — or whether that intelligence lives inside people, tools, and vendor relationships it cannot govern. Without all three, organizational intelligence is fragile by design.
-            </p>
-            <a
-              href={FOUNDER_ESSAY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 text-emerald-400 hover:text-emerald-300 font-semibold text-sm transition-colors"
-            >
-              Read the full essay on LinkedIn
-              <span aria-hidden="true">→</span>
-            </a>
-          </div>
-        </div>
-      </section>
-
-      <hr className="assurance-divider" />
-
-      {/* ── Constitutional Index Section ── */}
-      <section id="index" className="scroll-mt-20 py-28 px-6">
-        <div className="max-w-7xl mx-auto">
-          <header className="mb-12 max-w-4xl">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-              Constitutional Index
-            </p>
-            <h2 className="text-4xl md:text-6xl font-semibold tracking-tight mb-5">
-              A public benchmark for Governance and Sovereignty in the AI industry.
-            </h2>
-            <p className="text-white/60 text-lg leading-relaxed">
-              The AOC Constitutional Index evaluates AI organizations across Governance and Sovereignty
-              dimensions. It provides a public evidence layer for understanding how organizations balance
-              accountability, control, dependency, and institutional resilience.
-            </p>
-            {emergingCandidates.length > 0 && (
-              <p className="mt-4 text-sm text-white/40">
-                {CONSTITUTIONAL_INDEX_ORGANIZATIONS.length} organizations assessed.
-                Closest emerging candidate: {emergingCandidates[0].name}.
-              </p>
-            )}
-          </header>
-
-          <ConstitutionalBenchmarkExplorer />
-
-          <div className="grid md:grid-cols-2 gap-6 mt-10">
-            <div className="ci-leader-panel">
-              <p className="ci-leader-panel-title">Governance Score Leaders</p>
-              <ol className="ci-leader-list">
-                {GOVERNANCE_RANKED.slice(0, 3).map((org, i) => (
-                  <li key={org.id} className="ci-leader-item">
-                    <span className="ci-leader-rank">{i + 1}</span>
-                    <div className="ci-leader-meta">
-                      <strong>{org.name}</strong>
-                      <span>{org.quadrantLabel}</span>
-                    </div>
-                    <strong className="ci-leader-score">{org.governanceScore}</strong>
-                  </li>
-                ))}
-              </ol>
-            </div>
-
-            <div className="ci-leader-panel">
-              <p className="ci-leader-panel-title">Sovereignty Score Leaders</p>
-              <ol className="ci-leader-list">
-                {SOVEREIGNTY_RANKED.slice(0, 3).map((org, i) => (
-                  <li key={org.id} className="ci-leader-item">
-                    <span className="ci-leader-rank">{i + 1}</span>
-                    <div className="ci-leader-meta">
-                      <strong>{org.name}</strong>
-                      <span>{org.quadrantLabel}</span>
-                    </div>
-                    <strong className="ci-leader-score ci-leader-score--sovereignty">{org.sovereigntyScore}</strong>
-                  </li>
-                ))}
-              </ol>
-            </div>
           </div>
         </div>
       </section>
@@ -707,6 +587,219 @@ const AssurancePage = () => {
           >
             Explore AOC Enterprise
           </a>
+        </div>
+      </section>
+
+      <hr className="assurance-divider" />
+
+      {/* ── Learn More Section ── */}
+      <section id="learn-more" className="scroll-mt-20 py-28 px-6">
+        <div className="max-w-4xl mx-auto">
+          <header className="mb-12">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+              Learn More
+            </p>
+            <h2 className="text-4xl md:text-5xl font-semibold tracking-tight mb-4">
+              Learn More
+            </h2>
+            <p className="text-white/60 text-lg leading-relaxed">
+              Explore the ideas behind AOC Assurance.
+            </p>
+          </header>
+
+          <div className="space-y-3">
+
+            {/* Card 1: Why does this happen? — Constitutional Framework */}
+            <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
+              <button
+                type="button"
+                className="w-full flex items-center justify-between gap-4 px-7 py-6 text-left hover:bg-white/[0.02] transition-colors"
+                aria-expanded={openLearnMore === 'framework'}
+                onClick={() => toggleLearnMore('framework')}
+              >
+                <span className="text-xl font-semibold">Why does this happen?</span>
+                <span
+                  aria-hidden="true"
+                  className={`flex-shrink-0 text-emerald-400 text-xl font-light transition-transform duration-300 ${openLearnMore === 'framework' ? 'rotate-45' : ''}`}
+                >
+                  +
+                </span>
+              </button>
+              {openLearnMore === 'framework' && (
+                <div className="px-7 pb-8 border-t border-white/10">
+                  <div className="pt-8">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+                      AOC Constitutional Framework
+                    </p>
+                    <h3 className="text-2xl md:text-3xl font-semibold tracking-tight mb-5">
+                      These are not just knowledge problems. They are constitutional failures.
+                    </h3>
+                    <p className="text-white/60 text-base leading-relaxed mb-8">
+                      Most organizations do not have a data problem. They have a continuity problem. Intelligence
+                      cannot survive without governance. Learning cannot scale without accountability. Resilience
+                      cannot exist without sovereignty. AOC Assurance evaluates the constitutional conditions that
+                      determine whether organizational intelligence remains durable, traceable, and usable through change.
+                    </p>
+
+                    <div className="grid md:grid-cols-3 gap-6 mb-10">
+                      {FRAMEWORK_CARDS.map((card) => (
+                        <div key={card.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-7">
+                          <h4 className="text-base font-semibold mb-3">{card.title}</h4>
+                          <p className="text-white/60 text-sm leading-relaxed">{card.body}</p>
+                        </div>
+                      ))}
+                    </div>
+
+                    <h4 className="text-xl md:text-2xl font-semibold tracking-tight mb-5">
+                      AOC Assurance measures whether your intelligence can survive change.
+                    </h4>
+                    <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
+                      {ASSESSMENT_DIMENSIONS.map((dim) => (
+                        <div key={dim.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+                          <p className="text-emerald-400 text-sm font-semibold mb-2">{dim.title}</p>
+                          <p className="text-white/55 text-sm leading-relaxed">{dim.body}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Card 2: Why did we create AOC? — Founder Essay */}
+            <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
+              <button
+                type="button"
+                className="w-full flex items-center justify-between gap-4 px-7 py-6 text-left hover:bg-white/[0.02] transition-colors"
+                aria-expanded={openLearnMore === 'founder-essay'}
+                onClick={() => toggleLearnMore('founder-essay')}
+              >
+                <span className="text-xl font-semibold">Why did we create AOC?</span>
+                <span
+                  aria-hidden="true"
+                  className={`flex-shrink-0 text-emerald-400 text-xl font-light transition-transform duration-300 ${openLearnMore === 'founder-essay' ? 'rotate-45' : ''}`}
+                >
+                  +
+                </span>
+              </button>
+              {openLearnMore === 'founder-essay' && (
+                <div className="px-7 pb-8 border-t border-white/10">
+                  <div className="pt-8">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+                      Founder Essay
+                    </p>
+                    <h3 className="text-2xl md:text-3xl font-semibold tracking-tight mb-3">
+                      Why Governance Alone Is Not Enough
+                    </h3>
+                    <p className="text-xl font-medium text-white/70 leading-snug mb-8">
+                      I Started Looking for Sovereignty. I Found a Constitutional Problem.
+                    </p>
+                    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 md:p-10">
+                      <p className="text-white/70 text-base leading-relaxed mb-6">
+                        Most organizations believe that if they govern their data well enough, they will be resilient. They invest in policies, frameworks, and tools. They document decisions. They deploy knowledge management systems. They add governance layers on top of governance layers.
+                      </p>
+                      <p className="text-white/70 text-base leading-relaxed mb-6">
+                        And yet critical intelligence keeps disappearing. Key employees leave and take context with them. Strategic decisions are made again because nobody can reconstruct why the original decision was made. AI systems are deployed but cannot understand the business they are supposed to serve. Organizations grow but do not learn.
+                      </p>
+                      <p className="text-white/70 text-base leading-relaxed mb-6">
+                        When I started investigating why this keeps happening, I expected to find a data problem. What I found instead was a constitutional problem.
+                      </p>
+                      <p className="text-white/70 text-base leading-relaxed mb-8">
+                        Governance defines who owns a decision. Accountability defines who is responsible when it fails. Sovereignty defines whether the organization actually controls its intelligence — or whether that intelligence lives inside people, tools, and vendor relationships it cannot govern. Without all three, organizational intelligence is fragile by design.
+                      </p>
+                      <a
+                        href={FOUNDER_ESSAY_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 text-emerald-400 hover:text-emerald-300 font-semibold text-sm transition-colors"
+                      >
+                        Read the full essay on LinkedIn
+                        <span aria-hidden="true">→</span>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Card 3: See the Public Benchmark — Constitutional Index */}
+            <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
+              <button
+                type="button"
+                className="w-full flex items-center justify-between gap-4 px-7 py-6 text-left hover:bg-white/[0.02] transition-colors"
+                aria-expanded={openLearnMore === 'index'}
+                onClick={() => toggleLearnMore('index')}
+              >
+                <span className="text-xl font-semibold">See the Public Benchmark</span>
+                <span
+                  aria-hidden="true"
+                  className={`flex-shrink-0 text-emerald-400 text-xl font-light transition-transform duration-300 ${openLearnMore === 'index' ? 'rotate-45' : ''}`}
+                >
+                  +
+                </span>
+              </button>
+              {openLearnMore === 'index' && (
+                <div className="px-7 pb-8 border-t border-white/10">
+                  <div id="index" className="scroll-mt-20 pt-8">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+                      Constitutional Index
+                    </p>
+                    <h3 className="text-2xl md:text-4xl font-semibold tracking-tight mb-5">
+                      A public benchmark for Governance and Sovereignty in the AI industry.
+                    </h3>
+                    <p className="text-white/60 text-base leading-relaxed mb-4">
+                      The AOC Constitutional Index evaluates AI organizations across Governance and Sovereignty
+                      dimensions. It provides a public evidence layer for understanding how organizations balance
+                      accountability, control, dependency, and institutional resilience.
+                    </p>
+                    {emergingCandidates.length > 0 && (
+                      <p className="mb-8 text-sm text-white/40">
+                        {CONSTITUTIONAL_INDEX_ORGANIZATIONS.length} organizations assessed.
+                        Closest emerging candidate: {emergingCandidates[0].name}.
+                      </p>
+                    )}
+
+                    <ConstitutionalBenchmarkExplorer />
+
+                    <div className="grid md:grid-cols-2 gap-6 mt-10">
+                      <div className="ci-leader-panel">
+                        <p className="ci-leader-panel-title">Governance Score Leaders</p>
+                        <ol className="ci-leader-list">
+                          {GOVERNANCE_RANKED.slice(0, 3).map((org, i) => (
+                            <li key={org.id} className="ci-leader-item">
+                              <span className="ci-leader-rank">{i + 1}</span>
+                              <div className="ci-leader-meta">
+                                <strong>{org.name}</strong>
+                                <span>{org.quadrantLabel}</span>
+                              </div>
+                              <strong className="ci-leader-score">{org.governanceScore}</strong>
+                            </li>
+                          ))}
+                        </ol>
+                      </div>
+
+                      <div className="ci-leader-panel">
+                        <p className="ci-leader-panel-title">Sovereignty Score Leaders</p>
+                        <ol className="ci-leader-list">
+                          {SOVEREIGNTY_RANKED.slice(0, 3).map((org, i) => (
+                            <li key={org.id} className="ci-leader-item">
+                              <span className="ci-leader-rank">{i + 1}</span>
+                              <div className="ci-leader-meta">
+                                <strong>{org.name}</strong>
+                                <span>{org.quadrantLabel}</span>
+                              </div>
+                              <strong className="ci-leader-score ci-leader-score--sovereignty">{org.sovereigntyScore}</strong>
+                            </li>
+                          ))}
+                        </ol>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+          </div>
         </div>
       </section>
 

--- a/frontend/app/src/landing/AssurancePage.tsx
+++ b/frontend/app/src/landing/AssurancePage.tsx
@@ -248,19 +248,29 @@ const AssurancePage = () => {
     setOpenLearnMore((prev) => (prev === id ? null : id));
 
   return (
-    <main className="min-h-screen bg-[#070d0b] text-white font-sans">
+    <main className="min-h-screen bg-[#070d0b] text-white font-sans pb-[72px] md:pb-0">
 
-      {/* ── Sticky CTA (desktop only, appears after Hero) ── */}
+      {/* ── Mobile sticky CTA bar ── */}
       <div
+        className={`assurance-mobile-cta-bar transition-all duration-300 ${showStickyCta ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2 pointer-events-none'}`}
         aria-hidden={!showStickyCta}
-        className={`fixed bottom-6 right-6 z-50 hidden md:block transition-all duration-300 ${showStickyCta ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'}`}
       >
         <a
           href="#assessments"
-          className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold text-sm rounded-2xl shadow-[0_8px_32px_rgba(52,211,153,0.35)] transition-colors"
+          className="flex items-center justify-center w-full py-3.5 bg-emerald-500 hover:bg-emerald-400 text-black font-semibold text-sm rounded-xl transition-colors"
         >
           Assess Intelligence Risk
-          <span aria-hidden="true">↑</span>
+        </a>
+      </div>
+
+      {/* ── Desktop sticky CTA (appears after Hero) ── */}
+      <div
+        className={`assurance-sticky-cta transition-all duration-300 ${showStickyCta ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3 pointer-events-none'}`}
+        aria-hidden={!showStickyCta}
+      >
+        <a href="#assessments" className="assurance-sticky-cta-inner">
+          <span className="assurance-sticky-cta-dot" aria-hidden="true" />
+          Assess Intelligence Risk
         </a>
       </div>
 
@@ -412,12 +422,12 @@ const AssurancePage = () => {
         </div>
       </section>
 
-      <hr className="assurance-divider" />
+      <hr className="assurance-section-divider-strong" />
 
       {/* ── Assessments Section ── */}
-      <section id="assessments" className="scroll-mt-20 py-28 px-6">
+      <section id="assessments" className="assurance-assessments-glow scroll-mt-20 py-36 px-6">
         <div className="max-w-7xl mx-auto">
-          <header className="mb-16 max-w-3xl">
+          <header className="mb-6 max-w-3xl">
             <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
               Assessments
             </p>
@@ -429,6 +439,18 @@ const AssurancePage = () => {
               intelligence continuity risk across teams, vendors, systems, and AI initiatives.
             </p>
           </header>
+
+          <div className="assurance-conversion-bridge">
+            <p><strong>If any of those questions made you pause</strong> — that is the signal. Start with the Public Assessment and know where you stand in 72 hours.</p>
+            <a
+              href={FOUNDATION_CHECKOUT_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="flex-shrink-0 inline-flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold rounded-xl transition-colors"
+            >
+              Start for $49 →
+            </a>
+          </div>
 
           <div className="grid md:grid-cols-3 gap-6">
             {/* Public Assessment */}
@@ -466,9 +488,9 @@ const AssurancePage = () => {
                 href={FOUNDATION_CHECKOUT_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="text-center py-3 rounded-xl text-sm font-semibold border border-white/15 hover:border-white/30 text-white transition-colors"
+                className="text-center py-3.5 rounded-xl text-sm font-semibold border border-emerald-500/40 hover:border-emerald-400/60 hover:bg-emerald-500/10 text-emerald-300 hover:text-emerald-200 transition-colors"
               >
-                Start Public Assessment
+                Start Public Assessment — $49
               </a>
             </article>
 
@@ -517,9 +539,9 @@ const AssurancePage = () => {
                 href={FOUNDER_PROGRAM_CHECKOUT_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="text-center py-3 rounded-xl text-sm font-semibold bg-emerald-500 hover:bg-emerald-400 text-black transition-colors"
+                className="text-center py-4 rounded-xl text-sm font-bold bg-emerald-500 hover:bg-emerald-400 text-black transition-colors shadow-[0_4px_24px_rgba(52,211,153,0.25)]"
               >
-                Join Founder Program
+                Join Founder Program — $149
               </a>
             </article>
 
@@ -559,7 +581,7 @@ const AssurancePage = () => {
                 href={ENTERPRISE_INTAKE_FORM_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="text-center py-3 rounded-xl text-sm font-semibold border border-white/15 hover:border-white/30 text-white transition-colors"
+                className="text-center py-3.5 rounded-xl text-sm font-semibold border border-white/15 hover:border-white/30 text-white/80 hover:text-white transition-colors"
               >
                 Request Enterprise Briefing
               </a>
@@ -595,152 +617,157 @@ const AssurancePage = () => {
       {/* ── Learn More Section ── */}
       <section id="learn-more" className="scroll-mt-20 py-28 px-6">
         <div className="max-w-4xl mx-auto">
-          <header className="mb-12">
+          <header className="mb-10">
             <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-              Learn More
+              Research &amp; Framework
             </p>
             <h2 className="text-4xl md:text-5xl font-semibold tracking-tight mb-4">
-              Learn More
+              Explore the research behind AOC Assurance.
             </h2>
-            <p className="text-white/60 text-lg leading-relaxed">
-              Explore the ideas behind AOC Assurance.
+            <p className="text-white/55 text-lg leading-relaxed max-w-2xl">
+              The framework, the founder's perspective, and the public benchmark — for those who want to understand the thinking before or after purchasing.
             </p>
           </header>
 
-          <div className="space-y-3">
+          <div className="space-y-2">
 
             {/* Card 1: Why does this happen? — Constitutional Framework */}
-            <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
+            <div className={`assurance-learn-more-card${openLearnMore === 'framework' ? ' assurance-learn-more-card--open' : ''}`}>
               <button
                 type="button"
-                className="w-full flex items-center justify-between gap-4 px-7 py-6 text-left hover:bg-white/[0.02] transition-colors"
+                className="assurance-learn-more-trigger"
                 aria-expanded={openLearnMore === 'framework'}
                 onClick={() => toggleLearnMore('framework')}
               >
-                <span className="text-xl font-semibold">Why does this happen?</span>
+                <div className="assurance-learn-more-trigger-text">
+                  <span className="assurance-learn-more-trigger-title">Why does this happen?</span>
+                  <span className="assurance-learn-more-trigger-desc">Explore the Governance, Accountability, and Sovereignty principles behind organizational intelligence loss.</span>
+                </div>
                 <span
                   aria-hidden="true"
-                  className={`flex-shrink-0 text-emerald-400 text-xl font-light transition-transform duration-300 ${openLearnMore === 'framework' ? 'rotate-45' : ''}`}
+                  className={`assurance-learn-more-icon${openLearnMore === 'framework' ? ' assurance-learn-more-icon--open' : ''}`}
                 >
                   +
                 </span>
               </button>
               {openLearnMore === 'framework' && (
-                <div className="px-7 pb-8 border-t border-white/10">
-                  <div className="pt-8">
-                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-                      AOC Constitutional Framework
-                    </p>
-                    <h3 className="text-2xl md:text-3xl font-semibold tracking-tight mb-5">
-                      These are not just knowledge problems. They are constitutional failures.
-                    </h3>
-                    <p className="text-white/60 text-base leading-relaxed mb-8">
-                      Most organizations do not have a data problem. They have a continuity problem. Intelligence
-                      cannot survive without governance. Learning cannot scale without accountability. Resilience
-                      cannot exist without sovereignty. AOC Assurance evaluates the constitutional conditions that
-                      determine whether organizational intelligence remains durable, traceable, and usable through change.
-                    </p>
+                <div className="assurance-learn-more-body">
+                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+                    AOC Constitutional Framework
+                  </p>
+                  <h3 className="text-2xl md:text-3xl font-semibold tracking-tight mb-5">
+                    These are not just knowledge problems. They are constitutional failures.
+                  </h3>
+                  <p className="text-white/60 text-base leading-relaxed mb-8">
+                    Most organizations do not have a data problem. They have a continuity problem. Intelligence
+                    cannot survive without governance. Learning cannot scale without accountability. Resilience
+                    cannot exist without sovereignty. AOC Assurance evaluates the constitutional conditions that
+                    determine whether organizational intelligence remains durable, traceable, and usable through change.
+                  </p>
 
-                    <div className="grid md:grid-cols-3 gap-6 mb-10">
-                      {FRAMEWORK_CARDS.map((card) => (
-                        <div key={card.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-7">
-                          <h4 className="text-base font-semibold mb-3">{card.title}</h4>
-                          <p className="text-white/60 text-sm leading-relaxed">{card.body}</p>
-                        </div>
-                      ))}
-                    </div>
+                  <div className="grid md:grid-cols-3 gap-5 mb-10">
+                    {FRAMEWORK_CARDS.map((card) => (
+                      <div key={card.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+                        <h4 className="text-base font-semibold mb-3">{card.title}</h4>
+                        <p className="text-white/60 text-sm leading-relaxed">{card.body}</p>
+                      </div>
+                    ))}
+                  </div>
 
-                    <h4 className="text-xl md:text-2xl font-semibold tracking-tight mb-5">
-                      AOC Assurance measures whether your intelligence can survive change.
-                    </h4>
-                    <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
-                      {ASSESSMENT_DIMENSIONS.map((dim) => (
-                        <div key={dim.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
-                          <p className="text-emerald-400 text-sm font-semibold mb-2">{dim.title}</p>
-                          <p className="text-white/55 text-sm leading-relaxed">{dim.body}</p>
-                        </div>
-                      ))}
-                    </div>
+                  <h4 className="text-xl md:text-2xl font-semibold tracking-tight mb-5">
+                    AOC Assurance measures whether your intelligence can survive change.
+                  </h4>
+                  <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                    {ASSESSMENT_DIMENSIONS.map((dim) => (
+                      <div key={dim.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+                        <p className="text-emerald-400 text-sm font-semibold mb-2">{dim.title}</p>
+                        <p className="text-white/55 text-sm leading-relaxed">{dim.body}</p>
+                      </div>
+                    ))}
                   </div>
                 </div>
               )}
             </div>
 
             {/* Card 2: Why did we create AOC? — Founder Essay */}
-            <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
+            <div className={`assurance-learn-more-card${openLearnMore === 'founder-essay' ? ' assurance-learn-more-card--open' : ''}`}>
               <button
                 type="button"
-                className="w-full flex items-center justify-between gap-4 px-7 py-6 text-left hover:bg-white/[0.02] transition-colors"
+                className="assurance-learn-more-trigger"
                 aria-expanded={openLearnMore === 'founder-essay'}
                 onClick={() => toggleLearnMore('founder-essay')}
               >
-                <span className="text-xl font-semibold">Why did we create AOC?</span>
+                <div className="assurance-learn-more-trigger-text">
+                  <span className="assurance-learn-more-trigger-title">Why did we create AOC?</span>
+                  <span className="assurance-learn-more-trigger-desc">Read the founder's essay explaining the constitutional problem behind modern organizational intelligence loss.</span>
+                </div>
                 <span
                   aria-hidden="true"
-                  className={`flex-shrink-0 text-emerald-400 text-xl font-light transition-transform duration-300 ${openLearnMore === 'founder-essay' ? 'rotate-45' : ''}`}
+                  className={`assurance-learn-more-icon${openLearnMore === 'founder-essay' ? ' assurance-learn-more-icon--open' : ''}`}
                 >
                   +
                 </span>
               </button>
               {openLearnMore === 'founder-essay' && (
-                <div className="px-7 pb-8 border-t border-white/10">
-                  <div className="pt-8">
-                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
-                      Founder Essay
+                <div className="assurance-learn-more-body">
+                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
+                    Founder Essay
+                  </p>
+                  <h3 className="text-2xl md:text-3xl font-semibold tracking-tight mb-3">
+                    Why Governance Alone Is Not Enough
+                  </h3>
+                  <p className="text-xl font-medium text-white/70 leading-snug mb-8">
+                    I Started Looking for Sovereignty. I Found a Constitutional Problem.
+                  </p>
+                  <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 md:p-10">
+                    <p className="text-white/70 text-base leading-relaxed mb-6">
+                      Most organizations believe that if they govern their data well enough, they will be resilient. They invest in policies, frameworks, and tools. They document decisions. They deploy knowledge management systems. They add governance layers on top of governance layers.
                     </p>
-                    <h3 className="text-2xl md:text-3xl font-semibold tracking-tight mb-3">
-                      Why Governance Alone Is Not Enough
-                    </h3>
-                    <p className="text-xl font-medium text-white/70 leading-snug mb-8">
-                      I Started Looking for Sovereignty. I Found a Constitutional Problem.
+                    <p className="text-white/70 text-base leading-relaxed mb-6">
+                      And yet critical intelligence keeps disappearing. Key employees leave and take context with them. Strategic decisions are made again because nobody can reconstruct why the original decision was made. AI systems are deployed but cannot understand the business they are supposed to serve. Organizations grow but do not learn.
                     </p>
-                    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 md:p-10">
-                      <p className="text-white/70 text-base leading-relaxed mb-6">
-                        Most organizations believe that if they govern their data well enough, they will be resilient. They invest in policies, frameworks, and tools. They document decisions. They deploy knowledge management systems. They add governance layers on top of governance layers.
-                      </p>
-                      <p className="text-white/70 text-base leading-relaxed mb-6">
-                        And yet critical intelligence keeps disappearing. Key employees leave and take context with them. Strategic decisions are made again because nobody can reconstruct why the original decision was made. AI systems are deployed but cannot understand the business they are supposed to serve. Organizations grow but do not learn.
-                      </p>
-                      <p className="text-white/70 text-base leading-relaxed mb-6">
-                        When I started investigating why this keeps happening, I expected to find a data problem. What I found instead was a constitutional problem.
-                      </p>
-                      <p className="text-white/70 text-base leading-relaxed mb-8">
-                        Governance defines who owns a decision. Accountability defines who is responsible when it fails. Sovereignty defines whether the organization actually controls its intelligence — or whether that intelligence lives inside people, tools, and vendor relationships it cannot govern. Without all three, organizational intelligence is fragile by design.
-                      </p>
-                      <a
-                        href={FOUNDER_ESSAY_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 text-emerald-400 hover:text-emerald-300 font-semibold text-sm transition-colors"
-                      >
-                        Read the full essay on LinkedIn
-                        <span aria-hidden="true">→</span>
-                      </a>
-                    </div>
+                    <p className="text-white/70 text-base leading-relaxed mb-6">
+                      When I started investigating why this keeps happening, I expected to find a data problem. What I found instead was a constitutional problem.
+                    </p>
+                    <p className="text-white/70 text-base leading-relaxed mb-8">
+                      Governance defines who owns a decision. Accountability defines who is responsible when it fails. Sovereignty defines whether the organization actually controls its intelligence — or whether that intelligence lives inside people, tools, and vendor relationships it cannot govern. Without all three, organizational intelligence is fragile by design.
+                    </p>
+                    <a
+                      href={FOUNDER_ESSAY_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 text-emerald-400 hover:text-emerald-300 font-semibold text-sm transition-colors"
+                    >
+                      Read the full essay on LinkedIn
+                      <span aria-hidden="true">→</span>
+                    </a>
                   </div>
                 </div>
               )}
             </div>
 
             {/* Card 3: See the Public Benchmark — Constitutional Index */}
-            <div className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
+            <div className={`assurance-learn-more-card${openLearnMore === 'index' ? ' assurance-learn-more-card--open' : ''}`}>
               <button
                 type="button"
-                className="w-full flex items-center justify-between gap-4 px-7 py-6 text-left hover:bg-white/[0.02] transition-colors"
+                className="assurance-learn-more-trigger"
                 aria-expanded={openLearnMore === 'index'}
                 onClick={() => toggleLearnMore('index')}
               >
-                <span className="text-xl font-semibold">See the Public Benchmark</span>
+                <div className="assurance-learn-more-trigger-text">
+                  <span className="assurance-learn-more-trigger-title">See the Public Benchmark</span>
+                  <span className="assurance-learn-more-trigger-desc">Explore how AI organizations compare across Governance and Sovereignty dimensions in the AOC Constitutional Index.</span>
+                </div>
                 <span
                   aria-hidden="true"
-                  className={`flex-shrink-0 text-emerald-400 text-xl font-light transition-transform duration-300 ${openLearnMore === 'index' ? 'rotate-45' : ''}`}
+                  className={`assurance-learn-more-icon${openLearnMore === 'index' ? ' assurance-learn-more-icon--open' : ''}`}
                 >
                   +
                 </span>
               </button>
               {openLearnMore === 'index' && (
-                <div className="px-7 pb-8 border-t border-white/10">
-                  <div id="index" className="scroll-mt-20 pt-8">
+                <div className="assurance-learn-more-body">
+                  <div id="index" className="scroll-mt-20">
                     <p className="text-xs font-semibold uppercase tracking-[0.22em] text-emerald-400 mb-4">
                       Constitutional Index
                     </p>

--- a/frontend/app/src/landing/assurance.css
+++ b/frontend/app/src/landing/assurance.css
@@ -8,11 +8,223 @@
   );
 }
 
+.assurance-assessments-glow {
+  background:
+    radial-gradient(ellipse 70% 60% at 50% 0%, rgba(11, 44, 37, 0.65) 0%, transparent 65%),
+    radial-gradient(ellipse 40% 30% at 80% 100%, rgba(11, 44, 37, 0.25) 0%, transparent 55%);
+}
+
 .assurance-divider {
   border: none;
   border-top: 1px solid rgba(255, 255, 255, 0.07);
   margin: 0;
 }
+
+.assurance-section-divider-strong {
+  border: none;
+  border-top: 1px solid rgba(52, 211, 153, 0.12);
+  margin: 0;
+  background: linear-gradient(90deg, transparent, rgba(52, 211, 153, 0.06), transparent);
+  height: 1px;
+}
+
+/* ── Learn More Accordion ── */
+
+.assurance-learn-more-card {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.assurance-learn-more-card:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.assurance-learn-more-card--open {
+  border-color: rgba(52, 211, 153, 0.2);
+}
+
+.assurance-learn-more-trigger {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  gap: 1.5rem;
+  padding: 1.75rem 1.75rem;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.018);
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  color: #fff;
+  transition: background-color 0.2s ease;
+}
+
+.assurance-learn-more-trigger:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.assurance-learn-more-trigger-text {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.assurance-learn-more-trigger-title {
+  font-size: 1.1875rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
+.assurance-learn-more-trigger-desc {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.48);
+  line-height: 1.55;
+}
+
+.assurance-learn-more-icon {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+  color: #6ee7b7;
+  font-size: 1.25rem;
+  font-weight: 300;
+  line-height: 1;
+  transition: transform 0.25s ease, border-color 0.2s ease, background-color 0.2s ease;
+  margin-top: 0.1rem;
+}
+
+.assurance-learn-more-icon--open {
+  transform: rotate(45deg);
+  border-color: rgba(52, 211, 153, 0.35);
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.assurance-learn-more-body {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.012);
+  padding: 2rem 1.75rem 2.25rem;
+}
+
+/* ── Mobile Sticky CTA Bar ── */
+
+.assurance-mobile-cta-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding: 0.875rem 1.25rem;
+  padding-bottom: calc(0.875rem + env(safe-area-inset-bottom, 0px));
+  background: rgba(7, 13, 11, 0.96);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+@media (min-width: 768px) {
+  .assurance-mobile-cta-bar { display: none; }
+}
+
+/* ── Desktop Sticky CTA ── */
+
+.assurance-sticky-cta {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 50;
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .assurance-sticky-cta { display: block; }
+}
+
+.assurance-sticky-cta-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  background: rgba(7, 13, 11, 0.88);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  color: #6ee7b7;
+  font-size: 0.875rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  box-shadow:
+    0 0 0 1px rgba(52, 211, 153, 0.08),
+    0 8px 32px rgba(0, 0, 0, 0.45),
+    0 0 24px rgba(52, 211, 153, 0.12);
+  transition: border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  white-space: nowrap;
+}
+
+.assurance-sticky-cta-inner:hover {
+  border-color: rgba(52, 211, 153, 0.6);
+  color: #fff;
+  background: rgba(52, 211, 153, 0.12);
+  box-shadow:
+    0 0 0 1px rgba(52, 211, 153, 0.15),
+    0 8px 32px rgba(0, 0, 0, 0.45),
+    0 0 32px rgba(52, 211, 153, 0.2);
+}
+
+.assurance-sticky-cta-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #34d399;
+  animation: assurance-pulse 2s ease-in-out infinite;
+}
+
+@keyframes assurance-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.6; transform: scale(0.75); }
+}
+
+/* ── Assessments section conversion band ── */
+
+.assurance-conversion-bridge {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.25rem 1.75rem;
+  border: 1px solid rgba(52, 211, 153, 0.15);
+  border-radius: 1rem;
+  background:
+    linear-gradient(135deg, rgba(52, 211, 153, 0.05), rgba(52, 211, 153, 0.02)),
+    rgba(255, 255, 255, 0.015);
+  margin-bottom: 3.5rem;
+}
+
+.assurance-conversion-bridge p {
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.assurance-conversion-bridge p strong {
+  color: #fff;
+  font-weight: 650;
+}
+
+@media (max-width: 640px) {
+  .assurance-conversion-bridge {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+
 
 /* ── Constitutional Map ── */
 


### PR DESCRIPTION
## Summary
Restructured the AssurancePage to improve navigation and conversion flow by consolidating educational content into a collapsible "Learn More" section and adding persistent call-to-action elements that appear after the hero section.

## Key Changes

- **Navigation restructuring**: Replaced separate "Framework" and "Index" nav items with a single "Learn More" link that anchors to a new accordion-style section
- **Sticky CTA implementation**: Added mobile and desktop sticky call-to-action bars that appear after the hero section scrolls out of view, using IntersectionObserver to detect visibility
- **Learn More accordion**: Converted three previously separate full-page sections (Constitutional Framework, Founder Essay, Constitutional Index) into expandable accordion cards within a single "Learn More" section, reducing page length while maintaining content accessibility
- **Assessments section enhancement**: 
  - Added a conversion bridge component above the assessment cards with persuasive copy and a CTA button
  - Enhanced button styling with emerald accent colors and improved visual hierarchy
  - Added glow background effect to the section
- **Visual refinements**:
  - Added `assurance-section-divider-strong` with emerald gradient for visual emphasis
  - Updated button styles across assessment cards for better conversion signaling
  - Added bottom padding to main content to accommodate mobile sticky CTA bar

## Implementation Details

- Used React `useState` and `useEffect` hooks to manage accordion state and sticky CTA visibility
- IntersectionObserver monitors the hero section to toggle sticky CTA display
- Accordion uses a `LearnMoreId` type union for type-safe state management
- CSS includes new animations (pulse effect for sticky CTA dot) and responsive design patterns
- Maintained all original content and functionality while improving information architecture

https://claude.ai/code/session_01UAWNbKowink6JDtFAhKVU9