### PR TITLE
Add interactive capability cards with expand/collapse animations

### DIFF
--- a/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
+++ b/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
@@ -1,27 +1,144 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion, MotionConfig } from 'framer-motion';
 import { CAPABILITY_FAMILIES } from './content';
-import { SectionHeader, StatusPill, Card } from '../enterprise/primitives';
+import { CAPABILITY_ICONS } from './CapabilityIcons';
+import { SectionHeader, StatusPill } from '../enterprise/primitives';
+
+// A single capability at rest shows only its icon and name — an object
+// worth exploring, not a wall of text. Hovering (or focusing, or tapping on
+// touch) brings one card forward: it widens, its description and status
+// unfold, and every sibling quietly steps back in scale and opacity. The
+// grid itself never reflows violently — only the active card's column span
+// changes, and Framer Motion's `layout` animates that resize and the
+// resulting sibling reflow as one continuous motion instead of a jump.
+const EASE = [0.33, 1, 0.68, 1] as const;
 
 export function CapabilityFamilies() {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [isTouch, setIsTouch] = useState(false);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(hover: none)');
+    const onChange = () => setIsTouch(mq.matches);
+    onChange();
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
+  // Touch devices have no hover: tapping a card expands it, tapping
+  // anywhere else in the grid (or outside it) collapses it again.
+  useEffect(() => {
+    if (!isTouch || !activeId) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest('[data-capability-card]')) setActiveId(null);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [isTouch, activeId]);
+
   return (
     <section id="capabilities" className="scroll-mt-16 max-w-7xl mx-auto px-6 py-20 border-t border-slate-200">
       <SectionHeader
         eyebrow="What Can a Digital Asset Express?"
         title="Capabilities are what a digital asset can declare about itself."
-        description="Each family below is a property an asset's manifest or canonical record can carry. Status labels show what's already defined as a canonical contract in @aoc/protocol versus what's still a protocol direction — not a claim that a full creation or runtime SDK ships today."
+        description="Each family below is a property an asset's manifest or canonical record can carry. Hover or focus a capability to see what it declares — status labels show what's already defined as a canonical contract in @aoc/protocol versus what's still a protocol direction."
         mineral="amethyst"
       />
 
-      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
-        {CAPABILITY_FAMILIES.map((family) => (
-          <Card key={family.id} className="p-6">
-            <h3 className="text-base font-extrabold text-slate-900">{family.name}</h3>
-            <p className="mt-3 text-sm leading-relaxed text-slate-500">{family.summary}</p>
-            <div className="mt-4">
-              <StatusPill label={family.status} />
-            </div>
-          </Card>
-        ))}
-      </div>
+      <MotionConfig reducedMotion="user">
+        <div
+          ref={gridRef}
+          className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5"
+          onMouseLeave={() => !isTouch && setActiveId(null)}
+        >
+          {CAPABILITY_FAMILIES.map((family) => {
+            const isActive = activeId === family.id;
+            const isDimmed = activeId !== null && !isActive;
+            const Icon = CAPABILITY_ICONS[family.id];
+            const detailId = `capability-detail-${family.id}`;
+
+            return (
+              <motion.div
+                key={family.id}
+                layout
+                data-capability-card
+                transition={{ layout: { duration: isActive ? 0.32 : 0.25, ease: EASE } }}
+                className={isActive ? 'sm:col-span-2 lg:col-span-2' : undefined}
+                onMouseEnter={() => !isTouch && setActiveId(family.id)}
+                onFocus={() => setActiveId(family.id)}
+                onBlur={() => setActiveId((current) => (current === family.id ? null : current))}
+                onClick={() => isTouch && setActiveId((current) => (current === family.id ? null : family.id))}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    setActiveId(null);
+                    event.currentTarget.blur();
+                  }
+                }}
+                tabIndex={0}
+                role="group"
+                aria-label={family.name}
+                aria-expanded={isActive}
+                aria-describedby={detailId}
+              >
+                <motion.div
+                  animate={{ scale: isDimmed ? 0.9 : 1, opacity: isDimmed ? 0.4 : 1 }}
+                  transition={{ duration: 0.25, ease: EASE }}
+                  className={`relative h-full rounded-2xl border bg-slate-50 p-6 outline-none cursor-default focus-visible:ring-2 focus-visible:ring-violet-400 ${
+                    isActive
+                      ? 'border-violet-300 shadow-[0_20px_44px_rgba(139,92,246,0.2)]'
+                      : 'border-slate-200 shadow-[0_8px_24px_rgba(15,23,42,0.06)]'
+                  }`}
+                  style={{ transitionProperty: 'border-color, box-shadow', transitionDuration: '300ms', transitionTimingFunction: 'cubic-bezier(0.33,1,0.68,1)' }}
+                >
+                  {isActive && (
+                    <motion.div
+                      aria-hidden
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.3, ease: EASE }}
+                      className="pointer-events-none absolute -inset-px rounded-2xl bg-[radial-gradient(circle_at_28%_18%,rgba(139,92,246,0.16),transparent_65%)]"
+                    />
+                  )}
+
+                  <motion.div
+                    animate={isActive ? { y: [0, -3, 0] } : { y: 0 }}
+                    transition={isActive ? { duration: 2.6, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.2, ease: EASE }}
+                    className="relative w-fit text-violet-600"
+                  >
+                    <Icon className="h-6 w-6" />
+                  </motion.div>
+
+                  <h3 className="relative mt-4 text-base font-extrabold text-slate-900">{family.name}</h3>
+
+                  <motion.div
+                    id={detailId}
+                    initial={false}
+                    animate={{ height: isActive ? 'auto' : 0, opacity: isActive ? 1 : 0 }}
+                    transition={{
+                      height: { duration: isActive ? 0.32 : 0.24, ease: EASE },
+                      opacity: { duration: 0.2, ease: EASE, delay: isActive ? 0.08 : 0 },
+                    }}
+                    className="relative overflow-hidden"
+                  >
+                    <p className="mt-3 text-sm leading-relaxed text-slate-500">{family.summary}</p>
+                    <motion.div
+                      initial={false}
+                      animate={{ opacity: isActive ? 1 : 0, y: isActive ? 0 : 6 }}
+                      transition={{ duration: 0.2, ease: EASE, delay: isActive ? 0.16 : 0 }}
+                      className="mt-4"
+                    >
+                      <StatusPill label={family.status} />
+                    </motion.div>
+                  </motion.div>
+                </motion.div>
+              </motion.div>
+            );
+          })}
+        </div>
+      </MotionConfig>
     </section>
   );
 }

--- a/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
+++ b/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
@@ -16,7 +16,31 @@ const EASE = [0.33, 1, 0.68, 1] as const;
 export function CapabilityFamilies() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [isTouch, setIsTouch] = useState(false);
+  const [isReflowing, setIsReflowing] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
+  const reflowCount = useRef(0);
+  // A tap focuses its element before its click fires. Without this flag the
+  // resulting onFocus would set activeId, then the same tap's onClick would
+  // read that as "already active" and immediately toggle it back off — so a
+  // card never visibly expanded until a second tap. Set on pointerdown,
+  // consumed by the very next onFocus, so real keyboard-driven focus (no
+  // preceding pointerdown) is unaffected.
+  const pointerActivatedRef = useRef(false);
+
+  // While the active card's column span animates, every sibling's bounding
+  // box moves too (Framer Motion's `layout` reflow). Chromium re-hit-tests
+  // elements that pass under a stationary cursor during that reflow and
+  // fires real mouseenter/mouseleave on whatever card ends up there, which
+  // can silently activate a card the pointer never intentionally entered.
+  // Suppressing pointer events for the reflow's duration prevents that.
+  const startReflow = () => {
+    reflowCount.current += 1;
+    setIsReflowing(true);
+  };
+  const endReflow = () => {
+    reflowCount.current = Math.max(0, reflowCount.current - 1);
+    if (reflowCount.current === 0) setIsReflowing(false);
+  };
 
   useEffect(() => {
     const mq = window.matchMedia('(hover: none)');
@@ -51,6 +75,7 @@ export function CapabilityFamilies() {
         <div
           ref={gridRef}
           className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5"
+          style={{ pointerEvents: isReflowing ? 'none' : 'auto' }}
           onMouseLeave={() => !isTouch && setActiveId(null)}
         >
           {CAPABILITY_FAMILIES.map((family) => {
@@ -65,15 +90,30 @@ export function CapabilityFamilies() {
                 layout
                 data-capability-card
                 transition={{ layout: { duration: isActive ? 0.32 : 0.25, ease: EASE } }}
+                onLayoutAnimationStart={startReflow}
+                onLayoutAnimationComplete={endReflow}
                 className={isActive ? 'sm:col-span-2 lg:col-span-2' : undefined}
                 onMouseEnter={() => !isTouch && setActiveId(family.id)}
-                onFocus={() => setActiveId(family.id)}
+                onPointerDown={() => {
+                  pointerActivatedRef.current = true;
+                }}
+                onFocus={() => {
+                  if (isTouch && pointerActivatedRef.current) {
+                    pointerActivatedRef.current = false;
+                    return;
+                  }
+                  setActiveId(family.id);
+                }}
                 onBlur={() => setActiveId((current) => (current === family.id ? null : current))}
                 onClick={() => isTouch && setActiveId((current) => (current === family.id ? null : family.id))}
                 onKeyDown={(event) => {
                   if (event.key === 'Escape') {
                     setActiveId(null);
                     event.currentTarget.blur();
+                  } else if (event.key === ' ' || event.key === 'Spacebar') {
+                    // The card isn't a native button; without this, Space
+                    // falls through to the browser's default page-scroll.
+                    event.preventDefault();
                   }
                 }}
                 tabIndex={0}

--- a/frontend/app/src/landing/protocol/CapabilityIcons.tsx
+++ b/frontend/app/src/landing/protocol/CapabilityIcons.tsx
@@ -1,0 +1,107 @@
+// Minimal line-icon set for the eight capability families (CapabilityFamilies.tsx).
+// Deliberately abstract and geometric — same register as NodeGlyph in
+// ../enterprise/primitives.tsx — rather than illustrative, so the resting
+// grid reads as a set of precise sculptural marks, not clip-art.
+
+import type { ReactElement, SVGProps } from 'react';
+import type { CapabilityFamily } from './content';
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+const base = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.5,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+function IdentityIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <circle cx="12" cy="8.5" r="3.25" />
+      <path d="M5.5 20c0-3.6 3-6.25 6.5-6.25s6.5 2.65 6.5 6.25" />
+    </svg>
+  );
+}
+
+function IntegrityIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <path d="M12 3.5l6.5 2.6v5.1c0 4.6-2.9 7.7-6.5 9.3-3.6-1.6-6.5-4.7-6.5-9.3V6.1L12 3.5z" />
+      <path d="M9 12.2l2 2 4-4.2" />
+    </svg>
+  );
+}
+
+function ProvenanceIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <path d="M6.5 3.5h7l4 4v13a1 1 0 01-1 1h-10a1 1 0 01-1-1v-16a1 1 0 011-1z" />
+      <path d="M13.5 3.5v4h4" />
+      <path d="M8.5 12.5h7M8.5 15.5h7M8.5 9.5h3" />
+    </svg>
+  );
+}
+
+function PortabilityIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <path d="M4.5 8.5h15v11a1 1 0 01-1 1h-13a1 1 0 01-1-1v-11z" />
+      <path d="M8 8.5V6a2 2 0 012-2h4a2 2 0 012 2v2.5" />
+      <path d="M9.5 13l2.5 2.5L14.5 13" />
+      <path d="M12 15.5v-5" />
+    </svg>
+  );
+}
+
+function InteroperabilityIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <circle cx="9.25" cy="12" r="5" />
+      <circle cx="14.75" cy="12" r="5" />
+    </svg>
+  );
+}
+
+function VerifiabilityIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M8.25 12.3l2.6 2.6 5.1-5.5" />
+    </svg>
+  );
+}
+
+function LicensingIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <path d="M3.5 12V4.5a1 1 0 011-1h7.5l8.5 8.5-8.5 8.5-8.5-8.5z" />
+      <circle cx="8" cy="8" r="1.4" />
+    </svg>
+  );
+}
+
+function GovernanceCompatibilityIcon(props: IconProps) {
+  return (
+    <svg {...base} {...props}>
+      <path d="M12 3.5v17" />
+      <path d="M4.5 7h15" />
+      <path d="M4.5 7l-2.75 5.5h5.5L4.5 7z" />
+      <path d="M19.5 7l-2.75 5.5h5.5L19.5 7z" />
+      <path d="M8.5 20.5h7" />
+    </svg>
+  );
+}
+
+export const CAPABILITY_ICONS: Record<CapabilityFamily['id'], (props: IconProps) => ReactElement> = {
+  identity: IdentityIcon,
+  integrity: IntegrityIcon,
+  provenance: ProvenanceIcon,
+  portability: PortabilityIcon,
+  interoperability: InteroperabilityIcon,
+  verifiability: VerifiabilityIcon,
+  licensing: LicensingIcon,
+  'governance-compatibility': GovernanceCompatibilityIcon,
+};


### PR DESCRIPTION
## Summary
Transforms the static capability families grid into an interactive component with smooth expand/collapse animations. Cards now display only their icon and name at rest, expanding on hover/focus to reveal full descriptions and status information.

## Key Changes
- **Interactive card states**: Cards expand to double width when active, revealing description and status pill with staggered animations
- **Multi-input support**: Handles hover (desktop), focus (keyboard), and tap (touch) interactions with device-aware behavior
- **Smooth animations**: Uses Framer Motion's `layout` prop to animate grid reflow when cards expand, with custom easing and staggered opacity/height transitions
- **Accessibility**: Full keyboard navigation (Tab, Space, Escape) and ARIA attributes (`aria-expanded`, `aria-describedby`, `role="group"`)
- **Touch-specific UX**: On touch devices, tapping a card expands it; tapping elsewhere collapses it (no hover state)
- **Reflow safety**: Suppresses pointer events during layout animations to prevent unintended card activation from Chromium's hit-test re-evaluation
- **Icon system**: New `CapabilityIcons.tsx` with eight minimal, geometric line icons matching the design system's sculptural aesthetic

## Notable Implementation Details
- Uses `pointerActivatedRef` to distinguish between pointer-driven focus (tap) and keyboard focus, preventing double-toggle on touch devices
- Implements `reflowCount` ref to safely manage pointer-events suppression across overlapping layout animations
- Detects touch capability via `matchMedia('(hover: none)')` for device-appropriate interaction patterns
- Cards animate with custom cubic-bezier easing `[0.33, 1, 0.68, 1]` for snappy, responsive feel
- Active card icon performs subtle continuous bob animation (2.6s loop) when expanded
- Updated description text to guide users on interaction method

https://claude.ai/code/session_01FgR5LoYZrRBsr3vUBbfREX