### PR TITLE
Lower composition sign-off

### DIFF
--- a/frontend/app/src/landing/protocol/AssetComposition.tsx
+++ b/frontend/app/src/landing/protocol/AssetComposition.tsx
@@ -99,7 +99,7 @@ export function AssetComposition() {
               viewBox="0 0 280 92"
               aria-hidden="true"
               role="presentation"
-              className="pointer-events-none mx-auto -mt-3 block h-auto w-[210px] max-w-full overflow-visible text-slate-500/65 sm:-mt-24 sm:mr-1 sm:ml-auto sm:w-[245px] md:-mt-30 md:mr-3 md:w-[270px] lg:-mt-[9.5rem]"
+              className="pointer-events-none mx-auto -mt-3 block h-auto w-[210px] max-w-full overflow-visible text-slate-500/65 sm:-mt-12 sm:mr-1 sm:ml-auto sm:w-[245px] md:-mt-18 md:mr-3 md:w-[270px] lg:-mt-[6.5rem]"
             >
               <g className="hidden sm:block" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M10 8 C 38 11, 45 37, 77 38 C 94 39, 105 32, 116 25" strokeWidth="1.7" />


### PR DESCRIPTION
### Motivation
- Reduce visual overlap between the decorative SVG sign-off (arrow + script text) and the underlying content by lowering the sign-off on small/medium/large breakpoints so it no longer obstructs background copy.

### Description
- Adjusted the SVG container `className` in `frontend/app/src/landing/protocol/AssetComposition.tsx` to reduce the top offset on `sm`, `md`, and `lg` breakpoints (`sm:-mt-12`, `md:-mt-18`, `lg:-mt-[6.5rem]`) so the sign-off sits lower and interferes less with background text.

### Testing
- `npm run build` in `frontend/app` completed successfully (exit 0). 
- `npm test -- --run src/landing/protocol` ran the protocol tests and all tests passed (`11` tests). 
- `npx eslint src/landing/protocol/AssetComposition.tsx` reported no issues for the modified file, while a full `npm run lint -- --quiet` exposed preexisting lint errors elsewhere in the app that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a756ca8c6108325b7875bc0d3a9f424)