### PR TITLE
Refine file-to-asset illustration: retro photo frame + minimal stick-figure SVG

### DIFF
--- a/frontend/app/src/landing/protocol/FileToAsset.tsx
+++ b/frontend/app/src/landing/protocol/FileToAsset.tsx
@@ -1,11 +1,10 @@
 import { useRef } from 'react';
 import { motion, type Variants } from 'framer-motion';
-import { Card, SectionHeader } from '../enterprise/primitives';
+import { SectionHeader } from '../enterprise/primitives';
 import { MINERALS } from '../enterprise/minerals';
 import { TransformationCore } from './TransformationCore';
 import { useTransformationPhase } from './useTransformationPhase';
 
-const FILE_TRAITS = ['Content', 'Format', 'Location'];
 const ASSET_TRAITS = ['Identity', 'Integrity', 'Provenance', 'Capabilities', 'References', 'Portability'];
 const m = MINERALS.amethyst;
 
@@ -18,6 +17,42 @@ const traitItemVariants: Variants = {
   hidden: { opacity: 0, x: -6 },
   visible: { opacity: 1, x: 0, transition: { duration: 0.32, ease: [0.22, 1, 0.36, 1] } },
 };
+
+function RetroFilePortrait() {
+  return (
+    <figure className="w-52 rotate-[-1deg] border-2 border-slate-950 bg-white p-2.5 pb-4 shadow-[5px_6px_0_rgba(15,23,42,0.12)] md:w-56">
+      <div className="flex aspect-[4/5] items-center justify-center border border-slate-950 bg-white">
+        <svg
+          aria-label="Minimal smiling stick figure with messy hair"
+          className="h-[88%] w-[88%] text-slate-950"
+          viewBox="0 0 180 220"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="4"
+          >
+            <path d="M53 62C54 36 72 20 94 21C119 22 132 40 128 65C124 88 110 99 88 97C65 95 52 83 53 62Z" />
+            <path d="M70 54L70 66M108 53L107 66" />
+            <path d="M68 74C75 87 99 91 112 74" />
+            <path d="M70 25L61 10M78 22L75 4M87 21L89 2M97 21L105 5M105 24L120 11" />
+            <path d="M90 98L90 158M89 112L49 151M91 112L129 151" />
+            <path d="M49 151L36 151M49 151L43 164M49 151L55 162" />
+            <path d="M129 151L142 151M129 151L123 164M129 151L136 162" />
+            <path d="M90 158L68 202M90 158L113 202" />
+            <path d="M68 202C61 207 53 207 48 204M113 202C120 207 129 206 134 202" />
+          </g>
+        </svg>
+      </div>
+      <figcaption className="pt-3 text-center font-mono text-[11px] uppercase tracking-[0.18em] text-slate-700">
+        photo.jpg
+      </figcaption>
+    </figure>
+  );
+}
 
 export function FileToAsset() {
   const stageRef = useRef<HTMLDivElement>(null);
@@ -33,23 +68,13 @@ export function FileToAsset() {
         mineral="amethyst"
       />
 
-      <div ref={stageRef} className="grid md:grid-cols-[minmax(0,26rem)_auto_minmax(0,26rem)] xl:grid-cols-[26rem_auto_26rem] md:justify-center gap-2 md:gap-0 items-center">
+      <div ref={stageRef} className="grid md:grid-cols-[18rem_auto_minmax(0,26rem)] xl:grid-cols-[18rem_auto_26rem] md:justify-center gap-6 md:gap-0 items-center">
         <motion.div
+          className="flex justify-center"
           animate={reduceMotion ? undefined : { y: [0, -2, 0] }}
           transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
         >
-          <Card className="flex flex-col justify-center p-6 md:h-60 md:p-5">
-            <p className="text-xs uppercase tracking-[0.2em] text-slate-500 font-mono">A File</p>
-            <p className="mt-2 font-mono text-slate-700 text-base leading-5">photo.jpg</p>
-            <ul className="mt-4 space-y-1.5">
-              {FILE_TRAITS.map((trait) => (
-                <li key={trait} className="flex items-center gap-2.5 text-[15px] leading-5 text-slate-500">
-                  <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-slate-300" />
-                  {trait}
-                </li>
-              ))}
-            </ul>
-          </Card>
+          <RetroFilePortrait />
         </motion.div>
 
         <TransformationCore phase={phase} reduceMotion={reduceMotion} />


### PR DESCRIPTION
### Motivation

- The left file card was visually dominating the comparison layout and needed to be smaller and more photo-like to match the intended retro/photo metaphor.
- A compact, bordered white frame with a minimal cartoon inside better matches the provided reference and keeps the left visual from competing with the asset card.

### Description

- Replaced the wide left `Card` visual with a new `RetroFilePortrait` React component that renders a white, black-framed, slightly-rotated photo-style box containing an inline SVG minimal smiling stick-figure with messy hair.  
- Removed the unused `Card` import and `FILE_TRAITS` list and swapped the left column content to render `<RetroFilePortrait />` in `FileToAsset`.  
- Rebalanced the grid by changing the left column width from `26rem` to `18rem` and added centering classes so the left visual no longer dominates the layout.  
- Kept the right-hand AOC-compatible asset card and the `TransformationCore` unchanged except for layout adjustments; styling uses existing tokens from `MINERALS.amethyst`.

### Testing

- Ran `npm run build` in `frontend/app` and the production build completed successfully.  
- Ran `npx eslint src/landing/protocol/FileToAsset.tsx` and the modified file passed ESLint in isolation.  
- Ran `npm run test -- --run` and the Vitest suite executed, with the relevant test file passing (`11 tests passed`).  
- Ran `npm run lint` which reported pre-existing lint errors in unrelated files, but these errors are outside the changed file and did not block the local build or the modified file lint check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a750c2dd79c8325b1150794ec33bd6b)