### PR TITLE
Build Governed Access product landing page (W006)

### DIFF
--- a/frontend/app/docs/w006-governed-access-product-landing.md
+++ b/frontend/app/docs/w006-governed-access-product-landing.md
@@ -1,0 +1,108 @@
+# W006 — Governed Access product landing
+
+Status: complete. Governed Access now has a dedicated product page instead
+of the navigation-skeleton stub W005 left in place (see "What W005
+intentionally did not touch" in `w005-enterprise-pitch-deck-design-system.md`).
+
+## Why
+
+AOC Enterprise's homepage (W005) introduces Governed Access as a concept
+across three of its own sections (`Problem`, `MissingLayer`,
+`ArchitectureStack`) on the way to explaining AOC Enterprise as a whole.
+Governed Access is also AOC Enterprise's first commercial Solution — it
+needs a page that sells the capability on its own terms, in under two
+minutes, without re-explaining the platform around it. That page did not
+exist; `GovernedAccessPage.tsx` was a placeholder noting the real page was
+"in preparation." This PR builds it.
+
+Positioning guardrail carried through every section: Governed Access is
+**operational governance for access to digital assets** — not identity,
+authentication, authorization, storage, IAM, OAuth, or Zero Trust. Sections
+are written to explain what the product *does*, not to re-litigate what
+AOC Enterprise *is*.
+
+## Design system — reused, not reinvented
+
+This page is built entirely on the W005 commercial design system —
+`frontend/app/src/landing/enterprise/primitives.tsx` (`Card`, `IconCircle`,
+`Chip`, `PipelineRail`, `SectionHeader`, `Eyebrow`) and the same tokens
+documented in `w005-enterprise-pitch-deck-design-system.md` (light-primary
+body, `#0B1220` dark bookends for Hero and the closing CTA, `indigo-600`
+accent). No new visual language, no new primitive components were
+introduced — every section composes the existing library.
+
+New, page-scoped components live under
+`frontend/app/src/landing/enterprise/governed-access/`, mirroring how
+`landing/protocol/` and `landing/enterprise/` already separate content
+families:
+
+| File | Role |
+|---|---|
+| `content.ts` | All copy/data for the page — mechanisms, gaps, the 8-stage lifecycle, providers, capabilities, audiences, example scenarios, assessment steps. |
+| `Hero.tsx` | Section 1 — dark bookend. Single CTA: Request Technical Assessment. |
+| `Problem.tsx` | Section 2 — the access mechanisms teams already use, and what they can't answer. |
+| `Lifecycle.tsx` | Section 3 — the 8-stage chain stated as a single declaration (`Chip` row). |
+| `ProviderNeutral.tsx` | Section 4 — provider grid (Pinata live, others roadmap) + "Future Providers" tile. |
+| `Architecture.tsx` | Section 5 — the same 3-band Protocol/Enterprise/Provider diagram as `../ArchitectureStack.tsx`, reused verbatim as a visual pattern. |
+| `OperationalLifecycle.tsx` | Section 6 — the same chain as `Lifecycle.tsx`, now interactive (hover-to-reveal), reusing `../Pipeline.tsx`'s exact interaction. |
+| `Capabilities.tsx` | Section 7 — 8 capability cards, same grid as `../Benefits.tsx`. |
+| `WhoBenefits.tsx` | Section 8 — 8 audiences, same layout as `../CustomerSegments.tsx`. |
+| `Examples.tsx` | Section 9 — 7 illustrative scenarios, explicitly labeled "Example Scenario," no customer claims. |
+| `Assessment.tsx` | Section 10 — Assessment → Architecture Review → Pilot → Implementation (`PipelineRail`), then the closing CTA (dark bookend). |
+
+`GovernedAccessPage.tsx` assembles these in brief order, with `EnterpriseNav`,
+`Breadcrumbs` (Protocol → Enterprise → Solutions → Governed Access), and
+`ProtocolFooter accent="indigo"` — the same shell `EnterprisePage.tsx` uses.
+
+## Why the lifecycle has 8 stages, not the homepage's 8
+
+The Enterprise homepage's `Pipeline.tsx` also has 8 stages, but names them
+Request, Decision, Obligations, Grant, Translation, Execution, Usage,
+Evidence — Policy and Revocation aren't named stages there. This page names
+both explicitly (`Request → Decision → Policy → Grant → Provider
+Translation → Usage → Evidence → Revocation`), matching the fuller list
+`ArchitectureStack.tsx` already summarizes in its Enterprise band
+("Decision · Obligation · Grant · Revocation · Usage · Evidence") and the
+brief's required flow. This page is the canonical, spelled-out version;
+the homepage's shorter pipeline is intentionally left as its own summary
+and untouched by this change.
+
+## Honesty bar — claims match `PlatformStatus.tsx`
+
+Every maturity claim on this page is consistent with what
+`../PlatformStatus.tsx` already states about the platform: Pinata is the
+only conformance-tested provider adapter; S3, Azure Blob, Cloudflare R2,
+Google Drive, and SharePoint are roadmap, not shipped. The provider grid
+and "Future Providers" tile make that distinction visible rather than
+implying broader coverage than exists today. Section 9's examples are
+explicitly labeled "Example Scenario" — illustrative only, never framed as
+deployments or customer claims, matching the brief's "no customer claims"
+requirement.
+
+## CTA
+
+Exactly one commercial call to action appears anywhere on this page:
+**Request Technical Assessment** — in the nav (inherited from
+`EnterpriseNav`), the Hero, and the closing CTA. Unlike
+`../CtaSection.tsx` (the Enterprise homepage's closing CTA, which also
+carries secondary "Request a Live Demo" / "Request an Architecture Review"
+links), `Assessment.tsx`'s closing CTA deliberately omits secondary links —
+this page holds to a single CTA throughout, per brief.
+
+## Routing
+
+No routing changes were required. `App.tsx` already dispatches
+`?view=governed-access` to `GovernedAccessPage`, and
+`SolutionsAndServices.tsx` / `enterprise/content.ts`'s nav already link to
+it — both were wired ahead of this page's existence, in W005.
+
+## Verification performed
+
+- `npx tsc -b --pretty false` — no new errors; the only errors present are
+  the pre-existing, unrelated monorepo workspace-resolution failure in
+  `enterprise/src/assurance/*` documented in the W005 doc.
+- `npx eslint src/landing/enterprise/governed-access src/landing/enterprise/GovernedAccessPage.tsx` — zero errors.
+- `npx vite build` — succeeds.
+- Manual visual QA via a local dev server + Chromium screenshots at 1440px
+  and 390px (mobile) viewports, full page top to bottom, plus a targeted
+  screenshot of the interactive Operational Lifecycle hover state.

--- a/frontend/app/src/landing/enterprise/GovernedAccessPage.tsx
+++ b/frontend/app/src/landing/enterprise/GovernedAccessPage.tsx
@@ -1,58 +1,54 @@
 import { ProtocolFooter } from '../components/ProtocolFooter';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { EnterpriseNav } from './Nav';
+import { Hero } from './governed-access/Hero';
+import { Problem } from './governed-access/Problem';
+import { Lifecycle } from './governed-access/Lifecycle';
+import { ProviderNeutral } from './governed-access/ProviderNeutral';
+import { Architecture } from './governed-access/Architecture';
+import { OperationalLifecycle } from './governed-access/OperationalLifecycle';
+import { Capabilities } from './governed-access/Capabilities';
+import { WhoBenefits } from './governed-access/WhoBenefits';
+import { Examples } from './governed-access/Examples';
+import { Assessment } from './governed-access/Assessment';
 
-// Governed Access is the first commercial Solution under AOC Enterprise —
-// it implements governed access over externally stored digital assets.
-// This is a navigation-skeleton page: it exists so "Solutions > Governed
-// Access" resolves to a real destination with the correct place in the
-// hierarchy, not a full product page.
+// Governed Access is AOC Enterprise's first commercial Solution (see
+// ./SolutionsAndServices.tsx / ../routes.ts). This is its dedicated product
+// landing — W006 — built on the same W005 commercial design system as
+// ../EnterprisePage.tsx (light-primary, dark hero/CTA bookends, indigo
+// accent) so it reads as the same product family, but tells the narrower,
+// sharper story of this one capability rather than AOC Enterprise as a
+// whole. See docs/w006-governed-access-product-landing.md for the section
+// map and design rationale.
 export function GovernedAccessPage() {
   return (
-    <main className="min-h-screen bg-[#090b11] text-white font-sans">
+    <main className="min-h-screen bg-white text-slate-900 font-sans">
       <EnterpriseNav />
-
-      <Breadcrumbs
-        items={[
-          { label: 'Protocol', href: '/' },
-          { label: 'Enterprise', href: '/?view=enterprise' },
-          { label: 'Solutions' },
-          { label: 'Governed Access' },
-        ]}
-      />
-
-      <div className="max-w-3xl mx-auto px-6 py-16">
-        <a href="/?view=enterprise" className="text-sm text-white/40 hover:text-white/70 transition-colors">
-          &larr; Back to Enterprise
-        </a>
-
-        <p className="mt-8 text-[11px] uppercase tracking-[0.22em] text-cyan-300/80 font-mono">
-          Enterprise Solution
-        </p>
-        <h1 className="mt-3 text-4xl font-semibold tracking-tight text-white">
-          Governed Access
-        </h1>
-        <p className="mt-4 max-w-xl text-lg text-white/60 leading-relaxed">
-          Implement governed access over externally stored digital assets — built on the identity,
-          consent, and capability primitives defined by AOC Protocol.
-        </p>
-
-        <div className="mt-10 rounded-2xl border border-white/10 bg-white/[0.02] px-6 py-8">
-          <p className="text-sm text-white/50 leading-relaxed">
-            Governed Access is AOC Enterprise&apos;s first Solution. The dedicated Governed Access
-            product page is in preparation.
-          </p>
-        </div>
-
-        <a
-          href="mailto:hello@aocprotocol.xyz?subject=AOC%20Enterprise%20Governed%20Access"
-          className="mt-8 inline-flex items-center justify-center rounded-xl bg-cyan-300 px-5 py-3 text-sm font-semibold text-black hover:bg-cyan-200 transition-colors"
-        >
-          Talk to architecture
-        </a>
+      {/* Breadcrumbs uses light-on-dark text — wrapped here so it stays
+          legible against the dark hero directly beneath it. */}
+      <div className="bg-[#0B1220]">
+        <Breadcrumbs
+          items={[
+            { label: 'Protocol', href: '/' },
+            { label: 'Enterprise', href: '/?view=enterprise' },
+            { label: 'Solutions' },
+            { label: 'Governed Access' },
+          ]}
+        />
       </div>
 
-      <ProtocolFooter />
+      <Hero />
+      <Problem />
+      <Lifecycle />
+      <ProviderNeutral />
+      <Architecture />
+      <OperationalLifecycle />
+      <Capabilities />
+      <WhoBenefits />
+      <Examples />
+      <Assessment />
+
+      <ProtocolFooter accent="indigo" />
     </main>
   );
 }

--- a/frontend/app/src/landing/enterprise/governed-access/Architecture.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/Architecture.tsx
@@ -1,0 +1,50 @@
+import { SectionHeader } from '../primitives';
+
+function ArrowDown() {
+  return (
+    <div className="flex justify-center py-2 text-slate-400">
+      <svg viewBox="0 0 256 256" className="h-[18px] w-[18px]" fill="currentColor" aria-hidden="true">
+        <path d="M205.66,149.66l-72,72a8,8,0,0,1-11.32,0l-72-72a8,8,0,0,1,11.32-11.32L120,196.69V40a8,8,0,0,1,16,0V196.69l58.34-58.35a8,8,0,0,1,11.32,11.32Z" />
+      </svg>
+    </div>
+  );
+}
+
+// The same three-band composition diagram as ../ArchitectureStack.tsx —
+// reused verbatim as the visual pattern rather than reinvented, per the
+// "reuse W005 visual language" brief. Scoped copy: this page frames the
+// stack as what makes the product provider-neutral, not as the Enterprise
+// homepage's broader "governance emerges from composition" thesis.
+export function Architecture() {
+  return (
+    <section id="architecture" className="scroll-mt-16 max-w-4xl mx-auto px-6 py-20 border-t border-slate-200">
+      <SectionHeader
+        eyebrow="Architecture"
+        title="Three layers. One governed decision."
+        description="Enterprise never holds a credential. Only grant status and usage cross the boundary between what decides and what stores."
+      />
+
+      <div className="rounded-xl bg-slate-100 px-6 py-5">
+        <p className="text-sm font-extrabold tracking-[0.05em] text-slate-500">AOC PROTOCOL</p>
+        <p className="mt-2 text-[12.5px] text-slate-500">identity &middot; consent &middot; capability tokens &middot; audit envelopes</p>
+      </div>
+      <ArrowDown />
+      <div className="rounded-xl bg-indigo-600 px-6 py-5 shadow-[0_8px_24px_rgba(15,23,42,0.08)]">
+        <p className="text-sm font-extrabold tracking-[0.05em] text-white">AOC ENTERPRISE &mdash; GOVERNED ACCESS</p>
+        <p className="mt-2 text-[12.5px] text-indigo-200">
+          Decision &middot; Policy &middot; Grant &middot; Revocation &middot; Usage &middot; Evidence
+        </p>
+      </div>
+      <ArrowDown />
+      <div className="rounded-xl bg-slate-100 px-6 py-5">
+        <p className="text-sm font-extrabold tracking-[0.05em] text-slate-500">PROVIDER ADAPTER</p>
+        <p className="mt-2 text-[12.5px] text-slate-500">reads only resource &middot; status &middot; expiry &mdash; writes only usage events</p>
+      </div>
+
+      <p className="mt-8 text-sm text-slate-500 leading-relaxed max-w-2xl">
+        This is the same stack Enterprise composes for every capability it offers. Governed Access is the first
+        capability to ship on it — see <a href="/?view=enterprise#architecture" className="text-indigo-600 hover:text-indigo-500 font-semibold">the full architecture on AOC Enterprise</a>.
+      </p>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/Assessment.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/Assessment.tsx
@@ -1,0 +1,47 @@
+import { PipelineRail, SectionHeader } from '../primitives';
+import { ASSESSMENT_STEPS } from './content';
+
+const EMAIL = 'hello@aocprotocol.xyz';
+const CTA_HREF = `mailto:${EMAIL}?subject=${encodeURIComponent('Governed Access — Technical Assessment Request')}`;
+
+// Closing section: the engagement funnel (light), followed by the single
+// commercial CTA (dark bookend, matching ../CtaSection.tsx). Deliberately
+// omits the secondary "Request a Live Demo" / "Request an Architecture
+// Review" links ../CtaSection.tsx carries on the Enterprise homepage — this
+// product page holds to exactly one CTA throughout, per brief.
+export function Assessment() {
+  return (
+    <>
+      <section id="assessment" className="scroll-mt-16 max-w-5xl mx-auto px-6 py-20 border-t border-slate-200">
+        <SectionHeader
+          eyebrow="Technical Assessment"
+          title="Start with a scoped assessment, not a sales cycle"
+          description="Four steps from first conversation to a validated, production-bound rollout."
+        />
+
+        <PipelineRail steps={ASSESSMENT_STEPS} activeIndex={0} />
+      </section>
+
+      <section className="scroll-mt-16 bg-[#0B1220] px-6 py-24 md:py-28 text-center">
+        <div className="max-w-2xl mx-auto flex flex-col items-center">
+          <h2 className="text-[32px] md:text-5xl font-extrabold tracking-tight text-white">
+            Request a Technical Assessment
+          </h2>
+          <p className="mt-4 max-w-xl text-base md:text-lg text-slate-400">
+            A scoped review of your environment. No commitment beyond the assessment itself.
+          </p>
+
+          <a
+            href={CTA_HREF}
+            className="mt-10 inline-flex items-center gap-2.5 rounded-full bg-indigo-600 px-8 py-4 text-sm font-bold text-white shadow-[0_8px_24px_rgba(15,23,42,0.08)] transition-transform hover:-translate-y-0.5 hover:bg-indigo-500"
+          >
+            Request Technical Assessment
+            <svg viewBox="0 0 256 256" className="h-[18px] w-[18px]" fill="currentColor" aria-hidden="true">
+              <path d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z" />
+            </svg>
+          </a>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/Capabilities.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/Capabilities.tsx
@@ -1,0 +1,28 @@
+import { IconCircle, SectionHeader } from '../primitives';
+import { CAPABILITIES } from './content';
+
+// Same grid pattern as ../Benefits.tsx, applied to the capability set this
+// product actually ships rather than a build-vs-buy comparison.
+export function Capabilities() {
+  return (
+    <section id="capabilities" className="scroll-mt-16 max-w-5xl mx-auto px-6 py-20 border-t border-slate-200">
+      <SectionHeader
+        eyebrow="Capabilities"
+        title="What Governed Access ships"
+        description="Eight capabilities, composed from the same architecture — not eight separate products."
+      />
+
+      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
+        {CAPABILITIES.map((capability) => (
+          <div key={capability.title} className="rounded-2xl border border-slate-200 bg-slate-50 p-6">
+            <IconCircle size="sm">
+              <svg viewBox="0 0 24 24" aria-hidden="true" dangerouslySetInnerHTML={{ __html: capability.icon }} />
+            </IconCircle>
+            <h4 className="mt-3 text-[14.5px] font-extrabold text-slate-900">{capability.title}</h4>
+            <p className="mt-2 text-[12.5px] leading-relaxed text-slate-500">{capability.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/Examples.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/Examples.tsx
@@ -1,0 +1,28 @@
+import { SectionHeader } from '../primitives';
+import { EXAMPLE_SCENARIOS } from './content';
+
+// Illustrative scenarios only — deliberately not customer claims or case
+// studies. Each card is labeled "Example Scenario" so that's unambiguous,
+// matching the honesty bar the rest of the Enterprise section holds to
+// (see ../PlatformStatus.tsx).
+export function Examples() {
+  return (
+    <section id="examples" className="scroll-mt-16 max-w-5xl mx-auto px-6 py-20 border-t border-slate-200">
+      <SectionHeader
+        eyebrow="Illustrative Only"
+        title="What this looks like in practice"
+        description="Example scenarios, not customer claims — the kind of access decision Governed Access is built to handle."
+      />
+
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        {EXAMPLE_SCENARIOS.map((example) => (
+          <div key={example.title} className="rounded-2xl border border-slate-200 bg-slate-50 p-6">
+            <p className="text-[10.5px] font-extrabold uppercase tracking-[0.12em] text-indigo-600">Example Scenario</p>
+            <h4 className="mt-2.5 text-[15.5px] font-extrabold text-slate-900">{example.title}</h4>
+            <p className="mt-2 text-[12.5px] leading-relaxed text-slate-500">{example.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/Hero.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/Hero.tsx
@@ -1,0 +1,62 @@
+import { LogoRotating } from '../../../components/logo/LogoRotating';
+
+const EMAIL = 'hello@aocprotocol.xyz';
+const CTA_HREF = `mailto:${EMAIL}?subject=${encodeURIComponent('Governed Access — Technical Assessment Request')}`;
+
+// Dark bookend, matching the visual rhythm of ../Hero.tsx (Enterprise) and
+// ../CtaSection.tsx: light-primary page, dark hero + closing CTA. Copy is
+// the product claim itself, not an explanation of AOC Enterprise as a
+// platform — see docs/w006-governed-access-product-landing.md.
+export function Hero() {
+  return (
+    <section id="overview" className="scroll-mt-16 bg-[#0B1220] px-6 pt-20 pb-24 md:pt-28 md:pb-32 text-center">
+      <div className="max-w-3xl mx-auto flex flex-col items-center">
+        <div className="flex items-center gap-2.5">
+          <LogoRotating size={18} inverted />
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-indigo-300">
+            AOC Enterprise &middot; Governed Access
+          </p>
+        </div>
+
+        <h1 className="mt-7 text-[44px] md:text-7xl font-extrabold tracking-tight text-white leading-[1.05]">
+          Governed Access
+          <br />
+          for Digital Assets
+        </h1>
+
+        <p className="mt-6 max-w-xl text-lg md:text-xl text-slate-400">
+          Every access request becomes an auditable, revocable and provable operational decision.
+        </p>
+
+        <div className="mt-8 flex items-center gap-3 text-[13px] font-bold tracking-[0.16em] text-indigo-300">
+          <span>PROVABLE</span>
+          <span className="text-slate-600">&middot;</span>
+          <span>REVOCABLE</span>
+          <span className="text-slate-600">&middot;</span>
+          <span>AUDITABLE</span>
+        </div>
+
+        <a
+          href={CTA_HREF}
+          className="mt-10 inline-flex items-center justify-center rounded-full bg-indigo-600 px-7 py-3.5 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors"
+        >
+          Request Technical Assessment
+        </a>
+
+        <div className="mt-16 flex flex-wrap items-center justify-center gap-x-2 gap-y-2 text-sm text-slate-400 tracking-wide font-mono">
+          <span>Request</span>
+          <span aria-hidden>&rarr;</span>
+          <span>Decision</span>
+          <span aria-hidden>&rarr;</span>
+          <span>Policy</span>
+          <span aria-hidden>&rarr;</span>
+          <span>Grant</span>
+          <span aria-hidden>&rarr;</span>
+          <span>Evidence</span>
+          <span aria-hidden>&rarr;</span>
+          <span>Revocation</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/Lifecycle.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/Lifecycle.tsx
@@ -1,0 +1,34 @@
+import { Chip } from '../primitives';
+import { LIFECYCLE_STAGES } from './content';
+
+// The deck-style "missing layer" moment (see ../MissingLayer.tsx), extended
+// to the full 8-stage chain this product owns end to end. This section is
+// the declaration — what the chain is. ./OperationalLifecycle.tsx below is
+// the teaching version, where each stage is explained on hover.
+export function Lifecycle() {
+  return (
+    <section className="scroll-mt-16 px-6 py-24 text-center border-t border-slate-200">
+      <p className="text-xs font-bold uppercase tracking-[0.14em] text-indigo-600">What Governed Access Adds</p>
+      <h2 className="mt-3.5 text-4xl md:text-5xl font-extrabold tracking-tight text-slate-900">
+        One chain, from request to revocation.
+      </h2>
+      <p className="mt-5 max-w-xl mx-auto text-lg text-slate-500">
+        Every request becomes a decision. Every decision becomes a grant. Every grant produces evidence — and
+        can be revoked.
+      </p>
+
+      <div className="mt-14 flex items-center justify-center gap-x-0 gap-y-4 flex-wrap max-w-3xl mx-auto">
+        {LIFECYCLE_STAGES.map((stage, i) => (
+          <span key={stage.label} className="flex items-center">
+            <Chip tone={i === 3 ? 'accent' : 'muted'}>{stage.label}</Chip>
+            {i < LIFECYCLE_STAGES.length - 1 ? (
+              <span className="mx-1.5 hidden sm:inline text-slate-300" aria-hidden>
+                &rarr;
+              </span>
+            ) : null}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/OperationalLifecycle.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/OperationalLifecycle.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { Card, SectionHeader } from '../primitives';
+import { LIFECYCLE_STAGES } from './content';
+
+// Interactive version of ./Lifecycle.tsx's static chain — same
+// hover-to-reveal interaction as ../Pipeline.tsx ("teach, don't decorate"),
+// extended to all 8 stages including Policy and Revocation named on their
+// own rather than folded into a neighboring stage.
+export function OperationalLifecycle() {
+  const [active, setActive] = useState(-1);
+
+  return (
+    <section id="lifecycle" className="scroll-mt-16 max-w-5xl mx-auto px-6 py-20 border-t border-slate-200">
+      <SectionHeader
+        eyebrow="Operational Lifecycle"
+        title="Every stage produces one immutable record"
+        description="Nothing is overwritten, only added to. Hover a stage to see what it does."
+      />
+
+      <div
+        role="list"
+        aria-label="Governed access lifecycle stages"
+        className="flex flex-wrap gap-y-8"
+        onMouseLeave={() => setActive(-1)}
+      >
+        {LIFECYCLE_STAGES.map((stage, i) => (
+          <button
+            key={stage.label}
+            type="button"
+            role="listitem"
+            onMouseEnter={() => setActive(i)}
+            onFocus={() => setActive(i)}
+            aria-current={active === i ? 'step' : undefined}
+            className="relative flex flex-1 min-w-[25%] md:min-w-0 flex-col items-center bg-transparent px-1 text-center"
+          >
+            {i < LIFECYCLE_STAGES.length - 1 ? (
+              <div className="absolute left-1/2 top-[26px] hidden h-px w-full bg-slate-200 md:block" aria-hidden />
+            ) : null}
+            <div
+              className={`relative z-10 flex h-[52px] w-[52px] items-center justify-center rounded-full text-[17px] font-extrabold transition-colors ${
+                active === i ? 'bg-indigo-600 text-white shadow-[0_8px_24px_rgba(15,23,42,0.08)]' : 'bg-indigo-50 text-indigo-600'
+              }`}
+            >
+              {i + 1}
+            </div>
+            <div className={`mt-4 text-[12.5px] font-bold leading-tight ${active === i ? 'text-indigo-800' : 'text-slate-900'}`}>
+              {stage.label}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <Card className="mt-12 max-w-3xl mx-auto px-8 py-7 min-h-[100px] flex flex-col justify-center">
+        <p className="text-xs font-bold uppercase tracking-[0.14em] text-indigo-600">
+          {active >= 0 ? LIFECYCLE_STAGES[active].label : 'Every stage'}
+        </p>
+        <p className="mt-3 text-[15px] leading-relaxed text-slate-900">
+          {active >= 0 ? LIFECYCLE_STAGES[active].detail : 'Hover a stage above to see what it does.'}
+        </p>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/Problem.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/Problem.tsx
@@ -1,0 +1,53 @@
+import { Card, SectionHeader } from '../primitives';
+import { GAPS, MECHANISMS } from './content';
+
+function DotIcon() {
+  return (
+    <svg viewBox="0 0 256 256" className="h-[22px] w-[22px] shrink-0 text-indigo-600" fill="currentColor" aria-hidden="true">
+      <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm12-40a12,12,0,1,1-12-12A12,12,0,0,1,140,176ZM128,72a8,8,0,0,0-8,8v64a8,8,0,0,0,16,0V80A8,8,0,0,0,128,72Z" />
+    </svg>
+  );
+}
+
+// Organizations can authenticate users. They can authorize users. They
+// rarely govern access — this section makes that gap concrete by naming
+// the ad hoc mechanisms teams already reach for and what they can't answer.
+// Structurally mirrors ../Problem.tsx (Enterprise's own Problem slide) but
+// scoped to the specific mechanisms and consequences this product replaces.
+export function Problem() {
+  return (
+    <section id="problem" className="scroll-mt-16 max-w-5xl mx-auto px-6 py-20 border-t border-slate-200">
+      <SectionHeader
+        eyebrow="The Problem"
+        title="You can authenticate. You can authorize. You rarely govern."
+        description="Every team assembles the same ad hoc mechanisms to grant access. None of them were built to prove that access was correct — only that it happened."
+      />
+
+      <div className="grid md:grid-cols-2 gap-12 mt-11">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-slate-500">What you're reaching for today</p>
+          <ul className="mt-5 flex flex-col gap-6">
+            {MECHANISMS.map((item) => (
+              <li key={item} className="flex items-center gap-3.5 text-base text-slate-900">
+                <DotIcon />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-slate-500">What they leave behind</p>
+          <div className="mt-5 flex flex-col gap-4">
+            {GAPS.map((gap) => (
+              <Card key={gap.title} className="px-6 py-5">
+                <p className="text-[15px] font-bold text-slate-900">{gap.title}</p>
+                <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{gap.body}</p>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/ProviderNeutral.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/ProviderNeutral.tsx
@@ -1,0 +1,52 @@
+import { SectionHeader } from '../primitives';
+import { PROVIDERS } from './content';
+
+// Deck-consistent provider grid (visual pattern shared with
+// ../ArchitectureStack.tsx's provider row), scoped to this page's own claim:
+// Enterprise doesn't change when the provider does — only the adapter does.
+// Status vocabulary matches ../PlatformStatus.tsx exactly: Pinata is the
+// only conformance-tested adapter today.
+export function ProviderNeutral() {
+  return (
+    <section id="provider-neutral" className="scroll-mt-16 max-w-5xl mx-auto px-6 py-20 border-t border-slate-200">
+      <SectionHeader
+        eyebrow="Provider Neutral"
+        title="The same governed decision. Any provider underneath."
+        description="Governed Access doesn't run inside a storage provider — it runs above it. Enterprise makes the same decision, issues the same kind of grant, and produces the same kind of evidence regardless of where the bytes live. Only the Provider Adapter changes."
+      />
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3.5">
+        {PROVIDERS.map((provider) => (
+          <div
+            key={provider.name}
+            className={`rounded-[10px] px-3 py-4 text-center ${
+              provider.status === 'live' ? 'bg-indigo-600 shadow-[0_8px_24px_rgba(15,23,42,0.08)]' : 'bg-slate-100'
+            }`}
+          >
+            <span className={`block text-[13.5px] font-bold ${provider.status === 'live' ? 'text-white' : 'text-slate-900'}`}>
+              {provider.name}
+            </span>
+            <span
+              className={`mt-1.5 block text-[9px] font-extrabold tracking-[0.1em] ${
+                provider.status === 'live' ? 'text-indigo-200' : 'text-slate-400'
+              }`}
+            >
+              {provider.status === 'live' ? 'LIVE' : 'ROADMAP'}
+            </span>
+          </div>
+        ))}
+        <div className="rounded-[10px] border border-dashed border-slate-300 px-3 py-4 text-center flex flex-col items-center justify-center">
+          <span className="text-lg font-bold text-slate-400" aria-hidden>
+            +
+          </span>
+          <span className="mt-1 block text-[11px] font-semibold text-slate-500">Future Providers</span>
+        </div>
+      </div>
+
+      <p className="mt-6 text-sm text-slate-500 leading-relaxed max-w-2xl">
+        A new provider is a new adapter, not a rewrite of the governance layer above it — the policy, decision,
+        grant, and evidence model stays identical.
+      </p>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/WhoBenefits.tsx
+++ b/frontend/app/src/landing/enterprise/governed-access/WhoBenefits.tsx
@@ -1,0 +1,31 @@
+import { IconCircle, SectionHeader } from '../primitives';
+import { AUDIENCES } from './content';
+
+// Same layout as ../CustomerSegments.tsx (icon + title + body, two-column),
+// scoped to the eight audiences this specific product serves rather than
+// the Enterprise homepage's six verticals.
+export function WhoBenefits() {
+  return (
+    <section id="who-benefits" className="scroll-mt-16 max-w-5xl mx-auto px-6 py-20 border-t border-slate-200">
+      <SectionHeader
+        eyebrow="Who Benefits"
+        title="Where governed access is the product, not a checkbox"
+        description="Eight audiences where proving what happened to a digital asset is routine, not rare."
+      />
+
+      <div className="grid md:grid-cols-2 gap-x-10 gap-y-9">
+        {AUDIENCES.map((audience) => (
+          <div key={audience.title} className="flex items-start gap-5">
+            <IconCircle>
+              <svg viewBox="0 0 24 24" aria-hidden="true" dangerouslySetInnerHTML={{ __html: audience.icon }} />
+            </IconCircle>
+            <div>
+              <h4 className="text-base font-extrabold text-slate-900">{audience.title}</h4>
+              <p className="mt-1.5 text-[12.5px] leading-relaxed text-slate-500">{audience.body}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/src/landing/enterprise/governed-access/content.ts
+++ b/frontend/app/src/landing/enterprise/governed-access/content.ts
@@ -1,0 +1,213 @@
+// Content model for the Governed Access product page.
+//
+// Governed Access is AOC Enterprise's first Solution (see
+// ../SolutionsAndServices.tsx / ../../routes.ts). Where the Enterprise
+// homepage introduces the concept in three sections (Problem, Missing
+// Layer, Architecture Stack), this page is the dedicated product landing:
+// it sells the capability on its own, in under two minutes, without
+// re-explaining the rest of AOC Enterprise. See docs/w006-governed-access-
+// product-landing.md for the full design rationale.
+//
+// Claims here are held to the same honesty bar as ../PlatformStatus.tsx —
+// Pinata is the only conformance-tested provider adapter today; every
+// other provider below is roadmap, not shipped.
+
+export const MECHANISMS = [
+  'Temporary URLs',
+  'API keys',
+  'Storage tokens',
+  'Manual permissions',
+  'Shared credentials',
+] as const;
+
+export const GAPS = [
+  {
+    title: 'Invisible access',
+    body: 'A link or key works for anyone who has it. Nothing records who actually used it, or when.',
+  },
+  {
+    title: 'Missing audit',
+    body: 'When access is questioned, there is no record to answer with — only what someone remembers.',
+  },
+] as const;
+
+export type LifecycleStage = {
+  label: string;
+  detail: string;
+};
+
+// The canonical 8-stage lifecycle. This is the superset the Enterprise
+// homepage's Pipeline.tsx and ArchitectureStack.tsx summarize — this page
+// is where it is stated in full, with Policy and Revocation named as their
+// own stages rather than folded into "Obligations" / left implicit.
+export const LIFECYCLE_STAGES: LifecycleStage[] = [
+  { label: 'Request', detail: 'A principal asks for access to a specific resource, for a specific purpose.' },
+  { label: 'Decision', detail: 'The request is checked against policy in real time — approve, deny, or escalate.' },
+  { label: 'Policy', detail: 'The applicable rules are resolved: who may approve, what conditions attach, how long a grant may last.' },
+  { label: 'Grant', detail: 'A time-bound, scoped capability is issued — never a standing credential.' },
+  { label: 'Provider Translation', detail: 'The grant is translated into the exact call the provider adapter understands.' },
+  { label: 'Usage', detail: 'Every read, view, or action is recorded as it happens — not reconstructed later.' },
+  { label: 'Evidence', detail: 'The full record becomes a provable, replayable audit trail correlated back to the original decision.' },
+  { label: 'Revocation', detail: 'The grant can be withdrawn at any point — on expiry, on policy change, or on demand — and the revocation is itself evidenced.' },
+];
+
+export type Provider = {
+  name: string;
+  status: 'live' | 'roadmap' | 'future';
+};
+
+export const PROVIDERS: Provider[] = [
+  { name: 'Pinata', status: 'live' },
+  { name: 'Amazon S3', status: 'roadmap' },
+  { name: 'Azure Blob', status: 'roadmap' },
+  { name: 'Cloudflare R2', status: 'roadmap' },
+  { name: 'Google Drive', status: 'roadmap' },
+  { name: 'SharePoint', status: 'roadmap' },
+];
+
+export type Capability = {
+  title: string;
+  body: string;
+  icon: string;
+};
+
+// Simple stroke icons (24x24, currentColor) — same authoring convention as
+// the risk-card icons on AssurancePage, chosen over freehand filled-path
+// glyphs to keep new icon geometry easy to verify by hand.
+export const CAPABILITIES: Capability[] = [
+  {
+    title: 'Policy Decisions',
+    body: 'Every request is evaluated against codified policy in real time — not a manual approval queue.',
+    icon: '<path d="M12 3l7 3v6c0 5-3.5 8-7 9-3.5-1-7-4-7-9V6l7-3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="none"/><path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>',
+  },
+  {
+    title: 'Scoped Grants',
+    body: 'Access is issued as a time-bound, purpose-bound capability — never a standing, reusable credential.',
+    icon: '<rect x="4" y="10" width="16" height="10" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M8 10V7a4 4 0 0 1 8 0v3" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="12" cy="15" r="1.6" fill="currentColor"/>',
+  },
+  {
+    title: 'Evidence Correlation',
+    body: 'Usage events, decisions, and grants are linked into a single provable chain — not scattered logs.',
+    icon: '<circle cx="6" cy="6" r="2.5" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="18" cy="6" r="2.5" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="12" cy="18" r="2.5" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M8.2 7.2L11 16M15.8 7.2L13 16M8.5 6h7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>',
+  },
+  {
+    title: 'Usage Events',
+    body: 'Every read, view, or action against a grant is recorded as it happens, at the point of access.',
+    icon: '<path d="M4 19V5M4 19h16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M7 15l3.5-4 3 2.5L18 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>',
+  },
+  {
+    title: 'Grant Revocation',
+    body: 'A grant can be withdrawn at any point — on expiry, on policy change, or on demand — and enforced immediately.',
+    icon: '<circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7 7l10 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>',
+  },
+  {
+    title: 'Provider Translation',
+    body: 'Grants are translated into the exact call each provider adapter understands — the same grant, any provider.',
+    icon: '<rect x="3" y="4" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><rect x="14" y="13" width="7" height="7" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M10 7.5h3a2 2 0 0 1 2 2V13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M13.5 5.5L17 7.5l-3.5 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>',
+  },
+  {
+    title: 'Immutable Decisions',
+    body: 'A decision, once made and recorded, is never overwritten — only superseded by a new, linked decision.',
+    icon: '<rect x="5" y="4" width="14" height="16" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M9 9h6M9 13h6M9 17h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="17.5" cy="17.5" r="3.5" fill="white" stroke="currentColor" stroke-width="1.5"/><path d="M16 17.5l1 1 2-2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>',
+  },
+  {
+    title: 'Operational Audit',
+    body: 'Access history is a chain you read, not logs you reconstruct — answering "prove it" with a record.',
+    icon: '<path d="M6 3h9l5 5v13H6z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="none"/><path d="M15 3v5h5" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="none"/><path d="M9 13h6M9 17h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>',
+  },
+];
+
+export type Audience = {
+  title: string;
+  body: string;
+  icon: string;
+};
+
+export const AUDIENCES: Audience[] = [
+  {
+    title: 'Developer Platforms',
+    body: 'Access governance stops being bespoke glue code written once per customer.',
+    icon: '<polyline points="8 6 3 12 8 18" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/><polyline points="16 6 21 12 16 18" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>',
+  },
+  {
+    title: 'Storage Providers',
+    body: 'Governance becomes a layer above the provider, not a feature every provider has to rebuild.',
+    icon: '<path d="M4 7a8 3 0 0 0 16 0 8 3 0 0 0-16 0z" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M4 7v10a8 3 0 0 0 16 0V7" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M4 12a8 3 0 0 0 16 0" stroke="currentColor" stroke-width="1.5" fill="none"/>',
+  },
+  {
+    title: 'AI Platforms',
+    body: 'Agents request access at machine speed and volume — every request still resolves to a governed decision.',
+    icon: '<rect x="5" y="7" width="14" height="11" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M12 7V4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="12" cy="3" r="1" fill="currentColor"/><circle cx="9" cy="12.5" r="1.3" fill="currentColor"/><circle cx="15" cy="12.5" r="1.3" fill="currentColor"/>',
+  },
+  {
+    title: 'Identity Providers',
+    body: 'Authentication answers who. Governed Access answers whether this identity should reach this resource now.',
+    icon: '<circle cx="12" cy="8" r="3.2" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>',
+  },
+  {
+    title: 'Enterprise SaaS',
+    body: 'Every customer storage integration stops being its own, one-off access model.',
+    icon: '<rect x="3" y="4" width="18" height="12" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M8 20h8M12 16v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>',
+  },
+  {
+    title: 'Healthcare',
+    body: 'Conditions on sensitive records — read-only, time-boxed, purpose-limited — are enforced, not just stated in a policy doc.',
+    icon: '<path d="M12 21s-7-4.35-9.5-9A5.5 5.5 0 0 1 12 6.5 5.5 5.5 0 0 1 21.5 12c-2.5 4.65-9.5 9-9.5 9z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/><path d="M9 12h2v-2h2v2h2v2h-2v2h-2v-2H9z" fill="currentColor"/>',
+  },
+  {
+    title: 'Finance',
+    body: 'Access must be provable years after the fact, not just at the moment it was granted.',
+    icon: '<path d="M3 10l9-6 9 6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M5 10v9M19 10v9M9 10v9M15 10v9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M3 19h18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>',
+  },
+  {
+    title: 'Media',
+    body: 'Licensed and embargoed assets can be shared on a schedule that is enforced, not just requested.',
+    icon: '<rect x="3" y="5" width="18" height="14" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="9" cy="10" r="2" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M4 17l5-4 3 2.5 4-3.5 4 3" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>',
+  },
+];
+
+export type ExampleScenario = {
+  title: string;
+  body: string;
+};
+
+// Illustrative only — no customer names, no deployment claims. Matches the
+// "example scenario" framing already used for Pipeline.tsx's M&A reference
+// scenario.
+export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
+  {
+    title: 'Secure document sharing',
+    body: 'A counterparty is granted a time-bound, read-only view of a confidential document — access ends automatically, and every view is recorded.',
+  },
+  {
+    title: 'Medical image access',
+    body: 'A referring clinician is granted scoped access to a single study for a defined review window, with every access evidenced.',
+  },
+  {
+    title: 'AI model downloads',
+    body: 'A licensed model artifact is released to an approved agent identity under a grant that expires after a single verified download.',
+  },
+  {
+    title: 'Customer portals',
+    body: 'A customer\'s access to their own exported records is granted, scoped, and revocable without a bespoke permissions system per tenant.',
+  },
+  {
+    title: 'Enterprise file exchange',
+    body: 'Two organizations exchange working files under a grant that both sides can audit, without either holding a standing credential to the other\'s storage.',
+  },
+  {
+    title: 'Partner integrations',
+    body: 'A partner system is granted narrow, purpose-bound access to specific resources instead of a broad, long-lived API key.',
+  },
+  {
+    title: 'Temporary project access',
+    body: 'A contractor is granted access scoped to a single project and a fixed window, revoked automatically when the engagement ends.',
+  },
+];
+
+export const ASSESSMENT_STEPS = [
+  { label: 'Assessment', sub: 'Scoped review of your environment' },
+  { label: 'Architecture Review', sub: 'How Governed Access fits your systems' },
+  { label: 'Pilot', sub: 'A working integration, narrowly scoped' },
+  { label: 'Implementation', sub: 'Validated, production-bound rollout' },
+];


### PR DESCRIPTION
## Summary

Replaces the placeholder Governed Access page with a complete, production-ready product landing. The page sells Governed Access as a standalone capability in under two minutes, using the W005 commercial design system without introducing new visual language or components.

## Changes

- **Content model** (`content.ts`): Defines all copy and data structures for the page — mechanisms, gaps, 8-stage lifecycle, providers, capabilities, audiences, example scenarios, and assessment steps. Honesty bar matches `PlatformStatus.tsx`: Pinata is live; S3, Azure Blob, Cloudflare R2, Google Drive, SharePoint are roadmap.

- **Page sections** (10 new components):
  - `Hero.tsx`: Dark bookend with product claim and single CTA (Request Technical Assessment)
  - `Problem.tsx`: Concrete gap analysis — ad hoc mechanisms teams use today and what they can't answer
  - `Lifecycle.tsx`: Static declaration of the 8-stage chain (Request → Decision → Policy → Grant → Provider Translation → Usage → Evidence → Revocation)
  - `ProviderNeutral.tsx`: Provider grid showing Pinata live, others roadmap, plus "Future Providers" tile
  - `Architecture.tsx`: Three-band composition diagram (Protocol → Enterprise → Provider Adapter), reused from `ArchitectureStack.tsx`
  - `OperationalLifecycle.tsx`: Interactive version of the lifecycle with hover-to-reveal stage details (same interaction pattern as `Pipeline.tsx`)
  - `Capabilities.tsx`: Eight capability cards in a grid (Policy Decisions, Scoped Grants, Evidence Correlation, Usage Events, Grant Revocation, Provider Translation, Immutable Decisions, Operational Audit)
  - `WhoBenefits.tsx`: Eight audiences where governed access is the product, not a checkbox (Developer Platforms, Storage Providers, AI Platforms, Identity Providers, Enterprise SaaS, Healthcare, Finance, Media)
  - `Examples.tsx`: Seven illustrative scenarios, explicitly labeled "Example Scenario" with no customer claims
  - `Assessment.tsx`: Engagement funnel (Assessment → Architecture Review → Pilot → Implementation) plus closing dark CTA bookend

- **Page assembly** (`GovernedAccessPage.tsx`): Replaced placeholder with full page composition using `EnterpriseNav`, breadcrumbs, all 10 sections, and `ProtocolFooter` with indigo accent. Maintains light-primary body with dark hero/CTA bookends, matching Enterprise homepage visual rhythm.

- **Design system reuse**: All sections compose existing W005 primitives (`Card`, `IconCircle`, `Chip`, `PipelineRail`, `SectionHeader`, `Eyebrow`) — no new components introduced. Uses same color tokens (light-primary, `#0B1220` dark bookends, `indigo-600` accent).

- **Documentation** (`w006-governed-access-product-landing.md`): Design rationale, section map, honesty bar justification, and verification checklist.

## Notable Details

- The 8-stage lifecycle on this page names Policy and Revocation as explicit stages, unlike the Enterprise homepage's Pipeline which folds them into "Obligations" and leaves Revocation implicit. This page is the canonical, spelled-out version.
- Single commercial CTA throughout (Request Technical Assessment) — deliberately omits secondary links that appear on the Enterprise homepage's closing CTA.
- All provider maturity claims are consistent with existing platform status documentation.
- Example scenarios are illustrative only, never framed as deployments or customer claims.
- No routing changes required — `App.tsx` and `SolutionsAndServices.tsx` already wire this page.

https://claude.ai/code/session_01Fju1PjaKhDz8GaeA4U7n5r