### PR TITLE
Refine File-to-Asset card density and scale central mineral

### DIFF
--- a/frontend/app/src/landing/protocol/FileToAsset.tsx
+++ b/frontend/app/src/landing/protocol/FileToAsset.tsx
@@ -38,12 +38,12 @@ export function FileToAsset() {
           animate={reduceMotion ? undefined : { y: [0, -2, 0] }}
           transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
         >
-          <Card className="p-6 md:p-7">
-            <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500 font-mono">A File</p>
-            <p className="mt-2 font-mono text-slate-700 text-sm">photo.jpg</p>
-            <ul className="mt-5 space-y-2.5">
+          <Card className="flex flex-col justify-center p-6 md:h-60 md:p-5">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500 font-mono">A File</p>
+            <p className="mt-2 font-mono text-slate-700 text-base leading-5">photo.jpg</p>
+            <ul className="mt-4 space-y-1.5">
               {FILE_TRAITS.map((trait) => (
-                <li key={trait} className="flex items-center gap-2.5 text-sm text-slate-500">
+                <li key={trait} className="flex items-center gap-2.5 text-[15px] leading-5 text-slate-500">
                   <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-slate-300" />
                   {trait}
                 </li>
@@ -54,13 +54,13 @@ export function FileToAsset() {
 
         <TransformationCore phase={phase} reduceMotion={reduceMotion} />
 
-        <div className={`rounded-2xl border ${m.border} ${m.soft} p-6 md:p-7`}>
-          <p className={`text-[11px] uppercase tracking-[0.2em] font-mono ${m.text}`}>
+        <div className={`flex flex-col justify-center rounded-2xl border ${m.border} ${m.soft} p-6 md:h-60 md:p-5`}>
+          <p className={`text-xs uppercase tracking-[0.2em] font-mono ${m.text}`}>
             AOC-Compatible Digital Asset
           </p>
-          <p className="mt-2 font-mono text-slate-700 text-sm">photo.jpg + protocol context</p>
+          <p className="mt-2 font-mono text-slate-700 text-base leading-5">photo.jpg + protocol context</p>
           <motion.ul
-            className="mt-5 space-y-2.5"
+            className="mt-4 space-y-1.5"
             variants={traitListVariants}
             animate={traitsRevealed ? 'visible' : 'hidden'}
             initial={reduceMotion ? false : 'hidden'}
@@ -68,7 +68,7 @@ export function FileToAsset() {
             {ASSET_TRAITS.map((trait) => (
               <motion.li
                 key={trait}
-                className="flex items-center gap-2.5 text-sm text-slate-900"
+                className="flex items-center gap-2.5 text-[15px] leading-5 text-slate-900"
                 variants={traitItemVariants}
               >
                 <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${m.dot}`} />

--- a/frontend/app/src/landing/protocol/TransformationCore.tsx
+++ b/frontend/app/src/landing/protocol/TransformationCore.tsx
@@ -295,9 +295,9 @@ export function TransformationCore({ phase, reduceMotion = false }: { phase: Tra
   // state rather than a slowed-down version of the sequence.
   if (reduceMotion) {
     return (
-      <div className="relative mx-auto flex h-28 w-28 items-center justify-center md:h-32 md:w-32" role="presentation" aria-hidden>
-        <div className="absolute h-20 w-20 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.5),transparent_72%)] opacity-20 blur-xl" />
-        <svg viewBox="0 0 100 100" className="relative h-14 w-14 md:h-16 md:w-16">
+      <div className="relative mx-auto flex h-32 w-32 items-center justify-center md:h-[9.5rem] md:w-[9.5rem]" role="presentation" aria-hidden>
+        <div className="absolute h-24 w-24 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.5),transparent_72%)] opacity-20 blur-xl" />
+        <svg viewBox="0 0 100 100" className="relative h-16 w-16 md:h-[4.75rem] md:w-[4.75rem]">
           {FACETS.map((facet, i) => (
             <polygon key={i} points={facet.points} fill="#8b5cf6" stroke="#ede9fe" strokeOpacity={0.35} strokeWidth={0.6} opacity={facet.opacity} />
           ))}
@@ -308,12 +308,12 @@ export function TransformationCore({ phase, reduceMotion = false }: { phase: Tra
 
   return (
     <div
-      className="relative mx-auto flex h-28 w-28 items-center justify-center md:h-32 md:w-32"
+      className="relative mx-auto flex h-32 w-32 items-center justify-center md:h-[9.5rem] md:w-[9.5rem]"
       role="presentation"
       aria-hidden
     >
       <motion.div
-        className="absolute h-20 w-20 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.5),transparent_72%)] blur-xl"
+        className="absolute h-24 w-24 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.5),transparent_72%)] blur-xl"
         variants={glowVariants}
         animate={phase}
         initial="idle"
@@ -325,7 +325,7 @@ export function TransformationCore({ phase, reduceMotion = false }: { phase: Tra
 
       <motion.svg
         viewBox="0 0 100 100"
-        className="relative h-14 w-14 md:h-16 md:w-16"
+        className="relative h-16 w-16 md:h-[4.75rem] md:w-[4.75rem]"
         variants={gemVariants}
         animate={phase}
         initial="idle"


### PR DESCRIPTION
### Motivation

- Reduce excessive vertical whitespace in the "From File to Digital Asset" comparison cards so the section reads denser and more intentional.
- Optically balance the left card (3 traits) and right card (6 capabilities) without changing copy, colors, borders, or overall layout.
- Give the central amethyst mineral slightly more presence so it better communicates the transformation from file → AOC-compatible asset.

### Description

- Adjusted the two card surfaces in `frontend/app/src/landing/protocol/FileToAsset.tsx` to use a centered column layout and identical desktop outer height via `md:h-60`, reduced desktop padding to `md:p-5`, and tightened vertical spacing (`mt-5` → `mt-4`, `space-y-2.5` → `space-y-1.5`).
- Increased internal typography: eyebrow labels to `text-xs`, primary file lines to `text-base` with `leading-5`, and list items to `text-[15px]` with balanced `leading-5` so elements read larger while preserving the type system and colors.
- Scaled the central mineral in `frontend/app/src/landing/protocol/TransformationCore.tsx` by ~15–20% by increasing container and glow sizes (`h-28`/`w-28` → `h-32`/`w-32`, `h-20` → `h-24` for glow) and enlarging the SVG (`h-14` → `h-16` and `md:h-16` → `md:h-[4.75rem]`), while keeping the mineral artwork and animation behavior unchanged.
- Preserved all required constraints: section headline, descriptive paragraph, card copy, capability names, colors, border treatment, general typography family/tokens, link treatment, and responsive behavior; only minimal classname changes were introduced in the two files below.

Files changed

- `frontend/app/src/landing/protocol/FileToAsset.tsx`
- `frontend/app/src/landing/protocol/TransformationCore.tsx`

### Testing

- Ran the production build with `npm run build`; build completed successfully (Vite finished with standard chunk-size warnings). 
- Ran the test suite with `npm run test -- --run`; the frontend tests executed and the relevant test file set passed: `1 test file` with `11 tests` all green.
- Ran targeted linting (`npx eslint`) against the modified files and no style errors were reported for those files. 
- Ran repository-wide lint (`npm run lint`), which remains blocked by pre-existing unrelated lint errors in other parts of the codebase (11 errors in unrelated files), so the global lint step was not fully green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74f151e7f483258280bc771deafb81)