### PR TITLE
Reduce file-to-asset card columns from 34rem to 26rem

### DIFF
--- a/frontend/app/src/landing/protocol/FileToAsset.tsx
+++ b/frontend/app/src/landing/protocol/FileToAsset.tsx
@@ -33,7 +33,7 @@ export function FileToAsset() {
         mineral="amethyst"
       />
 
-      <div ref={stageRef} className="grid md:grid-cols-[minmax(0,34rem)_auto_minmax(0,34rem)] xl:grid-cols-[34rem_auto_34rem] md:justify-center gap-2 md:gap-0 items-center">
+      <div ref={stageRef} className="grid md:grid-cols-[minmax(0,26rem)_auto_minmax(0,26rem)] xl:grid-cols-[26rem_auto_26rem] md:justify-center gap-2 md:gap-0 items-center">
         <motion.div
           animate={reduceMotion ? undefined : { y: [0, -2, 0] }}
           transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}


### PR DESCRIPTION
### Motivation
- Make the desktop card composition substantially more compact by moving the constrained card columns from `34rem` to `26rem` so each card becomes approximately `416px × 240px` while preserving the visual composition, mineral placement, and all internal styling and animations.

### Description
- Update the grid template in `frontend/app/src/landing/protocol/FileToAsset.tsx` to replace `34rem` with `26rem` for the `md` and `xl` constrained columns (now `md:grid-cols-[minmax(0,26rem)_auto_minmax(0,26rem)] xl:grid-cols-[26rem_auto_26rem]`) and leave `md:h-60` and all other markup/styles unchanged.

### Testing
- Ran `npx eslint src/landing/protocol/FileToAsset.tsx` (passed) and `npm run build` (Vite build succeeded), confirmed the committed change and that the desktop columns are `26rem = 416px`; repository-wide `npm run lint` still reports unrelated pre-existing lint errors so a full repo lint did not pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7502b915e4832594290a702a06f3fd)