### PR TITLE
Redesign Capability Explorer as a static-grid Dock-style hover interaction

### DIFF
--- a/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
+++ b/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
@@ -27,73 +27,69 @@ const CAPABILITY_ICONS: Record<CapabilityFamily['id'], (props: IconProps) => Ret
 
 // A single capability at rest shows only its icon and name — an object
 // worth exploring, not a wall of text. Hovering (or focusing, or tapping on
-// touch) brings one card forward: its description and status unfold in
-// place and it lifts slightly, while every sibling quietly steps back in
-// scale and opacity, and the row below it genuinely moves down to make
-// room — nothing is ever covered or unreachable.
+// touch) lifts that card into its own layer, Dock-style: it scales up and
+// rises slightly with a restrained amethyst glow, while every sibling
+// quietly steps back in scale and opacity. Its description and status
+// unfold in a floating panel attached to the card rather than participating
+// in layout at all.
 //
-// Five earlier versions got this wrong:
+// Six earlier versions tried to make the CARD ITSELF grow to fit its
+// description — via grid column-span, via normal-flow height growth, via
+// an always-taller invisible spacer — and every one of them either moved
+// or resized the interactive hit target under the cursor (causing
+// false/stuck hover across various specific mechanisms) or, when they
+// avoided that by overlaying instead of resizing, permanently occluded and
+// made unreachable whatever card sat in the space the overlay grew into.
+// Chasing bigger and more specific guards against the resulting hover
+// races (pointer-event locks, animation-callback counters, hover-intent
+// debouncing) fixed each specific failure but the category kept finding a
+// new edge.
 //
-// V1 changed the hit target's own grid column span to grow the active
-// card (smoothed via Framer Motion's `layout` prop) — that moved the hit
-// target itself under the cursor mid-hover, producing false/stuck hover
-// states on some transitions.
+// This version sidesteps the entire category rather than guarding it: the
+// grid's own geometry (row heights, column widths, item positions) never
+// changes, ever, regardless of activeId — nothing here uses layout
+// animation, grid-affecting size changes, or pointer-event manipulation.
+// Every visual change is a `transform`/`opacity`/`box-shadow` on the card's
+// own surface, which never alters its grid box, so no sibling can ever be
+// physically displaced by another card's state. The description lives in a
+// separate, absolutely positioned floating panel (outside normal flow, so
+// it cannot affect grid sizing either) with `pointer-events: none` — it can
+// visually extend over neighboring cards, exactly like a Dock tooltip or an
+// Apple Wallet detail popover would, but a completely inert layer never
+// blocks hovering, focusing, or clicking whatever is actually underneath.
 //
-// V2 tried to patch that by suppressing pointer events for the duration of
-// Framer's layout-animation callbacks, tracked with a start/complete
-// counter — but an interrupted animation can fire onLayoutAnimationStart
-// without its matching onLayoutAnimationComplete, so the counter could get
-// permanently stuck above zero, deadlocking hover for the rest of the
-// page's lifetime after the very first hover.
+// One edge this approach still had to account for: the panel being
+// pointer-events:none means the cursor passes through it to whatever's
+// really there — for a bottom-row card, that's empty space below the grid
+// container's own box, not another card. Getting the "should this still
+// count as hovered" check right took three attempts. Two of them tried to
+// read the active card's/panel's rects off a React ref populated only
+// while that card was active — neither ever actually attached through
+// `motion.div`'s own ref-forwarding (confirmed via direct fiber
+// inspection: `.current` stayed null even while genuinely active). The
+// third replaced the ref with a plain DOM lookup by stable id (which does
+// work) but still ran the check from the grid's own `onMouseLeave` — and
+// `mouseleave` is a one-shot event fired only at the instant the cursor
+// crosses the grid's box, not a continuous signal. Since a bottom-row
+// card's panel extends past that boundary, the one `mouseleave` the
+// browser ever sends usually still lands inside the card+panel union and
+// gets waved through — but the cursor can then travel arbitrarily far away
+// afterward without the grid ever hearing about it again, leaving the card
+// stuck open until something else (a different card's hover, a click,
+// Escape) intervened.
 //
-// V3 kept every card's own box a fixed width and let the description grow
-// in normal document flow, reasoning that CSS Grid's row-track sizing
-// would only ever grow the active row — but CSS Grid's default
-// `align-items: stretch` also stretches every *sibling* in that row to
-// match, so the row below still shifted out from under a hover mid-
-// transition (an admittedly rare miss, but a real one).
-//
-// V4 removed the description from normal flow entirely (an absolutely
-// positioned overlay on an invisible, never-resized spacer), which made
-// row-track sizing provably constant — but an overlay tall enough to hold
-// a full description is taller than one row, so it permanently painted
-// over — and made unreachable — whatever card sat in the same column one
-// row down. Not a transient mis-hover; a 100%-reproducible dead zone.
-//
-// V5 and V6 both went back to real, in-flow height growth with
-// `items-start` to stop sibling stretch — both correct, and kept below —
-// but each tried to guard the resulting row-shift with a pointer-events
-// lock (first grid-wide, then narrowed to non-active cards only). Both
-// leaned on browser hit-test behavior that turned out to be asymmetric:
-// Chromium fires a real mouseleave when an element is excluded from
-// hit-testing while the cursor sits on it, but does *not* fire a matching
-// mouseenter when it's later re-included under a still-stationary cursor.
-// V5's whole-grid lock excluded the active card itself, self-collapsing it
-// every ~415ms forever. V6's narrower per-card lock avoided that, but
-// re-armed on every incidental crossing (a fast or diagonal move can graze
-// an unrelated card's hit box en route to its real target) with no memory
-// of a lock already in flight, so a transition landing inside another
-// transition's lock window was silently dropped — the previous card stuck
-// open, the new target never activating (measured ~48% failure rate on
-// rapid diagonal transitions, and it also broke touch tap-switching, since
-// a tap's own blur-then-click sequence is exactly this kind of double
-// transition).
-//
-// This version stops trying to control hit-testing at all. Instead of
-// suppressing events during the window a reflow might cause a spurious
-// hover, it debounces *commitment*: a mouse-driven activation only takes
-// effect after it has been the single most recent hover event for
-// `HOVER_INTENT_MS` uninterrupted. A transient hover — a sibling sweeping
-// past a stationary cursor mid-reflow, or the cursor grazing an unrelated
-// card en route to its real target — gets superseded by the next real
-// hover event before its timer fires and never commits; a genuine,
-// sustained hover always outlasts the window and commits normally. This
-// needs no exemptions, no lock bookkeeping, and no assumption about which
-// direction the browser does or doesn't resynthesize events. Keyboard focus
-// and touch taps are unaffected — they're discrete, not continuous, so
-// they were never the pathway at risk and stay immediate.
+// This version drops the grid's own onMouseLeave for this purpose entirely
+// and tracks a `document`-level mousemove instead, active only while some
+// card is hovered-active: on every move it re-reads the current card's and
+// panel's rects fresh (by the same stable-id DOM lookup) and clears
+// activeId the moment the cursor is genuinely outside their union — a
+// continuous check rather than a single stale snapshot, so it's correct
+// however far or long the cursor travels afterward. `activeIdRef` mirrors
+// `activeId` synchronously (updated inside `setActive`, not through a
+// `useEffect`) so this listener — and the touch/keyboard paths, which all
+// go through `setActive` too — always compare against the true current
+// value instead of one captured in a stale closure.
 const EASE = [0.33, 1, 0.68, 1] as const;
-const HOVER_INTENT_MS = 100;
 
 export function CapabilityFamilies() {
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -106,32 +102,25 @@ export function CapabilityFamilies() {
   // consumed by the very next onFocus, so real keyboard-driven focus (no
   // preceding pointerdown) is unaffected.
   const pointerActivatedRef = useRef(false);
-  // Tracks the one pending mouse-hover-intent timer, if any. A new mouse
-  // hover event (on any card) always clears whatever was previously
-  // pending before scheduling its own, so a superseded intent can never
-  // fire after the fact.
-  const hoverIntentTimerRef = useRef<number | undefined>(undefined);
+  // Mirrors activeId so the document-level mousemove tracker below always
+  // reads the true current value, never one from a stale closure. Must be
+  // updated synchronously, in plain JS, at the moment setActive is called —
+  // not inside React's setState updater, which doesn't run until React's
+  // own render/flush timing. A raw `document.addEventListener` handler
+  // (like the mousemove tracker) sits outside React's event system, so a
+  // mousemove landing between an onMouseEnter call and React actually
+  // flushing that update would otherwise read activeIdRef one step behind
+  // reality — exactly the race a previous version of this fix hit: a fast
+  // move from one card straight into a non-overlapping one could have the
+  // tracker see the *old* card, decide the cursor is now outside it, and
+  // cancel the new card's activation that was already in flight.
+  const activeIdRef = useRef<string | null>(null);
 
-  const clearHoverIntent = () => {
-    window.clearTimeout(hoverIntentTimerRef.current);
+  const setActive = (next: string | null | ((current: string | null) => string | null)) => {
+    const resolved = typeof next === 'function' ? next(activeIdRef.current) : next;
+    activeIdRef.current = resolved;
+    setActiveId(resolved);
   };
-
-  // Immediate activation — used by every discrete input (keyboard focus,
-  // blur, click, Escape, tap-outside). None of these are susceptible to the
-  // reflow mis-hover problem, so none of them need to wait.
-  const setActiveNow = (next: string | null | ((current: string | null) => string | null)) => {
-    clearHoverIntent();
-    setActiveId(next);
-  };
-
-  // Debounced activation — used only by mouse hover. Supersedes (cancels)
-  // any previously pending hover intent.
-  const scheduleActiveFromHover = (id: string) => {
-    clearHoverIntent();
-    hoverIntentTimerRef.current = window.setTimeout(() => setActiveId(id), HOVER_INTENT_MS);
-  };
-
-  useEffect(() => clearHoverIntent, []);
 
   useEffect(() => {
     const mq = window.matchMedia('(hover: none)');
@@ -141,16 +130,55 @@ export function CapabilityFamilies() {
     return () => mq.removeEventListener('change', onChange);
   }, []);
 
+  // Continuously verifies, on every mouse move anywhere on the page, that
+  // the cursor is still within the active card's own footprint (its card
+  // plus its floating panel — looked up fresh each time by stable DOM id,
+  // not a ref; see the comment above the component for why). A single
+  // persistent listener rather than one scoped to activeId: it already
+  // no-ops correctly when nothing is active, and reading activeIdRef fresh
+  // means it never needs to be torn down and rebuilt on every change.
+  useEffect(() => {
+    const onDocumentMouseMove = (event: MouseEvent) => {
+      if (isTouch) return;
+      const id = activeIdRef.current;
+      if (!id) return;
+      const cardRect = document.querySelector(`[data-capability-card="${id}"]`)?.getBoundingClientRect();
+      const panelRect = document.getElementById(`capability-detail-${id}`)?.getBoundingClientRect();
+      const rects = [cardRect, panelRect].filter((rect): rect is DOMRect => rect != null);
+      if (rects.length === 0) {
+        setActive(null);
+        return;
+      }
+      // A small tolerance on every edge: at the exact instant a card
+      // activates via a boundary crossing, this same mousemove event can
+      // fire with coordinates the browser's native hit-testing already
+      // resolved to the new card but that land a sub-pixel short of its
+      // measured `getBoundingClientRect()` (observed ~1.4px) — without
+      // slack here, that single event would both activate the card (via
+      // onMouseEnter) and immediately cancel it (via this check reading
+      // the same coordinates as "outside"), most reliably on straight
+      // vertical/horizontal crossings like the top-row-panel-to-bottom-row
+      // handoff, where every card shares identical boundary geometry.
+      const EDGE_TOLERANCE = 4;
+      const left = Math.min(...rects.map((rect) => rect.left)) - EDGE_TOLERANCE;
+      const right = Math.max(...rects.map((rect) => rect.right)) + EDGE_TOLERANCE;
+      const top = Math.min(...rects.map((rect) => rect.top)) - EDGE_TOLERANCE;
+      const bottom = Math.max(...rects.map((rect) => rect.bottom)) + EDGE_TOLERANCE;
+      if (event.clientX < left || event.clientX > right || event.clientY < top || event.clientY > bottom) {
+        setActive(null);
+      }
+    };
+    document.addEventListener('mousemove', onDocumentMouseMove);
+    return () => document.removeEventListener('mousemove', onDocumentMouseMove);
+  }, [isTouch]);
+
   // Touch devices have no hover: tapping a card expands it, tapping
   // anywhere else in the grid (or outside it) collapses it again.
   useEffect(() => {
     if (!isTouch || !activeId) return;
-    // Direct setActiveId, not setActiveNow: touch never leaves a pending
-    // hover-intent timer behind (only mouse hover schedules one), so there
-    // is nothing here that needs clearing.
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target as HTMLElement;
-      if (!target.closest('[data-capability-card]')) setActiveId(null);
+      if (!target.closest('[data-capability-card]')) setActive(null);
     };
     document.addEventListener('pointerdown', onPointerDown);
     return () => document.removeEventListener('pointerdown', onPointerDown);
@@ -168,8 +196,7 @@ export function CapabilityFamilies() {
       <MotionConfig reducedMotion="user">
         <div
           ref={gridRef}
-          className="grid items-start sm:grid-cols-2 lg:grid-cols-4 gap-5"
-          onMouseLeave={() => !isTouch && setActiveNow(null)}
+          className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5"
         >
           {CAPABILITY_FAMILIES.map((family) => {
             const isActive = activeId === family.id;
@@ -180,8 +207,9 @@ export function CapabilityFamilies() {
             return (
               <motion.div
                 key={family.id}
-                data-capability-card
-                onMouseEnter={() => !isTouch && scheduleActiveFromHover(family.id)}
+                data-capability-card={family.id}
+                className="relative"
+                onMouseEnter={() => !isTouch && setActive(family.id)}
                 onPointerDown={() => {
                   pointerActivatedRef.current = true;
                 }}
@@ -190,13 +218,13 @@ export function CapabilityFamilies() {
                     pointerActivatedRef.current = false;
                     return;
                   }
-                  setActiveNow(family.id);
+                  setActive(family.id);
                 }}
-                onBlur={() => setActiveNow((current) => (current === family.id ? null : current))}
-                onClick={() => isTouch && setActiveNow((current) => (current === family.id ? null : family.id))}
+                onBlur={() => setActive((current) => (current === family.id ? null : current))}
+                onClick={() => isTouch && setActive((current) => (current === family.id ? null : family.id))}
                 onKeyDown={(event) => {
                   if (event.key === 'Escape') {
-                    setActiveNow(null);
+                    setActive(null);
                     event.currentTarget.blur();
                   } else if (event.key === ' ' || event.key === 'Spacebar') {
                     // The card isn't a native button; without this, Space
@@ -210,19 +238,29 @@ export function CapabilityFamilies() {
                 aria-expanded={isActive}
                 aria-describedby={detailId}
               >
+                {/* The puck — the only element that ever transforms. Its
+                    resting layout box (icon + title, unconditional) never
+                    changes, so the outer hit target above never resizes
+                    either; only paint-time scale/translate/shadow move. */}
                 <motion.div
-                  animate={{ scale: isActive ? 1.04 : isDimmed ? 0.9 : 1, opacity: isDimmed ? 0.4 : 1 }}
+                  animate={{
+                    scale: isActive ? 1.08 : isDimmed ? 0.96 : 1,
+                    y: isActive ? -8 : 0,
+                    opacity: isDimmed ? 0.85 : 1,
+                  }}
                   transition={{ duration: isActive ? 0.32 : 0.25, ease: EASE }}
                   style={{
-                    zIndex: isActive ? 10 : 1,
+                    zIndex: isActive ? 20 : 1,
                     transitionProperty: 'border-color, box-shadow',
                     transitionDuration: '300ms',
                     transitionTimingFunction: 'cubic-bezier(0.33,1,0.68,1)',
                   }}
                   className={`relative rounded-2xl border bg-slate-50 p-6 outline-none cursor-default focus-visible:ring-2 focus-visible:ring-violet-400 ${
                     isActive
-                      ? 'border-violet-300 shadow-[0_20px_44px_rgba(139,92,246,0.2)]'
-                      : 'border-slate-200 shadow-[0_8px_24px_rgba(15,23,42,0.06)]'
+                      ? 'border-violet-300 shadow-[0_24px_48px_rgba(139,92,246,0.24)]'
+                      : isDimmed
+                        ? 'border-slate-200 shadow-[0_4px_12px_rgba(15,23,42,0.04)]'
+                        : 'border-slate-200 shadow-[0_8px_24px_rgba(15,23,42,0.06)]'
                   }`}
                 >
                   {isActive && (
@@ -245,26 +283,37 @@ export function CapabilityFamilies() {
                   </motion.div>
 
                   <h3 className="relative mt-4 text-base font-extrabold text-slate-900">{family.name}</h3>
+                </motion.div>
 
+                {/* The floating panel — never part of layout (position:
+                    absolute, outside the puck's own box) and never
+                    interactive (pointer-events: none), so it can visually
+                    extend over neighboring cards, Wallet/Dock-tooltip
+                    style, without ever blocking hover/focus/click on
+                    whatever is actually underneath it. Always mounted
+                    (harmless — it's out of flow either way) rather than
+                    conditionally via AnimatePresence: an exit animation
+                    that keeps the real, id-bearing panel around briefly
+                    after isActive flips false would otherwise collide with
+                    a separately-mounted accessible duplicate carrying the
+                    same id. One element, one id, always in the a11y tree;
+                    only its opacity communicates active state. */}
+                <motion.div
+                  id={detailId}
+                  initial={false}
+                  animate={{ opacity: isActive ? 1 : 0, y: isActive ? 0 : -6 }}
+                  transition={{ duration: isActive ? 0.24 : 0.16, ease: EASE }}
+                  style={{ zIndex: 20 }}
+                  className="pointer-events-none absolute inset-x-0 top-full mt-2 rounded-2xl border border-violet-200 bg-slate-50 p-5 shadow-[0_20px_44px_rgba(139,92,246,0.2)]"
+                >
+                  <p className="text-sm leading-relaxed text-slate-500">{family.summary}</p>
                   <motion.div
-                    id={detailId}
                     initial={false}
-                    animate={{ height: isActive ? 'auto' : 0, opacity: isActive ? 1 : 0 }}
-                    transition={{
-                      height: { duration: isActive ? 0.32 : 0.24, ease: EASE },
-                      opacity: { duration: 0.2, ease: EASE, delay: isActive ? 0.08 : 0 },
-                    }}
-                    className="relative overflow-hidden"
+                    animate={{ opacity: isActive ? 1 : 0, y: isActive ? 0 : 6 }}
+                    transition={{ duration: 0.2, ease: EASE, delay: isActive ? 0.1 : 0 }}
+                    className="mt-4"
                   >
-                    <p className="mt-3 text-sm leading-relaxed text-slate-500">{family.summary}</p>
-                    <motion.div
-                      initial={false}
-                      animate={{ opacity: isActive ? 1 : 0, y: isActive ? 0 : 6 }}
-                      transition={{ duration: 0.2, ease: EASE, delay: isActive ? 0.16 : 0 }}
-                      className="mt-4"
-                    >
-                      <StatusPill label={family.status} />
-                    </motion.div>
+                    <StatusPill label={family.status} />
                   </motion.div>
                 </motion.div>
               </motion.div>

--- a/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
+++ b/frontend/app/src/landing/protocol/CapabilityFamilies.tsx
@@ -1,24 +1,104 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion, MotionConfig } from 'framer-motion';
-import { CAPABILITY_FAMILIES } from './content';
-import { CAPABILITY_ICONS } from './CapabilityIcons';
+import { CAPABILITY_FAMILIES, type CapabilityFamily } from './content';
+import {
+  GovernanceCompatibilityIcon,
+  IdentityIcon,
+  IntegrityIcon,
+  InteroperabilityIcon,
+  LicensingIcon,
+  PortabilityIcon,
+  ProvenanceIcon,
+  VerifiabilityIcon,
+  type IconProps,
+} from './CapabilityIcons';
 import { SectionHeader, StatusPill } from '../enterprise/primitives';
+
+const CAPABILITY_ICONS: Record<CapabilityFamily['id'], (props: IconProps) => ReturnType<typeof IdentityIcon>> = {
+  identity: IdentityIcon,
+  integrity: IntegrityIcon,
+  provenance: ProvenanceIcon,
+  portability: PortabilityIcon,
+  interoperability: InteroperabilityIcon,
+  verifiability: VerifiabilityIcon,
+  licensing: LicensingIcon,
+  'governance-compatibility': GovernanceCompatibilityIcon,
+};
 
 // A single capability at rest shows only its icon and name — an object
 // worth exploring, not a wall of text. Hovering (or focusing, or tapping on
-// touch) brings one card forward: it widens, its description and status
-// unfold, and every sibling quietly steps back in scale and opacity. The
-// grid itself never reflows violently — only the active card's column span
-// changes, and Framer Motion's `layout` animates that resize and the
-// resulting sibling reflow as one continuous motion instead of a jump.
+// touch) brings one card forward: its description and status unfold in
+// place and it lifts slightly, while every sibling quietly steps back in
+// scale and opacity, and the row below it genuinely moves down to make
+// room — nothing is ever covered or unreachable.
+//
+// Five earlier versions got this wrong:
+//
+// V1 changed the hit target's own grid column span to grow the active
+// card (smoothed via Framer Motion's `layout` prop) — that moved the hit
+// target itself under the cursor mid-hover, producing false/stuck hover
+// states on some transitions.
+//
+// V2 tried to patch that by suppressing pointer events for the duration of
+// Framer's layout-animation callbacks, tracked with a start/complete
+// counter — but an interrupted animation can fire onLayoutAnimationStart
+// without its matching onLayoutAnimationComplete, so the counter could get
+// permanently stuck above zero, deadlocking hover for the rest of the
+// page's lifetime after the very first hover.
+//
+// V3 kept every card's own box a fixed width and let the description grow
+// in normal document flow, reasoning that CSS Grid's row-track sizing
+// would only ever grow the active row — but CSS Grid's default
+// `align-items: stretch` also stretches every *sibling* in that row to
+// match, so the row below still shifted out from under a hover mid-
+// transition (an admittedly rare miss, but a real one).
+//
+// V4 removed the description from normal flow entirely (an absolutely
+// positioned overlay on an invisible, never-resized spacer), which made
+// row-track sizing provably constant — but an overlay tall enough to hold
+// a full description is taller than one row, so it permanently painted
+// over — and made unreachable — whatever card sat in the same column one
+// row down. Not a transient mis-hover; a 100%-reproducible dead zone.
+//
+// V5 and V6 both went back to real, in-flow height growth with
+// `items-start` to stop sibling stretch — both correct, and kept below —
+// but each tried to guard the resulting row-shift with a pointer-events
+// lock (first grid-wide, then narrowed to non-active cards only). Both
+// leaned on browser hit-test behavior that turned out to be asymmetric:
+// Chromium fires a real mouseleave when an element is excluded from
+// hit-testing while the cursor sits on it, but does *not* fire a matching
+// mouseenter when it's later re-included under a still-stationary cursor.
+// V5's whole-grid lock excluded the active card itself, self-collapsing it
+// every ~415ms forever. V6's narrower per-card lock avoided that, but
+// re-armed on every incidental crossing (a fast or diagonal move can graze
+// an unrelated card's hit box en route to its real target) with no memory
+// of a lock already in flight, so a transition landing inside another
+// transition's lock window was silently dropped — the previous card stuck
+// open, the new target never activating (measured ~48% failure rate on
+// rapid diagonal transitions, and it also broke touch tap-switching, since
+// a tap's own blur-then-click sequence is exactly this kind of double
+// transition).
+//
+// This version stops trying to control hit-testing at all. Instead of
+// suppressing events during the window a reflow might cause a spurious
+// hover, it debounces *commitment*: a mouse-driven activation only takes
+// effect after it has been the single most recent hover event for
+// `HOVER_INTENT_MS` uninterrupted. A transient hover — a sibling sweeping
+// past a stationary cursor mid-reflow, or the cursor grazing an unrelated
+// card en route to its real target — gets superseded by the next real
+// hover event before its timer fires and never commits; a genuine,
+// sustained hover always outlasts the window and commits normally. This
+// needs no exemptions, no lock bookkeeping, and no assumption about which
+// direction the browser does or doesn't resynthesize events. Keyboard focus
+// and touch taps are unaffected — they're discrete, not continuous, so
+// they were never the pathway at risk and stay immediate.
 const EASE = [0.33, 1, 0.68, 1] as const;
+const HOVER_INTENT_MS = 100;
 
 export function CapabilityFamilies() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [isTouch, setIsTouch] = useState(false);
-  const [isReflowing, setIsReflowing] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
-  const reflowCount = useRef(0);
   // A tap focuses its element before its click fires. Without this flag the
   // resulting onFocus would set activeId, then the same tap's onClick would
   // read that as "already active" and immediately toggle it back off — so a
@@ -26,21 +106,32 @@ export function CapabilityFamilies() {
   // consumed by the very next onFocus, so real keyboard-driven focus (no
   // preceding pointerdown) is unaffected.
   const pointerActivatedRef = useRef(false);
+  // Tracks the one pending mouse-hover-intent timer, if any. A new mouse
+  // hover event (on any card) always clears whatever was previously
+  // pending before scheduling its own, so a superseded intent can never
+  // fire after the fact.
+  const hoverIntentTimerRef = useRef<number | undefined>(undefined);
 
-  // While the active card's column span animates, every sibling's bounding
-  // box moves too (Framer Motion's `layout` reflow). Chromium re-hit-tests
-  // elements that pass under a stationary cursor during that reflow and
-  // fires real mouseenter/mouseleave on whatever card ends up there, which
-  // can silently activate a card the pointer never intentionally entered.
-  // Suppressing pointer events for the reflow's duration prevents that.
-  const startReflow = () => {
-    reflowCount.current += 1;
-    setIsReflowing(true);
+  const clearHoverIntent = () => {
+    window.clearTimeout(hoverIntentTimerRef.current);
   };
-  const endReflow = () => {
-    reflowCount.current = Math.max(0, reflowCount.current - 1);
-    if (reflowCount.current === 0) setIsReflowing(false);
+
+  // Immediate activation — used by every discrete input (keyboard focus,
+  // blur, click, Escape, tap-outside). None of these are susceptible to the
+  // reflow mis-hover problem, so none of them need to wait.
+  const setActiveNow = (next: string | null | ((current: string | null) => string | null)) => {
+    clearHoverIntent();
+    setActiveId(next);
   };
+
+  // Debounced activation — used only by mouse hover. Supersedes (cancels)
+  // any previously pending hover intent.
+  const scheduleActiveFromHover = (id: string) => {
+    clearHoverIntent();
+    hoverIntentTimerRef.current = window.setTimeout(() => setActiveId(id), HOVER_INTENT_MS);
+  };
+
+  useEffect(() => clearHoverIntent, []);
 
   useEffect(() => {
     const mq = window.matchMedia('(hover: none)');
@@ -54,6 +145,9 @@ export function CapabilityFamilies() {
   // anywhere else in the grid (or outside it) collapses it again.
   useEffect(() => {
     if (!isTouch || !activeId) return;
+    // Direct setActiveId, not setActiveNow: touch never leaves a pending
+    // hover-intent timer behind (only mouse hover schedules one), so there
+    // is nothing here that needs clearing.
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target as HTMLElement;
       if (!target.closest('[data-capability-card]')) setActiveId(null);
@@ -74,9 +168,8 @@ export function CapabilityFamilies() {
       <MotionConfig reducedMotion="user">
         <div
           ref={gridRef}
-          className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5"
-          style={{ pointerEvents: isReflowing ? 'none' : 'auto' }}
-          onMouseLeave={() => !isTouch && setActiveId(null)}
+          className="grid items-start sm:grid-cols-2 lg:grid-cols-4 gap-5"
+          onMouseLeave={() => !isTouch && setActiveNow(null)}
         >
           {CAPABILITY_FAMILIES.map((family) => {
             const isActive = activeId === family.id;
@@ -87,13 +180,8 @@ export function CapabilityFamilies() {
             return (
               <motion.div
                 key={family.id}
-                layout
                 data-capability-card
-                transition={{ layout: { duration: isActive ? 0.32 : 0.25, ease: EASE } }}
-                onLayoutAnimationStart={startReflow}
-                onLayoutAnimationComplete={endReflow}
-                className={isActive ? 'sm:col-span-2 lg:col-span-2' : undefined}
-                onMouseEnter={() => !isTouch && setActiveId(family.id)}
+                onMouseEnter={() => !isTouch && scheduleActiveFromHover(family.id)}
                 onPointerDown={() => {
                   pointerActivatedRef.current = true;
                 }}
@@ -102,13 +190,13 @@ export function CapabilityFamilies() {
                     pointerActivatedRef.current = false;
                     return;
                   }
-                  setActiveId(family.id);
+                  setActiveNow(family.id);
                 }}
-                onBlur={() => setActiveId((current) => (current === family.id ? null : current))}
-                onClick={() => isTouch && setActiveId((current) => (current === family.id ? null : family.id))}
+                onBlur={() => setActiveNow((current) => (current === family.id ? null : current))}
+                onClick={() => isTouch && setActiveNow((current) => (current === family.id ? null : family.id))}
                 onKeyDown={(event) => {
                   if (event.key === 'Escape') {
-                    setActiveId(null);
+                    setActiveNow(null);
                     event.currentTarget.blur();
                   } else if (event.key === ' ' || event.key === 'Spacebar') {
                     // The card isn't a native button; without this, Space
@@ -123,14 +211,19 @@ export function CapabilityFamilies() {
                 aria-describedby={detailId}
               >
                 <motion.div
-                  animate={{ scale: isDimmed ? 0.9 : 1, opacity: isDimmed ? 0.4 : 1 }}
-                  transition={{ duration: 0.25, ease: EASE }}
-                  className={`relative h-full rounded-2xl border bg-slate-50 p-6 outline-none cursor-default focus-visible:ring-2 focus-visible:ring-violet-400 ${
+                  animate={{ scale: isActive ? 1.04 : isDimmed ? 0.9 : 1, opacity: isDimmed ? 0.4 : 1 }}
+                  transition={{ duration: isActive ? 0.32 : 0.25, ease: EASE }}
+                  style={{
+                    zIndex: isActive ? 10 : 1,
+                    transitionProperty: 'border-color, box-shadow',
+                    transitionDuration: '300ms',
+                    transitionTimingFunction: 'cubic-bezier(0.33,1,0.68,1)',
+                  }}
+                  className={`relative rounded-2xl border bg-slate-50 p-6 outline-none cursor-default focus-visible:ring-2 focus-visible:ring-violet-400 ${
                     isActive
                       ? 'border-violet-300 shadow-[0_20px_44px_rgba(139,92,246,0.2)]'
                       : 'border-slate-200 shadow-[0_8px_24px_rgba(15,23,42,0.06)]'
                   }`}
-                  style={{ transitionProperty: 'border-color, box-shadow', transitionDuration: '300ms', transitionTimingFunction: 'cubic-bezier(0.33,1,0.68,1)' }}
                 >
                   {isActive && (
                     <motion.div

--- a/frontend/app/src/landing/protocol/CapabilityIcons.tsx
+++ b/frontend/app/src/landing/protocol/CapabilityIcons.tsx
@@ -3,10 +3,9 @@
 // ../enterprise/primitives.tsx — rather than illustrative, so the resting
 // grid reads as a set of precise sculptural marks, not clip-art.
 
-import type { ReactElement, SVGProps } from 'react';
-import type { CapabilityFamily } from './content';
+import type { SVGProps } from 'react';
 
-type IconProps = SVGProps<SVGSVGElement>;
+export type IconProps = SVGProps<SVGSVGElement>;
 
 const base = {
   viewBox: '0 0 24 24',
@@ -17,7 +16,7 @@ const base = {
   strokeLinejoin: 'round' as const,
 };
 
-function IdentityIcon(props: IconProps) {
+export function IdentityIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <circle cx="12" cy="8.5" r="3.25" />
@@ -26,7 +25,7 @@ function IdentityIcon(props: IconProps) {
   );
 }
 
-function IntegrityIcon(props: IconProps) {
+export function IntegrityIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <path d="M12 3.5l6.5 2.6v5.1c0 4.6-2.9 7.7-6.5 9.3-3.6-1.6-6.5-4.7-6.5-9.3V6.1L12 3.5z" />
@@ -35,7 +34,7 @@ function IntegrityIcon(props: IconProps) {
   );
 }
 
-function ProvenanceIcon(props: IconProps) {
+export function ProvenanceIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <path d="M6.5 3.5h7l4 4v13a1 1 0 01-1 1h-10a1 1 0 01-1-1v-16a1 1 0 011-1z" />
@@ -45,7 +44,7 @@ function ProvenanceIcon(props: IconProps) {
   );
 }
 
-function PortabilityIcon(props: IconProps) {
+export function PortabilityIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <path d="M4.5 8.5h15v11a1 1 0 01-1 1h-13a1 1 0 01-1-1v-11z" />
@@ -56,7 +55,7 @@ function PortabilityIcon(props: IconProps) {
   );
 }
 
-function InteroperabilityIcon(props: IconProps) {
+export function InteroperabilityIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <circle cx="9.25" cy="12" r="5" />
@@ -65,7 +64,7 @@ function InteroperabilityIcon(props: IconProps) {
   );
 }
 
-function VerifiabilityIcon(props: IconProps) {
+export function VerifiabilityIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <circle cx="12" cy="12" r="8.5" />
@@ -74,7 +73,7 @@ function VerifiabilityIcon(props: IconProps) {
   );
 }
 
-function LicensingIcon(props: IconProps) {
+export function LicensingIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <path d="M3.5 12V4.5a1 1 0 011-1h7.5l8.5 8.5-8.5 8.5-8.5-8.5z" />
@@ -83,7 +82,7 @@ function LicensingIcon(props: IconProps) {
   );
 }
 
-function GovernanceCompatibilityIcon(props: IconProps) {
+export function GovernanceCompatibilityIcon(props: IconProps) {
   return (
     <svg {...base} {...props}>
       <path d="M12 3.5v17" />
@@ -94,14 +93,3 @@ function GovernanceCompatibilityIcon(props: IconProps) {
     </svg>
   );
 }
-
-export const CAPABILITY_ICONS: Record<CapabilityFamily['id'], (props: IconProps) => ReactElement> = {
-  identity: IdentityIcon,
-  integrity: IntegrityIcon,
-  provenance: ProvenanceIcon,
-  portability: PortabilityIcon,
-  interoperability: InteroperabilityIcon,
-  verifiability: VerifiabilityIcon,
-  licensing: LicensingIcon,
-  'governance-compatibility': GovernanceCompatibilityIcon,
-};


### PR DESCRIPTION
## Summary

Rebuilds the Capability Explorer's hover interaction on a different architecture: the CSS Grid's own geometry (row heights, column widths, every card's position) never changes, regardless of which card is active. Hovering lifts a card into its own layer purely via `transform`/`opacity`/`box-shadow` (scale up, a slight rise, a restrained amethyst glow) while siblings step back in scale and opacity, and the description unfolds in a floating panel attached to the card rather than participating in layout — no grid reflow, no layout animation, no pointer locking. Matches the macOS Dock / Apple Wallet contextual-panel model.

- Cards at rest show only icon + title; the grid's row/column tracks are provably constant across every interaction state.
- The floating description panel is `position: absolute` and `pointer-events: none`, so it can visually extend over neighboring cards without ever blocking their own hover/focus/click.
- A persistent `document`-level `mousemove` listener continuously verifies the cursor is still within the active card's own footprint (card + panel), closing it the moment it's genuinely elsewhere — robust to however far or long the cursor travels afterward.
- Touch and keyboard activation stay on their own immediate paths, independent of the mouse-hover mechanics above.
- The panel is always mounted (opacity-driven) so its `id` is never briefly duplicated by a separate accessible fallback during a transition, and `aria-describedby` always resolves to real, queryable text.

## Notes on the fix history

Getting the "stay open while the cursor is on the panel, without ever blocking whatever it visually overlaps" behavior right took several iterations, each one caught by adversarial Playwright testing:

- A React ref meant to track the active panel's DOM node never attached through Framer Motion's own ref-forwarding on an always-mounted `motion.div` (tried both a plain-object and a callback ref) — replaced with a direct DOM lookup by stable id.
- Checking containment once via the grid's own one-shot `mouseleave` event left a card stuck open indefinitely once the cursor moved further away, since no further event ever reached the grid — replaced with the continuous `mousemove` tracker.
- That tracker's source of truth for "which card is active" was only updated inside React's deferred `setState` updater, which raced against the listener's own non-React event timing and could cancel a same-tick activation — the ref is now updated synchronously in plain JS at the call site.
- The same-tick race also showed up at exact card boundaries, where native hit-testing and a strict `getBoundingClientRect()` comparison could disagree by roughly a pixel — a small edge tolerance absorbs that mismatch.

## Test plan

- [x] `npm run build` (tsc + vite build) — clean, only pre-existing unrelated workspace errors remain
- [x] `npx eslint` on both changed files — clean
- [x] Adversarial Playwright verification across the full interaction surface: rapid/diagonal transition stress tests, panel-to-covered-card passthrough, stationary-hover stability, the bottom-row stuck-open case, keyboard and touch parity, accessibility (single stable id, always-queryable description), grid-geometry invariance, and no horizontal overflow across breakpoints (1440/1024/768/390)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgR5LoYZrRBsr3vUBbfREX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgR5LoYZrRBsr3vUBbfREX)_