### PR TITLE
Constrain file-to-asset comparison width to 34rem on desktop

### DIFF
--- a/frontend/app/src/landing/protocol/FileToAsset.tsx
+++ b/frontend/app/src/landing/protocol/FileToAsset.tsx
@@ -33,7 +33,7 @@ export function FileToAsset() {
         mineral="amethyst"
       />
 
-      <div ref={stageRef} className="grid md:grid-cols-[1fr_auto_1fr] gap-2 md:gap-0 items-center">
+      <div ref={stageRef} className="grid md:grid-cols-[minmax(0,34rem)_auto_minmax(0,34rem)] xl:grid-cols-[34rem_auto_34rem] md:justify-center gap-2 md:gap-0 items-center">
         <motion.div
           animate={reduceMotion ? undefined : { y: [0, -2, 0] }}
           transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}


### PR DESCRIPTION
### Motivation
- Reduce the excessive horizontal footprint of the file-to-asset comparison cards on desktop so both cards sit compactly side-by-side with the mineral acting as a visual bridge, while keeping the previous height/typography refinements intact.

### Description
- Replace the fluid `md:grid-cols-[1fr_auto_1fr]` with `md:grid-cols-[minmax(0,34rem)_auto_minmax(0,34rem)] xl:grid-cols-[34rem_auto_34rem]` and add `md:justify-center` so the card → mineral → card composition is centered and each desktop card is constrained to `34rem` (~544px) while preserving `md:h-60`, the tightened internal spacing, typography, mineral scale, colors, borders, shadows and animation.

### Testing
- Ran `npx eslint src/landing/protocol/FileToAsset.tsx` (the touched file passes), ran `npm test -- --run` (Vitest — 11 tests passed), and ran `npm run build` (TypeScript + Vite production build completed successfully); a repository-wide `npm run lint` surfaced pre-existing unrelated errors but did not affect the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74fe2438808325a0be5d5d6fd9e93b)