### PR TITLE
Refinar firma y espaciado en AssetComposition (guiño, ojo punto, flecha al borde, menor padding)

### DIFF
--- a/frontend/app/src/landing/protocol/AssetComposition.tsx
+++ b/frontend/app/src/landing/protocol/AssetComposition.tsx
@@ -41,7 +41,7 @@ import {
 // the same fabric, rather than forcing illegibly small type into the shape.
 export function AssetComposition() {
   return (
-    <section id="creation" className="relative scroll-mt-16 overflow-hidden border-t border-slate-200 py-24 md:py-32 lg:py-40">
+    <section id="creation" className="relative scroll-mt-16 overflow-hidden border-t border-slate-200 py-16 md:py-20 lg:py-24">
       <FabricSurface />
 
       <div className="relative z-10 mx-auto max-w-6xl px-6">
@@ -99,7 +99,7 @@ export function AssetComposition() {
               viewBox="0 0 280 92"
               aria-hidden="true"
               role="presentation"
-              className="pointer-events-none mx-auto -mt-3 block h-auto w-[210px] max-w-full overflow-visible text-slate-500/65 sm:-mt-7 sm:mr-1 sm:ml-auto sm:w-[245px] md:-mt-9 md:mr-3 md:w-[270px]"
+              className="pointer-events-none mx-auto -mt-3 block h-auto w-[210px] max-w-full overflow-visible text-slate-500/65 sm:-mt-24 sm:mr-1 sm:ml-auto sm:w-[245px] md:-mt-30 md:mr-3 md:w-[270px] lg:-mt-[9.5rem]"
             >
               <g className="hidden sm:block" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M10 8 C 38 11, 45 37, 77 38 C 94 39, 105 32, 116 25" strokeWidth="1.7" />
@@ -118,10 +118,10 @@ export function AssetComposition() {
                 Sovereignty
               </text>
               <path d="M67 76 C 120 83, 184 78, 222 70" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.1" opacity="0.62" />
-              <g fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="1.5">
-                <path d="M238 52 l5 1" />
-                <path d="M252 51 q3 3 0 6" />
-                <path d="M240 62 q7 7 14 0" />
+              <g stroke="currentColor" strokeLinecap="round" strokeWidth="1.5">
+                <circle cx="241" cy="53" r="1.8" fill="currentColor" stroke="none" />
+                <path d="M252 51 q3 3 0 6" fill="none" />
+                <path d="M240 62 q7 7 14 0" fill="none" />
               </g>
             </svg>
           </div>


### PR DESCRIPTION
### Motivation

- Ajustar la firma decorativa para que el smiley muestre un guiño en un ojo y el otro ojo sea un punto, y mantener la sonrisa manuscrita como elemento puramente decorativo.
- Hacer que el trazo/flecha de la firma empiece exactamente en el borde de la pieza del rompecabezas para mejorar la integración visual entre la firma y la silueta.
- Reducir el espacio vertical vacío de la sección para compactar el bloque y mejorar la relación visual con el contenido adyacente.

### Description

- Modificado `frontend/app/src/landing/protocol/AssetComposition.tsx` para reducir el padding vertical de la sección cambiando `py-24 md:py-32 lg:py-40` a `py-16 md:py-20 lg:py-24`.
- Ajustadas las clases de la firma SVG para acercar la firma al puzzle en distintos breakpoints modificando los valores `sm:-mt-*`, `md:-mt-*` y añadiendo `lg:-mt-[9.5rem]` en la propiedad `className` del SVG.
- Reemplazado el trazo que representaba el ojo por un elemento `<circle>` y normalizados los `path` de la firma con `fill="none"` para que el segundo ojo aparezca como un punto y el guiño se mantenga, y eliminada la propiedad de `fill` del `g` contenedor para controlar llenados individualmente.
- Los cambios preservan la intención decorativa y el marcado accesible existente (el SVG continúa siendo `aria-hidden`/presentational).

### Testing

- Ejecutado `npm run typecheck` y la verificación de tipos concluyó correctamente.
- Ejecutado `npm run build` (incluye `vite build`) y la compilación produjo `dist/` correctamente aunque con un aviso de chunks grandes, sin errores de build.
- Ejecutado `git diff --check` para comprobar problemas de formato y errores de pared y no se reportaron problemas.
- Ejecutado `git status --short` para verificar el estado del árbol y confirmó los cambios preparados en el repositorio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a756aabea988325b19d7b6055b5a5dc)