### PR TITLE
W004: Rebuild AOC Protocol landing page around digital assets, capabilities & sovereignty

### DIFF
--- a/frontend/app/docs/w004-protocol-digital-assets-sovereignty-refactor.md
+++ b/frontend/app/docs/w004-protocol-digital-assets-sovereignty-refactor.md
@@ -1,0 +1,143 @@
+# W004 — AOC Protocol digital-assets & sovereignty refactor
+
+Status: Protocol's landing page (`src/landing/AocLandingPage.tsx`) is rebuilt
+around its own thesis. This is the "Protocol Step 2" rewrite that W003 called
+out as a follow-up.
+
+## New Protocol thesis
+
+AOC Protocol defines the language and capabilities of sovereign digital
+assets: identity, integrity, provenance, capabilities, and the
+sovereignty-related properties that let an asset's meaning survive outside
+the platform that created it. AOC Enterprise operationalizes governance on
+top of those capabilities — access decisions, obligations, grants,
+revocation, evidence, and Assurance. Protocol describes; Enterprise decides,
+executes, observes, and audits.
+
+## Protocol ownership
+
+The rebuilt page owns, and only owns:
+
+- what a digital asset is (broad, non-crypto definition);
+- the capability families an asset can declare (identity, integrity,
+  provenance, portability, interoperability, verifiability, licensing &
+  terms, governance compatibility);
+- digital sovereignty, defined practically (not absolute);
+- the conceptual creation flow for an AOC-compatible asset;
+- provider neutrality — separating asset identity from storage location;
+- the Protocol → Enterprise boundary itself, as a bridge, not an explanation
+  of how Enterprise governs.
+
+## Enterprise boundary (unchanged, verified)
+
+Nothing governance-heavy was moved back into Protocol. Access enforcement,
+consent workflows, permission evaluation, audit operations, and the
+Governed Access / Assurance commercial offerings remain exclusively on AOC
+Enterprise (`enterprise/GovernanceGap.tsx`, `enterprise/GovernanceEmerges.tsx`,
+`enterprise/SolutionsAndServices.tsx`, `GovernedAccessPage.tsx`,
+`AssurancePage.tsx` — none of these were touched by this change). Protocol's
+new "Protocol to Enterprise" section only names what Enterprise owns; it
+does not explain how.
+
+## Digital asset definition
+
+The page defines a digital asset broadly and explicitly rejects a
+crypto/NFT/token framing: a photograph, document, dataset, video, audio
+file, model file, credential, contract, prompt, workflow, configuration,
+software package, or design all qualify. The framing used throughout: *a
+file contains content; a digital asset also carries identity, integrity,
+provenance, capabilities, and references that systems can interpret.* Not
+every raw file is automatically an AOC-compatible asset — an application or
+tool that speaks the protocol has to create or register that context (see
+`protocol/AssetCreationFlow.tsx`).
+
+## Capability model & manifest concept — what's real vs. conceptual
+
+Every capability family on the page (`protocol/content.ts`,
+`CAPABILITY_FAMILIES`) carries a status label — `Reference Model` or `Future
+Direction` — no capability is labeled `Available`/`Implemented`, because
+`@aoc/protocol` is not yet published to a registry (see
+`packages/protocol/README.md`).
+
+Grounded in real, repository-verified contract shapes in
+`packages/protocol/src/claims/`:
+
+- **Identity** — `CanonicalId`, `CanonicalCredentialRef`
+- **Integrity** — `CanonicalHashProof` (`claims/proofs/hash-proof.ts`) — a
+  declared digest (algorithm + hash) for a subject
+- **Provenance** — issuer/`issuedAt` fields on `CanonicalCredentialManifest`
+  (`claims/credentials/credential-manifest.ts`)
+- **Portability** — `CanonicalRegistryRef` / `CanonicalRegistryManifest`
+  (`claims/registries/`)
+- **Interoperability** — adapter interfaces in `packages/protocol/src/adapters`
+  (verification, revocation, registry lookup)
+- **Verifiability** — proof references + verification-key resolution
+- **Governance Compatibility** — capability/consent contract shapes that
+  Enterprise operationalizes
+
+Labeled `Future Direction` (no canonical contract found in the repository):
+
+- **Licensing & Terms** — references to policies, licenses, or economic
+  arrangements. Not yet a defined contract.
+- Cross-provider storage adapters (Pinata, S3, Azure) — illustrative only;
+  no adapter ships today. Pinata specifically does not appear anywhere in
+  the codebase outside this page's own illustrative list.
+
+The "digital asset manifest" concept (Section: From File to Digital Asset /
+How an AOC-Compatible Asset Is Created) is presented as a conceptual model —
+labeled "Protocol Direction — Conceptual Model" on the page — not a claim
+that a unified manifest schema or creation SDK ships today. No production
+schema was invented; the page instead points at the real canonical contract
+shapes above as the current foundation.
+
+## Sovereignty positioning
+
+Sovereignty is defined practically: the degree to which an asset (and its
+legitimate participants) retains control over identity, integrity,
+provenance, and resolution, rather than an absolute or legal claim. The page
+explicitly disclaims guaranteeing ownership, legal title, custody, or
+universal enforcement, and uses only the approved vocabulary
+(sovereignty-aware, sovereignty-enabling, portable, provider-neutral,
+independently verifiable).
+
+## SEO changes
+
+- `index.html`: title, meta description, keywords, `og:*`, and `twitter:*`
+  tags at the root URL were rewritten from an AOC Assurance framing
+  ("AI Governance and Sovereignty Assessment") to the Protocol thesis. The
+  JSON-LD `WebPage` node for `https://www.aocprotocol.org/` (name,
+  description, keywords) was updated to match — it previously described
+  Assurance despite being the entity for the Protocol root page. The
+  `Organization`, `WebSite`, `Product`, `Service`, and `FAQPage` JSON-LD
+  nodes were left untouched (out of scope — they describe Assurance's own
+  offering, not the Protocol page).
+- Added `protocol/usePageMeta.ts`, a live document-head updater (same
+  pattern already used by `GovVsSovPage.tsx` / `WhatIsAiSovereigntyPage.tsx`)
+  so the browser tab title and live meta tags match Protocol whenever this
+  page is the active client-side view, restoring the previous values on
+  unmount.
+
+## Component strategy
+
+New components live under `landing/protocol/` (mirroring the existing
+`landing/enterprise/` pattern): `content.ts` (narrative data),
+`primitives.tsx` (Eyebrow/SectionHeader/StatusPill/StepFlow), and one file
+per section (`Hero`, `FileToAsset`, `CapabilityFamilies`, `Sovereignty`,
+`AssetCreationFlow`, `PhotographExample`, `ProviderNeutral`,
+`ProtocolToEnterprise`, `Developers`). `AocLandingPage.tsx` composes them.
+`ProtocolFooter.tsx` (shared across Protocol and Enterprise pages) had its
+"AOC Protocol" tagline and inert `Protocol` link-column labels updated to
+drop leftover governance framing ("Consent Engine", "Audit Layer",
+"Ship access systems with explicit control semantics") — everything else in
+that shared component, and every Enterprise-owned component, is untouched.
+
+## Future implications (not committed in this PR)
+
+- A formal Digital Asset Manifest specification, if the canonical contracts
+  above are consolidated into one schema.
+- A creation/verification SDK for compatible applications.
+- Real storage-provider adapters (the page lists Pinata/S3/Azure only as
+  illustrative, labeled `Future Direction`).
+- Enterprise's own final commercial refactor (tracked separately from W004).
+- Governed Access and Assurance dedicated landing-page refactors (both still
+  navigation-skeleton / unchanged pages per W003).

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary Meta Tags -->
-    <title>AI Governance and Sovereignty Assessment | AOC Assurance</title>
+    <title>AOC Protocol — An Open Protocol for Digital Assets, Capabilities & Sovereignty</title>
     <meta
       name="description"
-      content="Measure Governance. Measure Sovereignty. Understand the Balance. AOC Assurance evaluates the constitutional posture of AI systems through Governance and Sovereignty assessments."
+      content="AOC Protocol is an open, provider-neutral protocol for digital assets — identity, integrity, provenance, capabilities and sovereignty that compatible systems can interpret. AOC Enterprise operationalizes governance on top of it."
     />
     <meta
       name="keywords"
-      content="AI Governance Assessment, AI Sovereignty Assessment, AI Constitutional Assessment, AI Trust Assessment, Governance Score, Sovereignty Score, Constitutional AI Operations, AI Risk, AI Assurance, AI Governance Framework, AOC Assurance, Constitutional Assurance"
+      content="Digital Asset Protocol, Digital Sovereignty, Open Protocol, Asset Identity, Asset Integrity, Asset Provenance, Digital Asset Capabilities, Interoperability, Provider Neutrality, AOC Protocol"
     />
     <meta name="author" content="Victor Valverde" />
     <meta name="robots" content="index, follow" />
@@ -21,29 +21,29 @@
     <link rel="icon" type="image/svg+xml" href="/favicon-pro.svg" />
 
     <!-- Open Graph -->
-    <meta property="og:site_name" content="AOC Assurance" />
-    <meta property="og:title" content="AI Governance and Sovereignty Assessment | AOC Assurance" />
+    <meta property="og:site_name" content="AOC Protocol" />
+    <meta property="og:title" content="AOC Protocol — An Open Protocol for Digital Assets, Capabilities & Sovereignty" />
     <meta
       property="og:description"
-      content="Measure Governance. Measure Sovereignty. Understand the Balance. AOC Assurance evaluates the constitutional posture of AI systems through Governance and Sovereignty assessments."
+      content="AOC Protocol is an open, provider-neutral protocol for digital assets — identity, integrity, provenance, capabilities and sovereignty that compatible systems can interpret. AOC Enterprise operationalizes governance on top of it."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.aocprotocol.org/" />
     <meta property="og:image" content="https://www.aocprotocol.org/og-image.png" />
-    <meta property="og:image:alt" content="AOC Assurance — Constitutional Assurance for AI" />
+    <meta property="og:image:alt" content="AOC Protocol — an open protocol for digital assets" />
     <meta property="og:locale" content="en_US" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@archofchange" />
     <meta name="twitter:creator" content="@archofchange" />
-    <meta name="twitter:title" content="AI Governance and Sovereignty Assessment | AOC Assurance" />
+    <meta name="twitter:title" content="AOC Protocol — An Open Protocol for Digital Assets, Capabilities & Sovereignty" />
     <meta
       name="twitter:description"
-      content="Measure Governance. Measure Sovereignty. Understand the Balance. AOC Assurance evaluates the constitutional posture of AI systems through Governance and Sovereignty assessments."
+      content="AOC Protocol is an open, provider-neutral protocol for digital assets — identity, integrity, provenance, capabilities and sovereignty that compatible systems can interpret. AOC Enterprise operationalizes governance on top of it."
     />
     <meta name="twitter:image" content="https://www.aocprotocol.org/og-image.png" />
-    <meta name="twitter:image:alt" content="AOC Assurance — Constitutional Assurance for AI" />
+    <meta name="twitter:image:alt" content="AOC Protocol — an open protocol for digital assets" />
 
     <meta name="theme-color" content="#0b2c25" />
 
@@ -101,8 +101,8 @@
           "@type": "WebPage",
           "@id": "https://www.aocprotocol.org/#webpage",
           "url": "https://www.aocprotocol.org/",
-          "name": "AI Governance and Sovereignty Assessment | AOC Assurance",
-          "description": "Measure Governance. Measure Sovereignty. Understand the Balance. AOC Assurance evaluates the constitutional posture of AI systems through Governance and Sovereignty assessments.",
+          "name": "AOC Protocol — An Open Protocol for Digital Assets, Capabilities & Sovereignty",
+          "description": "AOC Protocol is an open, provider-neutral protocol for digital assets — identity, integrity, provenance, capabilities and sovereignty that compatible systems can interpret. AOC Enterprise operationalizes governance on top of it.",
           "isPartOf": {
             "@id": "https://www.aocprotocol.org/#website"
           },
@@ -114,16 +114,15 @@
             "url": "https://www.aocprotocol.org/og-image.png"
           },
           "keywords": [
-            "AI Governance Assessment",
-            "AI Sovereignty Assessment",
-            "AI Constitutional Assessment",
-            "AI Trust Assessment",
-            "Governance Score",
-            "Sovereignty Score",
-            "Constitutional AI Operations",
-            "AI Risk",
-            "AI Assurance",
-            "AI Governance Framework"
+            "Digital Asset Protocol",
+            "Digital Sovereignty",
+            "Open Protocol",
+            "Asset Identity",
+            "Asset Integrity",
+            "Asset Provenance",
+            "Digital Asset Capabilities",
+            "Interoperability",
+            "Provider Neutrality"
           ],
           "inLanguage": "en-US"
         },

--- a/frontend/app/src/landing/AocLandingPage.tsx
+++ b/frontend/app/src/landing/AocLandingPage.tsx
@@ -1,16 +1,26 @@
 import { useState } from 'react';
 import { ProtocolFooter } from './components/ProtocolFooter'
 import { LogoRotating } from '../components/logo/LogoRotating';
+import { Hero } from './protocol/Hero';
+import { FileToAsset } from './protocol/FileToAsset';
+import { CapabilityFamilies } from './protocol/CapabilityFamilies';
+import { Sovereignty } from './protocol/Sovereignty';
+import { AssetCreationFlow } from './protocol/AssetCreationFlow';
+import { PhotographExample } from './protocol/PhotographExample';
+import { ProviderNeutral } from './protocol/ProviderNeutral';
+import { ProtocolToEnterprise } from './protocol/ProtocolToEnterprise';
+import { Developers } from './protocol/Developers';
+import { usePageMeta } from './protocol/usePageMeta';
 
 // Top-level site navigation: Protocol / Enterprise / About. Assurance and
 // Documentation now live one level down, under Enterprise (Services and
 // Developers respectively) — see enterprise/Nav.tsx for that hierarchy.
 //
-// W003 note: the former in-page Problem / Solution / How It Works sections
-// (and their nav anchors) were migrated to AOC Enterprise — see
-// enterprise/GovernanceGap.tsx and enterprise/GovernanceEmerges.tsx. This
-// page temporarily carries a short "foundation" bridge in their place until
-// Protocol's own sovereignty-focused refactor (W003 Step 2).
+// W004: Protocol is rebuilt around its own thesis — digital assets, their
+// capabilities, and sovereignty-related properties — rather than the
+// governance/operational-control narrative that now lives on AOC Enterprise
+// (see enterprise/GovernanceGap.tsx and enterprise/GovernanceEmerges.tsx,
+// migrated in W003). See docs/w004-protocol-digital-assets-sovereignty-refactor.md.
 const mobileNavigationItems = [
   { label: 'Protocol', href: '/' },
   { label: 'Enterprise', href: '/?view=enterprise' },
@@ -19,6 +29,7 @@ const mobileNavigationItems = [
 
 export const AocLandingPage = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  usePageMeta();
 
   return (
     <main className="min-h-screen bg-[#0a0a0a] text-white overflow-hidden font-sans">
@@ -39,8 +50,11 @@ export const AocLandingPage = () => {
             </div>
 
             <div className="hidden md:flex items-center gap-10 text-sm font-medium">
-              <a href="#foundation" className="hover:text-white transition">
-                Foundation
+              <a href="#digital-asset" className="hover:text-white transition">
+                Digital Assets
+              </a>
+              <a href="#capabilities" className="hover:text-white transition text-white/70">
+                Capabilities
               </a>
               <a href="/?view=enterprise" className="hover:text-white transition text-white/70">
                 Enterprise
@@ -121,84 +135,35 @@ export const AocLandingPage = () => {
         </nav>
       </header>
 
-      <section className="min-h-screen flex items-center pt-16">
-        <div className="max-w-5xl mx-auto px-6 text-center">
-          <h1 className="text-[68px] md:text-[82px] leading-[1.05] font-semibold tracking-[-3.5px] mb-6">
-            You don&apos;t own your data.
-          </h1>
-
-          <p className="text-[52px] md:text-[62px] leading-none font-light tracking-[-2px] text-white mb-8">
-            You just hope no one abuses it.
-          </p>
-
-          <p className="max-w-[620px] mx-auto text-[21px] text-white leading-relaxed mb-14">
-            There is a better system. One where access is granted, not assumed.
-          </p>
-
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href="#foundation"
-              className="px-12 py-5 bg-[#00f0ff] hover:bg-[#00d4e0] text-black font-semibold text-xl rounded-2xl transition-all active:scale-[0.98] inline-block"
-            >
-              Enter the new model →
-            </a>
-
-            <a
-              href="/?view=enterprise"
-              className="px-10 py-5 border border-white/15 hover:border-white/30 text-white font-semibold text-xl rounded-2xl transition-all active:scale-[0.98] inline-block"
-            >
-              Integrate AOC
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/*
-        W003 bridge section — temporary. The governance-oriented Problem,
-        Solution, How It Works, and infrastructure-diagram sections that
-        used to live here were migrated to AOC Enterprise (see
-        enterprise/GovernanceGap.tsx and enterprise/GovernanceEmerges.tsx).
-        This is intentionally a short, neutral transition, not Protocol's
-        final sovereignty-focused narrative — that rewrite is W003 Step 2.
-      */}
-      <section id="foundation" className="scroll-mt-24 py-32 border-t border-white/10">
-        <div className="max-w-3xl mx-auto px-6 text-center">
-          <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/80">The Foundation</p>
-          <h2 className="mt-4 text-4xl md:text-5xl font-semibold tracking-tight">
-            AOC Protocol is the open foundation.
-          </h2>
-          <p className="mt-6 text-lg text-white/65 leading-relaxed">
-            Protocol defines what a digital asset can be — identifiable, portable, verifiable, and
-            interoperable across systems. AOC Enterprise builds on that foundation to operationalize
-            governance: policy, consent, delegation, and audit for organizations that need to control
-            how those assets are actually used.
-          </p>
-
-          <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href="/?view=enterprise"
-              className="px-8 py-4 bg-[#00f0ff] hover:bg-[#00d4e0] text-black font-semibold rounded-2xl transition-all active:scale-[0.98] inline-block"
-            >
-              See how Enterprise governs it →
-            </a>
-            <a
-              href="/?view=docs#getting-started"
-              className="px-8 py-4 border border-white/15 hover:border-white/30 text-white font-semibold rounded-2xl transition-all active:scale-[0.98] inline-block"
-            >
-              Read the docs
-            </a>
-          </div>
-        </div>
-      </section>
+      <Hero />
+      <FileToAsset />
+      <CapabilityFamilies />
+      <Sovereignty />
+      <AssetCreationFlow />
+      <PhotographExample />
+      <ProviderNeutral />
+      <ProtocolToEnterprise />
+      <Developers />
 
       <ProtocolFooter />
 
       <section className="py-32 border-t border-white/10 text-center">
-        <div>
-          <h2 className="text-6xl font-semibold mb-8">Access should be earned.</h2>
-          <a href="/?view=docs#getting-started" className="inline-flex items-center justify-center px-12 py-6 bg-[#00f0ff] text-black font-semibold text-2xl rounded-2xl hover:scale-105 transition">
-            Start building on AOC →
-          </a>
+        <div className="max-w-3xl mx-auto px-6">
+          <h2 className="text-4xl md:text-6xl font-semibold mb-8">
+            Build digital assets that retain identity, integrity and capabilities beyond a single
+            application.
+          </h2>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <a href="#digital-asset" className="inline-flex items-center justify-center px-8 py-5 border border-white/15 hover:border-white/30 text-white font-semibold text-lg rounded-2xl transition-all active:scale-[0.98]">
+              Explore the Protocol
+            </a>
+            <a href="https://github.com/Architects-of-Change-Protocol/Architects_of_Change_Protocol" target="_blank" rel="noreferrer" className="inline-flex items-center justify-center px-8 py-5 border border-white/15 hover:border-white/30 text-white font-semibold text-lg rounded-2xl transition-all active:scale-[0.98]">
+              Build with AOC
+            </a>
+            <a href="/?view=enterprise" className="inline-flex items-center justify-center px-8 py-5 bg-[#00f0ff] text-black font-semibold text-lg rounded-2xl hover:scale-105 transition">
+              See AOC Enterprise →
+            </a>
+          </div>
         </div>
       </section>
     </main>

--- a/frontend/app/src/landing/components/ProtocolFooter.tsx
+++ b/frontend/app/src/landing/components/ProtocolFooter.tsx
@@ -8,9 +8,9 @@ type FooterItem = {
 
 const protocolLinks: FooterItem[] = [
   { label: 'Architecture' },
-  { label: 'Consent Engine' },
+  { label: 'Digital Assets' },
   { label: 'Capability Model' },
-  { label: 'Audit Layer' },
+  { label: 'Sovereignty' },
 ]
 
 const navigationLinks: FooterItem[] = [
@@ -28,7 +28,7 @@ export function ProtocolFooter() {
         <div className="footer-fade rounded-3xl border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] px-4 sm:px-6 py-8 text-center md:px-10 md:py-12">
           <p className="text-[11px] uppercase tracking-[0.24em] text-cyan-200/60">Protocol handoff</p>
           <h2 className="mx-auto mt-4 max-w-2xl text-3xl font-semibold tracking-tight text-white md:text-4xl">
-            Ship access systems with explicit control semantics.
+            Ship digital assets with identity, integrity and capabilities built in.
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-white/65 md:text-base">
             Explore the docs, review enterprise positioning, or contact the protocol directly.
@@ -53,7 +53,8 @@ export function ProtocolFooter() {
               <h3 className="text-base font-semibold tracking-tight text-white">AOC Protocol</h3>
               <div className="mt-4 h-px w-16 bg-cyan-200/20" />
               <p className="mt-4 text-sm leading-6 text-white/62">
-                Programmable control layer for consent-aware access, capability control, and auditable machine interaction.
+                An open, provider-neutral protocol for digital assets — identity, integrity,
+                provenance and capabilities that compatible systems can interpret.
               </p>
             </div>
 

--- a/frontend/app/src/landing/protocol/AssetCreationFlow.tsx
+++ b/frontend/app/src/landing/protocol/AssetCreationFlow.tsx
@@ -1,0 +1,21 @@
+import { CREATION_FLOW } from './content';
+import { SectionHeader, StepFlow } from './primitives';
+
+export function AssetCreationFlow() {
+  return (
+    <section id="creation" className="scroll-mt-24 max-w-5xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="How an AOC-Compatible Asset Is Created"
+        title="A conceptual model, not a claim about a shipped SDK."
+        description="This is the shape a compatible creation flow takes. Some steps already have canonical contracts in @aoc/protocol (identity, integrity, capability declaration); a complete, publicly available creation SDK does not exist yet — see the capability families above for what's defined today."
+      />
+
+      <div className="rounded-2xl border border-white/10 bg-white/[0.015] p-6 md:p-8">
+        <p className="mb-6 inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/[0.03] px-2.5 py-1 text-[11px] font-medium tracking-wide font-mono text-white/55">
+          Protocol Direction — Conceptual Model
+        </p>
+        <StepFlow steps={CREATION_FLOW} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
+++ b/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
@@ -1,0 +1,28 @@
+import { CAPABILITY_FAMILIES } from './content';
+import { SectionHeader, StatusPill } from './primitives';
+
+export function CapabilityFamilies() {
+  return (
+    <section id="capabilities" className="scroll-mt-24 max-w-7xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="What Can a Digital Asset Express?"
+        title="Capabilities are what a digital asset can declare about itself."
+        description="Each family below is a property an asset's manifest or canonical record can carry. Status labels show what's already defined as a canonical contract in @aoc/protocol versus what's still a protocol direction — not a claim that a full creation or runtime SDK ships today."
+      />
+
+      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
+        {CAPABILITY_FAMILIES.map((family) => (
+          <article key={family.id} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+            <div className="flex items-start justify-between gap-3">
+              <h3 className="text-base font-semibold text-white">{family.name}</h3>
+            </div>
+            <p className="mt-3 text-sm leading-relaxed text-white/55">{family.summary}</p>
+            <div className="mt-4">
+              <StatusPill status={family.status} />
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/Developers.tsx
+++ b/frontend/app/src/landing/protocol/Developers.tsx
@@ -1,0 +1,43 @@
+import { BUILDER_AUDIENCES } from './content';
+import { SectionHeader } from './primitives';
+
+const REPO_URL = 'https://github.com/Architects-of-Change-Protocol/Architects_of_Change_Protocol';
+const PROTOCOL_PACKAGE_URL = `${REPO_URL}/tree/main/packages/protocol`;
+
+export function Developers() {
+  return (
+    <section id="developers" className="scroll-mt-24 max-w-7xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="Developers and Builders"
+        title="Who builds with AOC Protocol."
+        description="@aoc/protocol publishes the versioned public contract layer — capability, proof, credential-manifest and claim shapes — as an open-source package under Apache-2.0. It's not yet published to a registry; build it from source in the repository."
+      />
+
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5 mb-10">
+        {BUILDER_AUDIENCES.map((audience) => (
+          <div key={audience.name} className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+            <p className="text-sm font-semibold text-white">{audience.name}</p>
+            <p className="mt-1.5 text-sm leading-relaxed text-white/55">{audience.summary}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+        <a
+          href={PROTOCOL_PACKAGE_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center justify-center rounded-xl border border-cyan-300/40 px-6 py-3 text-sm font-semibold text-cyan-200 transition hover:border-cyan-300/70 hover:bg-cyan-300/10"
+        >
+          View @aoc/protocol on GitHub
+        </a>
+        <a
+          href="/?view=docs"
+          className="inline-flex items-center justify-center rounded-xl border border-white/15 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-white/35 hover:text-white"
+        >
+          Read the docs
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/FileToAsset.tsx
+++ b/frontend/app/src/landing/protocol/FileToAsset.tsx
@@ -1,0 +1,60 @@
+import { SectionHeader } from './primitives';
+
+const FILE_TRAITS = ['Content', 'Format', 'Location'];
+const ASSET_TRAITS = ['Identity', 'Integrity', 'Provenance', 'Capabilities', 'References', 'Portability'];
+
+export function FileToAsset() {
+  return (
+    <section id="digital-asset" className="scroll-mt-24 max-w-7xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="From File to Digital Asset"
+        title="A file contains content. A digital asset carries more."
+        description="Any file — a photo, a document, a dataset — is just bytes with a format and a place it happens to sit. An AOC-compatible digital asset adds a layer that compatible systems can interpret: who it belongs to, whether it's intact, where it came from, and what it's allowed to do."
+      />
+
+      <div className="grid md:grid-cols-[1fr_auto_1fr] gap-6 items-center">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-6 md:p-7">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-white/40 font-mono">A File</p>
+          <p className="mt-2 font-mono text-white/70 text-sm">photo.jpg</p>
+          <ul className="mt-5 space-y-2.5">
+            {FILE_TRAITS.map((trait) => (
+              <li key={trait} className="flex items-center gap-2.5 text-sm text-white/55">
+                <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-white/25" />
+                {trait}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex items-center justify-center text-white/30" aria-hidden>
+          <span className="hidden md:inline text-2xl">&rarr;</span>
+          <span className="md:hidden text-2xl">&darr;</span>
+        </div>
+
+        <div className="rounded-2xl border border-cyan-300/25 bg-cyan-300/[0.04] p-6 md:p-7">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-cyan-300/70 font-mono">
+            AOC-Compatible Digital Asset
+          </p>
+          <p className="mt-2 font-mono text-white/70 text-sm">photo.jpg + protocol context</p>
+          <ul className="mt-5 space-y-2.5">
+            {ASSET_TRAITS.map((trait) => (
+              <li key={trait} className="flex items-center gap-2.5 text-sm text-white/80">
+                <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-cyan-300/70" />
+                {trait}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <p className="mt-8 max-w-3xl text-sm text-white/45 leading-relaxed">
+        Not every raw file is automatically an AOC-compatible asset. An application or tool that
+        speaks the protocol creates or registers that context — see{' '}
+        <a href="#creation" className="text-cyan-300/80 hover:text-cyan-200 underline underline-offset-2">
+          how an asset is created
+        </a>
+        .
+      </p>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/Hero.tsx
+++ b/frontend/app/src/landing/protocol/Hero.tsx
@@ -1,0 +1,37 @@
+export function Hero() {
+  return (
+    <section className="min-h-screen flex items-center pt-16">
+      <div className="max-w-4xl mx-auto px-6 text-center">
+        <p className="text-cyan-300/80 text-xs uppercase tracking-[0.22em] font-mono mb-6">
+          Open Protocol &middot; Digital Assets &amp; Sovereignty
+        </p>
+
+        <h1 className="text-[52px] md:text-[68px] leading-[1.05] font-semibold tracking-[-2.5px] mb-8">
+          Digital assets should be capable of more than being stored.
+        </h1>
+
+        <p className="max-w-[640px] mx-auto text-[19px] md:text-[21px] text-white/70 leading-relaxed mb-14">
+          AOC Protocol is an open, provider-neutral language for digital assets — a way to give any
+          file or resource identity, integrity, provenance and declared capabilities that
+          compatible systems can interpret.
+        </p>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href="#digital-asset"
+            className="px-10 py-5 bg-[#00f0ff] hover:bg-[#00d4e0] text-black font-semibold text-lg rounded-2xl transition-all active:scale-[0.98] inline-block"
+          >
+            Explore the capabilities &darr;
+          </a>
+
+          <a
+            href="/?view=enterprise"
+            className="px-10 py-5 border border-white/15 hover:border-white/30 text-white font-semibold text-lg rounded-2xl transition-all active:scale-[0.98] inline-block"
+          >
+            See AOC Enterprise
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/PhotographExample.tsx
+++ b/frontend/app/src/landing/protocol/PhotographExample.tsx
@@ -1,0 +1,42 @@
+import { OTHER_ASSET_EXAMPLES, PHOTO_PROGRESSION } from './content';
+import { SectionHeader, StepFlow } from './primitives';
+
+export function PhotographExample() {
+  return (
+    <section id="example" className="scroll-mt-24 max-w-5xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="A Simple Example"
+        title="A photograph, walked through the model."
+        description="A normal photograph is only photo.jpg — content, format, wherever it's stored. Walking it through the protocol model makes the difference concrete."
+      />
+
+      <div className="rounded-2xl border border-white/10 bg-white/[0.015] p-6 md:p-8">
+        <StepFlow steps={PHOTO_PROGRESSION} />
+      </div>
+
+      <div className="mt-8 rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+        <p className="text-sm leading-relaxed text-white/60">
+          Honesty matters here: compatible systems interpret and enforce these declarations. The
+          JPEG bytes themselves don't enforce a license or a permission once copied outside a
+          controlled system — enforcement depends on compatible applications and, for organizations
+          that need it, on{' '}
+          <a href="/?view=enterprise" className="text-cyan-300/80 hover:text-cyan-200 underline underline-offset-2">
+            AOC Enterprise
+          </a>{' '}
+          operationalizing governed delivery on top of the asset's declarations.
+        </p>
+      </div>
+
+      <p className="mt-6 text-sm text-white/45">
+        The same model applies to{' '}
+        {OTHER_ASSET_EXAMPLES.map((asset, idx) => (
+          <span key={asset.name}>
+            {asset.name}
+            {idx < OTHER_ASSET_EXAMPLES.length - 1 ? ', ' : ''}
+          </span>
+        ))}
+        {' '}— any digitally represented resource with value, identity, operational meaning or governance relevance.
+      </p>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/ProtocolToEnterprise.tsx
+++ b/frontend/app/src/landing/protocol/ProtocolToEnterprise.tsx
@@ -1,0 +1,57 @@
+import { SectionHeader } from './primitives';
+
+const PROTOCOL_OWNS = ['Identity', 'Integrity', 'Capabilities', 'Sovereignty', 'Interoperability'];
+const ENTERPRISE_OWNS = ['Governance', 'Access', 'Decisions', 'Obligations', 'Grants', 'Revocation', 'Evidence', 'Assurance'];
+
+export function ProtocolToEnterprise() {
+  return (
+    <section id="protocol-to-enterprise" className="scroll-mt-24 max-w-7xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="Protocol to Enterprise"
+        title="Protocol defines what an asset can be. Enterprise decides how it's used."
+        description="Protocol describes. AOC Enterprise decides, executes, observes and audits — operationalizing governance for organizations that need to control how assets built on the protocol are actually used."
+      />
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="rounded-2xl border border-cyan-300/25 bg-cyan-300/[0.04] p-6 md:p-7">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-cyan-300/70 font-mono">AOC Protocol defines</p>
+          <ul className="mt-5 space-y-2.5">
+            {PROTOCOL_OWNS.map((item) => (
+              <li key={item} className="flex items-center gap-2.5 text-sm text-white/80">
+                <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-cyan-300/70" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-6 md:p-7">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-white/40 font-mono">AOC Enterprise operationalizes</p>
+          <ul className="mt-5 space-y-2.5">
+            {ENTERPRISE_OWNS.map((item) => (
+              <li key={item} className="flex items-center gap-2.5 text-sm text-white/70">
+                <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-white/30" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a
+          href="/?view=enterprise"
+          className="px-8 py-4 bg-[#00f0ff] hover:bg-[#00d4e0] text-black font-semibold rounded-2xl transition-all active:scale-[0.98] inline-block"
+        >
+          Explore AOC Enterprise &rarr;
+        </a>
+        <a
+          href="/?view=docs#getting-started"
+          className="px-8 py-4 border border-white/15 hover:border-white/30 text-white font-semibold rounded-2xl transition-all active:scale-[0.98] inline-block"
+        >
+          Review Protocol Documentation
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/ProviderNeutral.tsx
+++ b/frontend/app/src/landing/protocol/ProviderNeutral.tsx
@@ -1,0 +1,45 @@
+import { ILLUSTRATIVE_PROVIDERS } from './content';
+import { SectionHeader, StatusPill } from './primitives';
+
+export function ProviderNeutral() {
+  return (
+    <section id="provider-neutral" className="scroll-mt-24 max-w-7xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="Open and Provider-Neutral"
+        title="A digital asset shouldn't be owned by the place it's stored."
+        description="A digital asset isn't conceptually owned by one storage provider, application, database or cloud. AOC Protocol separates an asset's identity from its location: canonical references, adapter interfaces and open contracts are the architectural objective, not a promise of automatic migration or universal compatibility across every provider today."
+      />
+
+      <div className="grid md:grid-cols-[1fr_1.2fr] gap-8 items-start">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-6 md:p-7">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-white/40 font-mono mb-4">
+            Digital Asset Identity
+          </p>
+          <div className="space-y-2.5">
+            {ILLUSTRATIVE_PROVIDERS.map((provider) => (
+              <div
+                key={provider.name}
+                className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.015] px-3.5 py-2.5"
+              >
+                <span className="text-sm text-white/70 font-mono">{provider.name}</span>
+                <StatusPill status={provider.status} />
+              </div>
+            ))}
+          </div>
+          <p className="mt-4 text-xs text-white/40 leading-relaxed">
+            Illustrative — no provider adapter ships as part of AOC Protocol today. Provider
+            adapters are an implementation concern, not a Protocol claim.
+          </p>
+        </div>
+
+        <p className="text-sm md:text-base leading-relaxed text-white/60">
+          An AOC-compatible digital asset may be stored in Pinata, S3, Azure or another provider
+          without making that provider the asset's canonical identity. Storage is where the bytes
+          live; identity is what the asset is. Moving an asset between providers, applications or
+          organizational boundaries shouldn't require re-establishing what it is from scratch —
+          that's what provider neutrality is for.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/Sovereignty.tsx
+++ b/frontend/app/src/landing/protocol/Sovereignty.tsx
@@ -1,0 +1,30 @@
+import { SectionHeader } from './primitives';
+
+const SOVEREIGNTY_QUESTIONS = [
+  { q: 'Who identifies the asset?', a: 'A canonical identity, not an account number or a storage path owned by one vendor.' },
+  { q: 'Can its integrity be verified?', a: 'Independently — against a declared digest, not by trusting whoever hands you the file.' },
+  { q: 'Can it move?', a: "Between storage providers or applications without losing its identity or its recorded provenance." },
+  { q: 'Can another compatible system understand it?', a: 'Yes, if that system speaks the same open contracts — no vendor-specific integration required.' },
+  { q: "Does its meaning survive outside the originating platform?", a: "That's the test. If it doesn't, the asset was only ever a file with a platform attached." },
+];
+
+export function Sovereignty() {
+  return (
+    <section id="sovereignty" className="scroll-mt-24 max-w-7xl mx-auto px-6 py-20 border-t border-white/10">
+      <SectionHeader
+        eyebrow="Digital Sovereignty"
+        title="Sovereignty means an asset's meaning doesn't depend on one platform."
+        description="Sovereignty here is practical, not absolute. It's the degree to which an asset — and whoever legitimately participates in it — retains control over identity, integrity, provenance and where it can be resolved, rather than that meaning being defined solely by whichever application currently holds the file. Protocol does not claim to guarantee legal ownership, custody or universal enforcement; it defines properties that make an asset sovereignty-aware and independently verifiable."
+      />
+
+      <dl className="grid md:grid-cols-2 gap-5">
+        {SOVEREIGNTY_QUESTIONS.map(({ q, a }) => (
+          <div key={q} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+            <dt className="text-sm font-semibold text-white">{q}</dt>
+            <dd className="mt-2 text-sm leading-relaxed text-white/55">{a}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/protocol/content.ts
+++ b/frontend/app/src/landing/protocol/content.ts
@@ -1,0 +1,149 @@
+// Content model for the AOC Protocol landing page (W004).
+//
+// Thesis: AOC Protocol defines what a digital asset can be — identity,
+// integrity, provenance, capabilities and sovereignty-related properties
+// that compatible systems can interpret. AOC Enterprise operationalizes
+// governance on top of it. This file holds the narrative data so the
+// section components stay focused on layout.
+
+export type ClaimStatus = 'Reference Model' | 'Future Direction';
+
+export const STATUS_COPY: Record<ClaimStatus, string> = {
+  'Reference Model': 'Defined as a canonical contract in @aoc/protocol today.',
+  'Future Direction': 'Not yet defined as a canonical contract — a protocol direction.',
+};
+
+export type CapabilityFamily = {
+  id: string;
+  name: string;
+  status: ClaimStatus;
+  summary: string;
+};
+
+// The eight capability families a digital asset can express. Grounded in the
+// canonical contract shapes already published in packages/protocol/src —
+// not a claim that a runtime or creation SDK implements them end to end.
+export const CAPABILITY_FAMILIES: CapabilityFamily[] = [
+  {
+    id: 'identity',
+    name: 'Identity',
+    status: 'Reference Model',
+    summary:
+      "A canonical identity and credential reference that name an asset independent of any single database, application or account.",
+  },
+  {
+    id: 'integrity',
+    name: 'Integrity',
+    status: 'Reference Model',
+    summary:
+      'A declared digest — algorithm plus hash — that lets a compatible system check whether the underlying resource has changed.',
+  },
+  {
+    id: 'provenance',
+    name: 'Provenance',
+    status: 'Reference Model',
+    summary:
+      "Issuer and issuance-time fields that record where an asset's context came from and when it was established.",
+  },
+  {
+    id: 'portability',
+    name: 'Portability',
+    status: 'Reference Model',
+    summary:
+      'A registry reference that lets an asset be looked up and resolved independent of which provider currently stores it.',
+  },
+  {
+    id: 'interoperability',
+    name: 'Interoperability',
+    status: 'Reference Model',
+    summary:
+      'Adapter interfaces for verification, revocation and registry lookup that any compatible runtime can implement.',
+  },
+  {
+    id: 'verifiability',
+    name: 'Verifiability',
+    status: 'Reference Model',
+    summary:
+      'Proof references and verification-key resolution that let a claim about an asset be checked without trusting whoever presents it.',
+  },
+  {
+    id: 'licensing',
+    name: 'Licensing & Terms',
+    status: 'Future Direction',
+    summary:
+      "References an asset's manifest could carry to policies, licenses or economic arrangements. Not yet defined as a canonical contract.",
+  },
+  {
+    id: 'governance-compatibility',
+    name: 'Governance Compatibility',
+    status: 'Reference Model',
+    summary:
+      'Capability and consent shapes that Protocol defines and that AOC Enterprise operationalizes into access decisions, grants and revocation.',
+  },
+];
+
+export type CreationStep = {
+  label: string;
+  detail: string;
+};
+
+export const CREATION_FLOW: CreationStep[] = [
+  { label: 'Application or Tool', detail: 'A compatible application originates or ingests a digital resource.' },
+  { label: 'Digital Resource Created or Registered', detail: 'A file, dataset or record is produced or brought under protocol reference.' },
+  { label: 'Canonical Identity Assigned', detail: "An identity that doesn't depend on the storage location is attached to the resource." },
+  { label: 'Integrity and Provenance Recorded', detail: 'A digest and issuer/time context are declared for the resource.' },
+  { label: 'Capabilities Declared', detail: 'The asset states what it can express — licensing references, governance compatibility, and more.' },
+  { label: 'Asset Available to Compatible Systems', detail: 'Compatible applications and, where deployed, AOC Enterprise can now interpret the asset.' },
+];
+
+export type PhotoStage = {
+  label: string;
+  detail: string;
+};
+
+export const PHOTO_PROGRESSION: PhotoStage[] = [
+  { label: 'Photo File', detail: 'photo.jpg — content, format, a place it happens to be stored.' },
+  { label: 'Identified Digital Asset', detail: 'A canonical asset identity and a creator or registrant reference are attached.' },
+  { label: 'Integrity and Provenance', detail: 'A digest fixes the file at a point in time; provenance records who registered it and when.' },
+  { label: 'Capabilities', detail: 'Preview vs. full-resolution, licensing references and governed-access compatibility are declared.' },
+  { label: 'Compatible Governance through Enterprise', detail: 'Organizations running AOC Enterprise can turn those declarations into access decisions.' },
+];
+
+export type ProviderEntry = {
+  name: string;
+  status: ClaimStatus;
+};
+
+export const ILLUSTRATIVE_PROVIDERS: ProviderEntry[] = [
+  { name: 'Pinata', status: 'Future Direction' },
+  { name: 'Amazon S3', status: 'Future Direction' },
+  { name: 'Azure Blob Storage', status: 'Future Direction' },
+  { name: 'Other providers', status: 'Future Direction' },
+];
+
+export type AssetExample = {
+  name: string;
+};
+
+export const OTHER_ASSET_EXAMPLES: AssetExample[] = [
+  { name: 'documents' },
+  { name: 'datasets' },
+  { name: 'videos' },
+  { name: 'models' },
+  { name: 'credentials' },
+];
+
+export type BuilderAudience = {
+  name: string;
+  summary: string;
+};
+
+export const BUILDER_AUDIENCES: BuilderAudience[] = [
+  { name: 'Application developers', summary: 'building tools that create, read or move digital assets.' },
+  { name: 'Storage platforms', summary: 'that want asset identity to survive a migration off their platform.' },
+  { name: 'Digital-asset tooling', summary: 'for creation, verification or cataloging workflows.' },
+  { name: 'Creator platforms', summary: 'issuing photos, media or other work with provenance attached.' },
+  { name: 'Document systems', summary: 'that need portable identity and integrity across organizational boundaries.' },
+  { name: 'AI and data platforms', summary: 'that need datasets and model files to carry verifiable origin.' },
+  { name: 'Infrastructure providers', summary: 'implementing adapters so their systems interoperate with compatible assets.' },
+];

--- a/frontend/app/src/landing/protocol/primitives.tsx
+++ b/frontend/app/src/landing/protocol/primitives.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from 'react';
+import type { ClaimStatus } from './content';
+import { STATUS_COPY } from './content';
+
+export function Eyebrow({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-cyan-300/80 text-xs uppercase tracking-[0.22em] font-mono">{children}</p>
+  );
+}
+
+export function SectionHeader({
+  eyebrow,
+  title,
+  description,
+  align = 'left',
+}: {
+  eyebrow: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  align?: 'left' | 'center';
+}) {
+  return (
+    <div className={`max-w-3xl mb-10 md:mb-12 ${align === 'center' ? 'mx-auto text-center' : ''}`}>
+      <Eyebrow>{eyebrow}</Eyebrow>
+      <h2 className="mt-4 text-3xl md:text-4xl font-semibold tracking-tight text-white">{title}</h2>
+      {description ? <p className="mt-4 text-white/60 text-base leading-relaxed">{description}</p> : null}
+    </div>
+  );
+}
+
+const statusToneMap: Record<ClaimStatus, string> = {
+  'Reference Model': 'text-cyan-300 border-cyan-400/30 bg-cyan-400/10',
+  'Future Direction': 'text-white/55 border-white/15 bg-white/[0.03]',
+};
+
+/** Maturity label for a claim on the page — see content.ts STATUS_COPY for what each tier means. */
+export function StatusPill({ status }: { status: ClaimStatus }) {
+  return (
+    <span
+      title={STATUS_COPY[status]}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium tracking-wide font-mono ${statusToneMap[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+/** A vertical, numbered step flow used for the creation and photo-example diagrams.
+ * Textual by construction so it stays meaningful without relying on an image. */
+export function StepFlow({ steps }: { steps: { label: string; detail: string }[] }) {
+  return (
+    <ol className="space-y-0">
+      {steps.map((step, idx) => (
+        <li key={step.label} className="relative pl-9">
+          {idx < steps.length - 1 ? (
+            <span aria-hidden className="absolute left-[11px] top-7 bottom-[-4px] w-px bg-white/15" />
+          ) : null}
+          <span
+            aria-hidden
+            className="absolute left-0 top-0.5 flex h-[22px] w-[22px] items-center justify-center rounded-full border border-cyan-300/40 bg-cyan-300/10 text-[11px] font-mono text-cyan-200"
+          >
+            {idx + 1}
+          </span>
+          <p className="text-sm font-semibold text-white">{step.label}</p>
+          <p className="mt-1 mb-6 text-sm leading-relaxed text-white/55">{step.detail}</p>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/app/src/landing/protocol/usePageMeta.ts
+++ b/frontend/app/src/landing/protocol/usePageMeta.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+
+const PAGE_URL = 'https://www.aocprotocol.org/';
+const TITLE = 'AOC Protocol — An Open Protocol for Digital Assets, Capabilities & Sovereignty';
+const DESCRIPTION =
+  "AOC Protocol is an open, provider-neutral protocol for digital assets — identity, integrity, provenance, capabilities and sovereignty that compatible systems can interpret. AOC Enterprise operationalizes governance on top of it.";
+
+// Per-page metadata injection so the root URL's live document head matches
+// the Protocol thesis instead of the static index.html defaults (which are
+// scoped to AOC Assurance for social scrapers that don't execute JS — see
+// the index.html edits in the same change for that fallback). Mirrors the
+// pattern already used by GovVsSovPage / WhatIsAiSovereigntyPage.
+export function usePageMeta() {
+  useEffect(() => {
+    const prevTitle = document.title;
+
+    const setMeta = (name: string, content: string, prop = false) => {
+      const attr = prop ? 'property' : 'name';
+      let el = document.querySelector(`meta[${attr}="${name}"]`) as HTMLMetaElement | null;
+      const created = !el;
+      if (!el) {
+        el = document.createElement('meta');
+        el.setAttribute(attr, name);
+        document.head.appendChild(el);
+      }
+      const prevContent = el.getAttribute('content');
+      el.setAttribute('content', content);
+      return { el, prevContent, created };
+    };
+
+    document.title = TITLE;
+
+    const restorers: Array<() => void> = [];
+    const track = (name: string, content: string, prop = false) => {
+      const { el, prevContent, created } = setMeta(name, content, prop);
+      restorers.push(() => {
+        if (created) el.remove();
+        else if (prevContent !== null) el.setAttribute('content', prevContent);
+      });
+    };
+
+    track('description', DESCRIPTION);
+    track('og:title', TITLE, true);
+    track('og:description', DESCRIPTION, true);
+    track('og:url', PAGE_URL, true);
+    track('og:site_name', 'AOC Protocol', true);
+    track('twitter:title', TITLE);
+    track('twitter:description', DESCRIPTION);
+
+    return () => {
+      document.title = prevTitle;
+      restorers.forEach((restore) => restore());
+    };
+  }, []);
+}


### PR DESCRIPTION
## Executive Summary

W003 moved governance-heavy commercial content off the Protocol landing page and onto AOC Enterprise, leaving Protocol with only a short, intentionally temporary "Foundation" bridge section. This PR is that follow-up ("Protocol Step 2"): the Protocol landing page is rebuilt around its actual thesis — digital assets, the capabilities they can express, and digital sovereignty — instead of governance, access control, or a blockchain/token narrative.

## Previous Problem

Before W003, Protocol's landing page sold operational governance (consent, permission evaluation, audit) that conceptually belongs to Enterprise. After W003, Protocol had a correct but minimal placeholder — a single bridge section with no real digital-asset narrative, capability model, or sovereignty explanation of its own.

## New Protocol Thesis

> Protocol defines what a digital asset can be. Enterprise operationalizes how it is governed.

A digital asset should be able to retain identity, integrity, provenance, capabilities and meaning beyond a single application or provider. AOC Protocol defines the open language for that possibility; AOC Enterprise turns those capabilities into operational governance.

## Page Structure

1. Hero — redefines the visitor's mental model of a digital asset (no governance language, no Enterprise pitch)
2. From File to Digital Asset — file vs. AOC-compatible asset comparison
3. What Can a Digital Asset Express? — 8 capability families, each status-labeled
4. Digital Sovereignty — practical, non-absolute definition via 5 Q&A cards
5. How an AOC-Compatible Asset Is Created — conceptual creation flow, explicitly labeled "Protocol Direction"
6. A Photograph, Walked Through the Model — the required simple example, with an honest note that compatible systems enforce declarations, not the file itself
7. Open and Provider-Neutral — asset identity vs. storage location, illustrative-only provider list
8. Protocol to Enterprise — the commercial bridge, two-column ownership split + CTAs
9. Developers and Builders — who builds with `@aoc/protocol`, links to the real GitHub package and docs
10. Closing CTA — "Build digital assets that retain identity, integrity and capabilities beyond a single application."

New components live under `frontend/app/src/landing/protocol/` (content.ts + primitives.tsx + one file per section), composed by `AocLandingPage.tsx`. No Enterprise-owned component was duplicated or modified except `ProtocolFooter.tsx` (shared), where only the "AOC Protocol" tagline and inert link-column labels were updated to drop leftover governance framing.

## Digital Asset Definition

Defined broadly and explicitly not reduced to crypto/NFTs/tokens: a photograph, document, dataset, video, audio file, model file, credential, contract, prompt, workflow, configuration, software package, or design all qualify. Framing used throughout: *a file contains content; a digital asset also carries identity, integrity, provenance, capabilities, and references that systems can interpret.* The page is explicit that not every raw file is automatically an AOC-compatible asset.

## Capability Model

Eight families (Identity, Integrity, Provenance, Portability, Interoperability, Verifiability, Licensing & Terms, Governance Compatibility), each labeled `Reference Model` or `Future Direction` — no capability is claimed `Available`/`Implemented`, since `@aoc/protocol` isn't published to a registry yet. Seven families are grounded in real, repository-verified contract shapes (`CanonicalHashProof`, `CanonicalCredentialManifest`, `CanonicalCapability`, `CanonicalRegistryRef`, adapter interfaces in `packages/protocol/src/`); only Licensing & Terms and the illustrative provider list (Pinata/S3/Azure) are labeled `Future Direction` since no such contract or adapter exists in the repo today.

## Sovereignty Positioning

Practical and non-absolute: the degree to which an asset (and its legitimate participants) retains control over identity, integrity, provenance, and resolution — not a claim of legal ownership, custody, or universal enforcement. Only approved vocabulary is used (sovereignty-aware, sovereignty-enabling, portable, provider-neutral, independently verifiable).

## Manifest Concept

Presented as a conceptual model — the "How an AOC-Compatible Asset Is Created" diagram is explicitly labeled "Protocol Direction — Conceptual Model," not a claim that a unified manifest schema or creation SDK ships today. No production schema was invented.

## Enterprise Boundary

Confirmed: no governance-heavy commercial content was moved back into Protocol. Access enforcement, consent workflows, audit operations, Governed Access, and Assurance remain exclusively on Enterprise — none of those files were touched.

## SEO Changes

`index.html`'s title/description/keywords/`og:*`/`twitter:*` tags and the root JSON-LD `WebPage` node were rewritten — they previously described "AI Governance and Sovereignty Assessment | AOC Assurance" for the Protocol root URL. Added `protocol/usePageMeta.ts`, a live document-head updater matching the existing `GovVsSovPage`/`WhatIsAiSovereigntyPage` pattern.

## Validation

- `npm run typecheck` / `npx tsc -p tsconfig.app.json --noEmit`: only the pre-existing, unrelated `enterprise/src/assurance/audit/*` module-resolution errors remain (verified identical on `main` before this change — see `docs/w003-...md`'s "Pre-existing" note).
- `npx eslint` on all touched/added files: clean.
- `npx vite build`: succeeds.
- Playwright: desktop (1440px), mobile (390px), and narrow mobile (320px) full-page screenshots — no console errors, no `pageerror`s, no horizontal overflow on any viewport.
- Verified real anchor-link navigation (`#digital-asset`, `#capabilities`) clears the fixed nav correctly via `scroll-mt-24`.
- Verified heading order: exactly one `<h1>`, logical `<h2>`/`<h3>` nesting, no skipped levels.
- Verified no duplicate DOM ids.
- Verified internal routes still resolve with no console errors: `/`, `/?view=enterprise`, `/?view=docs`, `/?view=about`, `/?view=governed-access`.
- Mobile menu open/close verified.

## Follow-Ups

- Final Enterprise commercial refactor (tracked separately, referenced in W003).
- Dedicated Governed Access and Assurance landing-page refactors (both still navigation-skeleton/unchanged).
- A formal Digital Asset Manifest specification, if the canonical contracts this page references are consolidated into one schema.
- A creation/verification SDK for compatible applications.
- Real storage-provider adapters (Pinata/S3/Azure are illustrative only today).

---

W004 COMPLETE — AOC PROTOCOL REPOSITIONED AROUND DIGITAL ASSETS AND SOVEREIGNTY

_Generated by [Claude Code](https://claude.ai/code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_016mpssGRMTXKJdxd2reuxmb)_