### PR TITLE
Refine “Who builds with AOC Protocol” into a restrained seven-node orbital composition

### DIFF
--- a/frontend/app/src/landing/protocol/Developers.css
+++ b/frontend/app/src/landing/protocol/Developers.css
@@ -1,0 +1,180 @@
+.developers-orbit {
+  --orbit-card-width: 15rem;
+  --orbit-radius: 22rem;
+  --orbit-duration: 120s;
+  position: relative;
+  min-height: 50rem;
+  isolation: isolate;
+}
+
+.developers-orbit__center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  z-index: 2;
+  display: grid;
+  width: 8rem;
+  height: 8rem;
+  place-items: center;
+  transform: translate(-50%, -50%);
+  border: 1px solid rgb(226 232 240 / 85%);
+  border-radius: 9999px;
+  background: rgb(248 250 252 / 92%);
+  box-shadow: 0 12px 36px rgb(15 23 42 / 7%);
+}
+
+.developers-orbit__ring {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: calc(var(--orbit-radius) * 2);
+  height: calc(var(--orbit-radius) * 2);
+  transform: translate(-50%, -50%);
+  border: 1px solid rgb(148 163 184 / 25%);
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgb(248 250 252 / 30%) 0 1px, transparent 1.5px) center / 2rem 2rem;
+  mask-image: radial-gradient(circle, transparent 0 68%, #000 78% 100%);
+}
+
+.developers-orbit__layer {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 0;
+  height: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.developers-orbit__node {
+  position: absolute;
+  width: 0;
+  height: 0;
+  transform: rotate(var(--orbit-angle)) translateY(calc(-1 * var(--orbit-radius)));
+}
+
+.developers-orbit__counter {
+  width: 0;
+  height: 0;
+  transform: rotate(calc(-1 * var(--orbit-angle)));
+}
+
+.developer-card {
+  position: absolute;
+  top: 0;
+  left: calc(var(--orbit-card-width) / -2);
+  width: var(--orbit-card-width);
+  min-height: 6.75rem;
+  transform: translateY(-50%);
+  transition: border-color 180ms ease, box-shadow 180ms ease, scale 180ms ease;
+}
+
+.developer-card:hover,
+.developers-orbit__node:focus-visible .developer-card {
+  border-color: rgb(196 181 253);
+  box-shadow: 0 12px 30px rgb(15 23 42 / 9%);
+  outline: none;
+  scale: 1.01;
+}
+
+@media (min-width: 64rem) and (max-width: 79.999rem) {
+  .developers-orbit {
+    --orbit-card-width: 13.5rem;
+    --orbit-radius: 19rem;
+    min-height: 44rem;
+  }
+}
+
+@media (min-width: 80rem) {
+  .developers-orbit__layer {
+    animation: developers-orbit var(--orbit-duration) linear infinite;
+  }
+
+  .developers-orbit__counter {
+    animation: developers-counter-orbit var(--orbit-duration) linear infinite;
+  }
+
+  .developers-orbit:has(.developer-card:hover) .developers-orbit__layer,
+  .developers-orbit:has(.developer-card:hover) .developers-orbit__counter,
+  .developers-orbit:has(.developers-orbit__node:focus-visible) .developers-orbit__layer,
+  .developers-orbit:has(.developers-orbit__node:focus-visible) .developers-orbit__counter {
+    animation-play-state: paused;
+  }
+}
+
+@media (max-width: 63.999rem) {
+  .developers-orbit {
+    min-height: 0;
+  }
+
+  .developers-orbit__center {
+    position: relative;
+    left: auto;
+    top: auto;
+    width: 6rem;
+    height: 6rem;
+    margin: 0 auto 2rem;
+    transform: none;
+  }
+
+  .developers-orbit__center > div {
+    transform: scale(.78);
+  }
+
+  .developers-orbit__ring {
+    display: none;
+  }
+
+  .developers-orbit__layer {
+    position: static;
+    display: grid;
+    width: auto;
+    height: auto;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .developers-orbit__node,
+  .developers-orbit__counter {
+    position: static;
+    width: auto;
+    height: auto;
+    transform: none;
+  }
+
+  .developer-card {
+    position: relative;
+    left: auto;
+    width: 100%;
+    height: 100%;
+    transform: none;
+  }
+}
+
+@media (max-width: 39.999rem) {
+  .developers-orbit__layer {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .developers-orbit__layer,
+  .developers-orbit__counter,
+  .developers-orbit__center svg,
+  .developers-orbit__center svg * {
+    animation: none !important;
+  }
+
+  .developer-card {
+    transition: none;
+  }
+}
+
+@keyframes developers-orbit {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes developers-counter-orbit {
+  from { transform: rotate(calc(-1 * var(--orbit-angle))); }
+  to { transform: rotate(calc(-1 * var(--orbit-angle) - 360deg)); }
+}

--- a/frontend/app/src/landing/protocol/Developers.test.tsx
+++ b/frontend/app/src/landing/protocol/Developers.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Developers } from './Developers';
+import { BUILDER_AUDIENCES } from './content';
+
+afterEach(cleanup);
+
+describe('Developers orbital composition', () => {
+  it('renders every audience exactly once in source order', () => {
+    render(<Developers />);
+
+    const audienceList = screen.getByRole('list', { name: 'Developer and builder audiences' });
+    const audienceItems = screen.getAllByRole('listitem');
+
+    expect(audienceItems).toHaveLength(7);
+    expect(audienceList).toContainElement(audienceItems[0]);
+    expect(audienceItems.map((item) => item.textContent)).toEqual(
+      BUILDER_AUDIENCES.map(({ name, summary }) => `${name}${summary}`),
+    );
+  });
+
+  it('spaces all nodes by exactly one seventh of a revolution', () => {
+    render(<Developers />);
+
+    const angles = screen.getAllByRole('listitem').map((item) =>
+      Number.parseFloat(item.style.getPropertyValue('--orbit-angle')),
+    );
+
+    angles.slice(1).forEach((angle, index) => {
+      const clockwiseSeparation = (angle - angles[index] + 360) % 360;
+      expect(clockwiseSeparation).toBeCloseTo(360 / 7, 8);
+    });
+  });
+
+  it('preserves the established calls to action', () => {
+    render(<Developers />);
+
+    expect(screen.getByRole('link', { name: 'View @aoc/protocol on GitHub' })).toHaveAttribute(
+      'href',
+      'https://github.com/Architects-of-Change-Protocol/Architects_of_Change_Protocol/tree/main/packages/protocol',
+    );
+    expect(screen.getByRole('link', { name: 'Read the docs' })).toHaveAttribute('href', '/?view=docs');
+  });
+});

--- a/frontend/app/src/landing/protocol/Developers.tsx
+++ b/frontend/app/src/landing/protocol/Developers.tsx
@@ -1,6 +1,9 @@
 import { BUILDER_AUDIENCES } from './content';
 import { SectionHeader, Card } from '../enterprise/primitives';
 import { MINERALS } from '../enterprise/minerals';
+import { LogoRotating } from '../../components/logo/LogoRotating';
+import type { CSSProperties } from 'react';
+import './Developers.css';
 
 const REPO_URL = 'https://github.com/Architects-of-Change-Protocol/Architects_of_Change_Protocol';
 const PROTOCOL_PACKAGE_URL = `${REPO_URL}/tree/main/packages/protocol`;
@@ -16,13 +19,30 @@ export function Developers() {
         mineral="amethyst"
       />
 
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5 mb-10">
-        {BUILDER_AUDIENCES.map((audience) => (
-          <Card key={audience.name} className="p-5">
-            <p className="text-sm font-extrabold text-slate-900">{audience.name}</p>
-            <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{audience.summary}</p>
-          </Card>
-        ))}
+      <div className="developers-orbit mb-10">
+        <div className="developers-orbit__center" aria-hidden="true">
+          <LogoRotating size={82} inverted={false} />
+        </div>
+
+        <div className="developers-orbit__ring" aria-hidden="true" />
+
+        <ol className="developers-orbit__layer" aria-label="Developer and builder audiences">
+          {BUILDER_AUDIENCES.map((audience, index) => {
+            const angle = -90 + index * (360 / BUILDER_AUDIENCES.length);
+            const orbitStyle = { '--orbit-angle': `${angle}deg` } as CSSProperties;
+
+            return (
+              <li className="developers-orbit__node" style={orbitStyle} key={audience.name} tabIndex={0}>
+                <div className="developers-orbit__counter">
+                  <Card className="developer-card p-5">
+                    <p className="text-sm font-extrabold text-slate-900">{audience.name}</p>
+                    <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{audience.summary}</p>
+                  </Card>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
       </div>
 
       <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">


### PR DESCRIPTION
### Motivation

- Replace the uneven 3+3+1 grid so the seven developer/builder cards form a deliberate, symmetric radial system centered on the AOC mark. 
- Preserve existing copy, CTAs, and visual restraint while adding an extremely slow, readable orbital motion that reads as architectural rather than flashy. 

### Description

- Replaced the previous rectangular grid with an ordered radial stage that positions each audience at `angle = -90° + i × (360 / 7)` and keeps DOM order intact for accessibility. 
- Reused the existing `LogoRotating` component at the center and added a subtle orbital ring and CSS-driven animations that rotate the outer layer over `--orbit-duration: 120s` while counter-rotating each card so text remains upright and readable. 
- Implemented interaction rules that pause the orbit on hover or keyboard focus and added `prefers-reduced-motion` handling to disable motion while preserving the radial layout. 
- Files changed: `frontend/app/src/landing/protocol/Developers.tsx`, `frontend/app/src/landing/protocol/Developers.css`, `frontend/app/src/landing/protocol/Developers.test.tsx`. 

### Testing

- Ran `npm run build` and the production build completed successfully. 
- Ran the full test suite with `npm test` / `vitest` and all tests passed (17 tests across the suite). 
- Added and ran targeted unit tests in `Developers.test.tsx` which validate: all seven audiences render once in source order, the nodes are spaced by `360/7` degrees, and CTA links remain unchanged; these targeted tests passed. 
- Ran targeted `eslint` on the modified files and `git diff --check`, both succeeded; Playwright/browser install failed in this environment due to a registry permission (HTTP 403), so no end-to-end screenshot run was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a757b4d347c8325838082a9b8b2c7df)