### PR TITLE
Add decorative crystal-cluster SVG to Protocol ↔ Enterprise comparison cards

### DIFF
--- a/frontend/app/src/landing/DocsPage.test.tsx
+++ b/frontend/app/src/landing/DocsPage.test.tsx
@@ -23,4 +23,13 @@ describe('public Protocol developer journey', () => {
     expect(links.at(-1)).toHaveTextContent('Explore AOC Enterprise');
     expect(links.at(-1)).toHaveAttribute('href', '/?view=enterprise');
   });
+
+  it('keeps both product crystal clusters decorative', () => {
+    const { container } = render(<ProtocolToEnterprise />);
+    const crystals = container.querySelectorAll('svg[aria-hidden="true"]');
+
+    expect(crystals).toHaveLength(2);
+    expect(within(container).getByText('Identity')).toBeInTheDocument();
+    expect(within(container).getByText('Governance')).toBeInTheDocument();
+  });
 });

--- a/frontend/app/src/landing/protocol/CrystalCluster.tsx
+++ b/frontend/app/src/landing/protocol/CrystalCluster.tsx
@@ -1,0 +1,107 @@
+import { useId } from 'react';
+
+type CrystalClusterProps = {
+  variant: 'protocol' | 'enterprise';
+};
+
+const PALETTE = {
+  protocol: {
+    glow: 'text-violet-400',
+    deep: 'text-violet-800',
+    mid: 'text-violet-600',
+    light: 'text-violet-300',
+    highlight: 'text-violet-100',
+  },
+  enterprise: {
+    glow: 'text-indigo-400',
+    deep: 'text-indigo-800',
+    mid: 'text-indigo-600',
+    light: 'text-indigo-300',
+    highlight: 'text-indigo-100',
+  },
+} as const;
+
+/** A shared faceted formation whose mineral palette identifies its product. */
+export function CrystalCluster({ variant }: CrystalClusterProps) {
+  const id = useId().replaceAll(':', '');
+  const palette = PALETTE[variant];
+  const face = `${id}-face`;
+  const brightFace = `${id}-bright-face`;
+  const glow = `${id}-glow`;
+
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 260 220"
+      className="h-full w-full overflow-visible"
+    >
+      <defs>
+        <linearGradient id={face} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" className={palette.light} stopColor="currentColor" stopOpacity="0.88" />
+          <stop offset="0.5" className={palette.mid} stopColor="currentColor" stopOpacity="0.68" />
+          <stop offset="1" className={palette.deep} stopColor="currentColor" stopOpacity="0.82" />
+        </linearGradient>
+        <linearGradient id={brightFace} x1="0" y1="0" x2="0.85" y2="1">
+          <stop offset="0" className={palette.highlight} stopColor="currentColor" stopOpacity="0.96" />
+          <stop offset="0.42" className={palette.light} stopColor="currentColor" stopOpacity="0.72" />
+          <stop offset="1" className={palette.mid} stopColor="currentColor" stopOpacity="0.48" />
+        </linearGradient>
+        <radialGradient id={glow}>
+          <stop offset="0" className={palette.glow} stopColor="currentColor" stopOpacity="0.24" />
+          <stop offset="1" className={palette.glow} stopColor="currentColor" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      <ellipse cx="139" cy="143" rx="112" ry="76" fill={`url(#${glow})`} />
+
+      {/* Rear shards establish the cluster silhouette before the central prism. */}
+      <g stroke="currentColor" strokeWidth="1" strokeLinejoin="round" className={palette.light}>
+        <g opacity="0.7">
+          <path d="M31 185 51 107 69 88 82 119 82 187Z" fill={`url(#${face})`} />
+          <path d="m51 107 18-19-4 87-14 10Z" className={palette.highlight} fill="currentColor" fillOpacity="0.45" />
+          <path d="m69 88 13 31v68l-17-12Z" className={palette.deep} fill="currentColor" fillOpacity="0.52" />
+        </g>
+        <g opacity="0.76">
+          <path d="m176 187 8-89 20-24 18 29 13 82Z" fill={`url(#${face})`} />
+          <path d="m184 98 20-24-5 101-23 12Z" fill={`url(#${brightFace})`} />
+          <path d="m204 74 18 29 13 82-36-10Z" className={palette.deep} fill="currentColor" fillOpacity="0.56" />
+        </g>
+      </g>
+
+      {/* Secondary prisms overlap the rear plane for translucent depth. */}
+      <g stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round" className={palette.light}>
+        <g opacity="0.84">
+          <path d="m56 188 12-105 23-31 23 35 5 101Z" fill={`url(#${face})`} />
+          <path d="m68 83 23-31-4 121-31 15Z" fill={`url(#${brightFace})`} />
+          <path d="m91 52 23 35 5 101-32-15Z" className={palette.deep} fill="currentColor" fillOpacity="0.6" />
+          <path d="m91 52-4 121" stroke="white" strokeOpacity="0.5" />
+        </g>
+        <g opacity="0.78">
+          <path d="m151 188 7-77 18-24 18 27 7 74Z" fill={`url(#${face})`} />
+          <path d="m158 111 18-24-3 90-22 11Z" fill={`url(#${brightFace})`} />
+          <path d="m176 87 18 27 7 74-28-11Z" className={palette.deep} fill="currentColor" fillOpacity="0.52" />
+        </g>
+      </g>
+
+      {/* The dominant architectural prism anchors the shared geometry. */}
+      <g stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" className={palette.light}>
+        <path d="m93 188 8-137 31-40 32 43 10 134Z" fill={`url(#${face})`} />
+        <path d="m101 51 31-40-5 158-34 19Z" fill={`url(#${brightFace})`} />
+        <path d="m132 11 32 43 10 134-47-19Z" className={palette.deep} fill="currentColor" fillOpacity="0.66" />
+        <path d="m132 11-5 158" stroke="white" strokeOpacity="0.66" />
+        <path d="m101 51 26 118-34 19" stroke="white" strokeOpacity="0.22" fill="none" />
+      </g>
+
+      {/* Low mineral bed grounds the prisms without reading as a rock. */}
+      <path
+        d="m25 188 31-16 29 7 27-12 31 10 29-9 28 12 35-5 20 13-19 18H48Z"
+        fill={`url(#${face})`}
+        className={palette.mid}
+        stroke="currentColor"
+        strokeOpacity="0.38"
+      />
+      <path d="m48 188 37-9 27-12 31 10 29-9 28 12 35-5" fill="none" stroke="white" strokeOpacity="0.48" />
+    </svg>
+  );
+}

--- a/frontend/app/src/landing/protocol/ProtocolToEnterprise.tsx
+++ b/frontend/app/src/landing/protocol/ProtocolToEnterprise.tsx
@@ -1,5 +1,6 @@
 import { SectionHeader } from '../enterprise/primitives';
 import { MINERALS } from '../enterprise/minerals';
+import { CrystalCluster } from './CrystalCluster';
 
 const PROTOCOL_OWNS = ['Identity', 'Integrity', 'Capabilities', 'Sovereignty', 'Interoperability'];
 const ENTERPRISE_OWNS = ['Governance', 'Access', 'Decisions', 'Obligations', 'Grants', 'Revocation', 'Evidence', 'Assurance'];
@@ -22,28 +23,38 @@ export function ProtocolToEnterprise() {
       />
 
       <div className="grid md:grid-cols-2 gap-6">
-        <div className={`rounded-2xl border ${amethyst.border} ${amethyst.soft} p-6 md:p-7`}>
-          <p className={`text-[11px] uppercase tracking-[0.2em] font-mono ${amethyst.text}`}>AOC Protocol defines</p>
-          <ul className="mt-5 space-y-2.5">
-            {PROTOCOL_OWNS.map((item) => (
-              <li key={item} className="flex items-center gap-2.5 text-sm text-slate-900">
-                <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${amethyst.dot}`} />
-                {item}
-              </li>
-            ))}
-          </ul>
+        <div className={`relative overflow-hidden rounded-2xl border ${amethyst.border} ${amethyst.soft} p-6 md:p-7`}>
+          <div className="relative z-10">
+            <p className={`text-[11px] uppercase tracking-[0.2em] font-mono ${amethyst.text}`}>AOC Protocol defines</p>
+            <ul className="mt-5 space-y-2.5">
+              {PROTOCOL_OWNS.map((item) => (
+                <li key={item} className="flex items-center gap-2.5 text-sm text-slate-900">
+                  <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${amethyst.dot}`} />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="pointer-events-none absolute bottom-3 right-3 hidden h-[78%] w-[38%] sm:block md:bottom-4 md:right-4 md:h-[76%] md:w-[40%] lg:right-6 lg:w-[38%]">
+            <CrystalCluster variant="protocol" />
+          </div>
         </div>
 
-        <div className={`rounded-2xl border ${sapphire.border} ${sapphire.soft} p-6 md:p-7`}>
-          <p className={`text-[11px] uppercase tracking-[0.2em] font-mono ${sapphire.text}`}>AOC Enterprise operationalizes</p>
-          <ul className="mt-5 space-y-2.5">
-            {ENTERPRISE_OWNS.map((item) => (
-              <li key={item} className="flex items-center gap-2.5 text-sm text-slate-900">
-                <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${sapphire.dot}`} />
-                {item}
-              </li>
-            ))}
-          </ul>
+        <div className={`relative overflow-hidden rounded-2xl border ${sapphire.border} ${sapphire.soft} p-6 md:p-7`}>
+          <div className="relative z-10">
+            <p className={`text-[11px] uppercase tracking-[0.2em] font-mono ${sapphire.text}`}>AOC Enterprise operationalizes</p>
+            <ul className="mt-5 space-y-2.5">
+              {ENTERPRISE_OWNS.map((item) => (
+                <li key={item} className="flex items-center gap-2.5 text-sm text-slate-900">
+                  <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${sapphire.dot}`} />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="pointer-events-none absolute bottom-3 right-3 hidden h-[78%] w-[38%] sm:block md:bottom-4 md:right-4 md:h-[76%] md:w-[40%] lg:right-6 lg:w-[38%]">
+            <CrystalCluster variant="enterprise" />
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation

- The two comparison cards contained substantial unused right-hand whitespace that should reinforce the existing AOC mineral visual language without altering approved copy or layout.
- Add a decorative, reusable crystal-cluster illustration that reads as the same faceted mineral language for both product columns while using color to distinguish Protocol vs Enterprise.

### Description

- Added a reusable inline SVG React component `CrystalCluster` that renders a multi-prism faceted cluster with one dominant central prism, secondary shards, overlapping translucent facets, subtle highlights and a restrained radial glow; the component is decorative (`aria-hidden="true"`, `focusable="false"`).
- Placed the cluster into the existing right-hand whitespace of each card by updating `ProtocolToEnterprise.tsx` to layer the illustration absolutely inside each card while preserving all existing text, copy, card sizes, spacing and layout.
- The same geometry is used for both clusters with palette variants for Protocol (amethyst/violet) and Enterprise (sapphire/ice-blue/indigo) that align with the project’s mineral accent language.
- Added a small regression test to `DocsPage.test.tsx` that asserts two decorative SVGs render and that the card content remains present.

### Testing

- Ran targeted ESLint on the touched files with no lint errors reported for the edited files: `npx eslint src/landing/protocol/CrystalCluster.tsx src/landing/protocol/ProtocolToEnterprise.tsx src/landing/DocsPage.test.tsx` (passed).
- Ran unit tests for the modified area: `npm test -- --run src/landing/DocsPage.test.tsx`, all tests passed (3 tests, 3 passed).
- Performed a production build: `npm run build` completed successfully (TypeScript + Vite build succeeded).
- Ran `git diff --check` with no whitespace/check errors reported.

Files changed:
- `frontend/app/src/landing/protocol/CrystalCluster.tsx` (new)
- `frontend/app/src/landing/protocol/ProtocolToEnterprise.tsx` (updated)
- `frontend/app/src/landing/DocsPage.test.tsx` (updated)

Notes: Visual browser screenshot verification was not available in this environment; the implementation uses absolute placement, clipping and `sm`/`hidden` breakpoints to ensure the cluster occupies the right-hand whitespace at desktop/tablet sizes and is hidden or reduced at narrow mobile widths so text always remains primary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7575bc83f48325aecdd79bf5da8e75)