### PR TITLE
Compact developers orbital layout and tighten cards

### DIFF
--- a/frontend/app/src/landing/protocol/Developers.css
+++ b/frontend/app/src/landing/protocol/Developers.css
@@ -1,9 +1,18 @@
+.developers-layout {
+  display: grid;
+  gap: 3rem;
+}
+
+.developers-copy > :first-child {
+  margin-bottom: 2rem;
+}
+
 .developers-orbit {
-  --orbit-card-width: 15rem;
-  --orbit-radius: 22rem;
+  --orbit-card-width: 9.75rem;
+  --orbit-radius: 12.25rem;
   --orbit-duration: 120s;
   position: relative;
-  min-height: 50rem;
+  min-height: 32rem;
   isolation: isolate;
 }
 
@@ -13,14 +22,14 @@
   top: 50%;
   z-index: 2;
   display: grid;
-  width: 8rem;
-  height: 8rem;
+  width: 5.5rem;
+  height: 5.5rem;
   place-items: center;
   transform: translate(-50%, -50%);
   border: 1px solid rgb(226 232 240 / 85%);
   border-radius: 9999px;
   background: rgb(248 250 252 / 92%);
-  box-shadow: 0 12px 36px rgb(15 23 42 / 7%);
+  box-shadow: 0 10px 28px rgb(15 23 42 / 7%);
 }
 
 .developers-orbit__ring {
@@ -64,7 +73,7 @@
   top: 0;
   left: calc(var(--orbit-card-width) / -2);
   width: var(--orbit-card-width);
-  min-height: 6.75rem;
+  min-height: 5.25rem;
   transform: translateY(-50%);
   transition: border-color 180ms ease, box-shadow 180ms ease, scale 180ms ease;
 }
@@ -77,15 +86,18 @@
   scale: 1.01;
 }
 
-@media (min-width: 64rem) and (max-width: 79.999rem) {
-  .developers-orbit {
-    --orbit-card-width: 13.5rem;
-    --orbit-radius: 19rem;
-    min-height: 44rem;
+@media (min-width: 64rem) {
+  .developers-layout {
+    grid-template-columns: minmax(19rem, 0.82fr) minmax(34rem, 1.18fr);
+    align-items: center;
+    gap: 2rem;
   }
-}
 
-@media (min-width: 80rem) {
+  .developers-copy {
+    position: relative;
+    z-index: 3;
+  }
+
   .developers-orbit__layer {
     animation: developers-orbit var(--orbit-duration) linear infinite;
   }
@@ -103,6 +115,10 @@
 }
 
 @media (max-width: 63.999rem) {
+  .developers-layout {
+    gap: 2.5rem;
+  }
+
   .developers-orbit {
     min-height: 0;
   }

--- a/frontend/app/src/landing/protocol/Developers.tsx
+++ b/frontend/app/src/landing/protocol/Developers.tsx
@@ -12,54 +12,58 @@ const m = MINERALS.amethyst;
 export function Developers() {
   return (
     <section id="developers" className="scroll-mt-16 max-w-7xl mx-auto px-6 py-20 border-t border-slate-200">
-      <SectionHeader
-        eyebrow="Developers and Builders"
-        title="Who builds with AOC Protocol."
-        description="@aoc/protocol publishes the versioned public contract layer — capability, proof, credential-manifest and claim shapes — as an open-source package under Apache-2.0. It's not yet published to a registry; build it from source in the repository."
-        mineral="amethyst"
-      />
+      <div className="developers-layout">
+        <div className="developers-copy">
+          <SectionHeader
+            eyebrow="Developers and Builders"
+            title="Who builds with AOC Protocol."
+            description="@aoc/protocol publishes the versioned public contract layer — capability, proof, credential-manifest and claim shapes — as an open-source package under Apache-2.0. It's not yet published to a registry; build it from source in the repository."
+            mineral="amethyst"
+          />
 
-      <div className="developers-orbit mb-10">
-        <div className="developers-orbit__center" aria-hidden="true">
-          <LogoRotating size={82} inverted={false} />
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+            <a
+              href={PROTOCOL_PACKAGE_URL}
+              target="_blank"
+              rel="noreferrer"
+              className={`inline-flex items-center justify-center rounded-xl border ${m.border} px-6 py-3 text-sm font-semibold ${m.text} transition hover:bg-violet-50`}
+            >
+              View @aoc/protocol on GitHub
+            </a>
+            <a
+              href="/?view=docs"
+              className="inline-flex items-center justify-center rounded-xl border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300"
+            >
+              Read the docs
+            </a>
+          </div>
         </div>
 
-        <div className="developers-orbit__ring" aria-hidden="true" />
+        <div className="developers-orbit">
+          <div className="developers-orbit__center" aria-hidden="true">
+            <LogoRotating size={56} inverted={false} />
+          </div>
 
-        <ol className="developers-orbit__layer" aria-label="Developer and builder audiences">
-          {BUILDER_AUDIENCES.map((audience, index) => {
-            const angle = -90 + index * (360 / BUILDER_AUDIENCES.length);
-            const orbitStyle = { '--orbit-angle': `${angle}deg` } as CSSProperties;
+          <div className="developers-orbit__ring" aria-hidden="true" />
 
-            return (
-              <li className="developers-orbit__node" style={orbitStyle} key={audience.name} tabIndex={0}>
-                <div className="developers-orbit__counter">
-                  <Card className="developer-card p-5">
-                    <p className="text-sm font-extrabold text-slate-900">{audience.name}</p>
-                    <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{audience.summary}</p>
-                  </Card>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
-      </div>
+          <ol className="developers-orbit__layer" aria-label="Developer and builder audiences">
+            {BUILDER_AUDIENCES.map((audience, index) => {
+              const angle = -90 + index * (360 / BUILDER_AUDIENCES.length);
+              const orbitStyle = { '--orbit-angle': `${angle}deg` } as CSSProperties;
 
-      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
-        <a
-          href={PROTOCOL_PACKAGE_URL}
-          target="_blank"
-          rel="noreferrer"
-          className={`inline-flex items-center justify-center rounded-xl border ${m.border} px-6 py-3 text-sm font-semibold ${m.text} transition hover:bg-violet-50`}
-        >
-          View @aoc/protocol on GitHub
-        </a>
-        <a
-          href="/?view=docs"
-          className="inline-flex items-center justify-center rounded-xl border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300"
-        >
-          Read the docs
-        </a>
+              return (
+                <li className="developers-orbit__node" style={orbitStyle} key={audience.name} tabIndex={0}>
+                  <div className="developers-orbit__counter">
+                    <Card className="developer-card p-3.5">
+                      <p className="text-xs font-extrabold leading-snug text-slate-900">{audience.name}</p>
+                      <p className="mt-1 text-[11px] leading-snug text-slate-500">{audience.summary}</p>
+                    </Card>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation

- Make the developers section's radial composition much smaller so the orbit and cards fit to the right of the descriptive copy and CTAs on wide screens.
- Preserve the original orbital behavior and responsive collapse while improving visual balance with the surrounding text.

### Description

- Restructured the Developers section into a two-column layout so the header and CTAs remain left-aligned and the orbital composition sits on the right, implemented in `frontend/app/src/landing/protocol/Developers.tsx`.
- Reduced orbital geometry and visuals in `frontend/app/src/landing/protocol/Developers.css` by shrinking the orbit radius to `12.25rem`, card width to `9.75rem`, central logo to `5.5rem` (logo usage size set to `56`), and lowering card padding and typographic sizes for a compact look.
- Adjusted interactions and animations to remain intact (hover/focus pause and reduced-motion handling) and preserved the mobile fallback that converts the orbit into a usable grid.
- Minor markup updates to the cards (smaller padding and text classes) to maintain readability at the reduced scale, in `Developers.tsx`.

### Testing

- Ran the component unit tests with `npm test -- --run src/landing/protocol/Developers.test.tsx`, which passed (3 tests).
- Built the app with `npm run build`, which completed successfully and produced the production bundles.
- Ran project linting (`npm run lint`), which completed but reported unrelated, preexisting lint errors in other files outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a757e0801588325aee0cc6ca3aeec90)