### PR TITLE
Add interactive three-layer Protocol→Enterprise architecture visualization

### DIFF
--- a/frontend/app/src/landing/DocsPage.test.tsx
+++ b/frontend/app/src/landing/DocsPage.test.tsx
@@ -24,12 +24,14 @@ describe('public Protocol developer journey', () => {
     expect(links.at(-1)).toHaveAttribute('href', '/?view=enterprise');
   });
 
-  it('keeps both product crystal clusters decorative', () => {
+  it('renders the three-layer capability architecture with semantic controls', () => {
     const { container } = render(<ProtocolToEnterprise />);
-    const crystals = container.querySelectorAll('svg[aria-hidden="true"]');
-
-    expect(crystals).toHaveLength(2);
+    expect(within(container).getByRole('heading', { name: 'Capabilities shape platforms.' })).toBeInTheDocument();
+    expect(within(container).getByText('Centers of gravity')).toBeInTheDocument();
+    expect(within(container).getByText('AOC Enterprise')).toBeInTheDocument();
+    expect(within(container).getByText('AOC Protocol')).toBeInTheDocument();
     expect(within(container).getByText('Identity')).toBeInTheDocument();
     expect(within(container).getByText('Governance')).toBeInTheDocument();
+    expect(within(container).getByRole('button', { name: /Creator:/ })).toBeInTheDocument();
   });
 });

--- a/frontend/app/src/landing/protocol/ProtocolToEnterprise.css
+++ b/frontend/app/src/landing/protocol/ProtocolToEnterprise.css
@@ -1,0 +1,62 @@
+.architecture-section { overflow:clip; background:radial-gradient(ellipse at 50% 47%,rgb(237 233 254 / .82),transparent 57%),linear-gradient(180deg,#fff 0%,rgb(248 250 252 / .72) 52%,#fff 100%); }
+.architecture-instrument { position:relative; height:960px; width:min(1240px,calc(100vw - 32px)); margin-inline:50%; transform:translateX(-50%); perspective:1450px; perspective-origin:50% 42%; isolation:isolate; }
+.glass-plane { position:absolute; height:270px; border:1px solid rgb(148 163 184 / .38); clip-path:polygon(7% 0,100% 0,93% 100%,0 100%); transform-style:preserve-3d; box-shadow:0 45px 60px rgb(15 23 42 / .14),0 18px 28px rgb(79 70 229 / .08),inset 0 1px rgb(255 255 255 / .98),inset 0 -7px rgb(148 163 184 / .1); backdrop-filter:blur(11px) saturate(128%); transition:border-color 1.2s ease,box-shadow 1.2s ease,filter 1.2s ease; }
+.glass-plane::before { content:''; position:absolute; z-index:1; inset:0; pointer-events:none; background:linear-gradient(108deg,rgb(255 255 255 / .8),transparent 22%,rgb(255 255 255 / .06) 55%,rgb(255 255 255 / .52)),linear-gradient(180deg,rgb(255 255 255 / .22),transparent 42%,rgb(148 163 184 / .06)); mix-blend-mode:screen; }
+.glass-plane::after { content:''; position:absolute; z-index:2; inset:1px; pointer-events:none; background:radial-gradient(ellipse at 18% 12%,rgb(255 255 255 / .42),transparent 24%),radial-gradient(ellipse at 78% 76%,rgb(255 255 255 / .2),transparent 27%),linear-gradient(112deg,transparent 44%,rgb(255 255 255 / .18) 49%,transparent 55%); opacity:.72; mix-blend-mode:screen; }
+.slab-edge { position:absolute; z-index:7; left:1.2%; right:5.8%; bottom:0; height:7px; background:linear-gradient(180deg,rgb(255 255 255 / .68),rgb(100 116 139 / .19) 52%,rgb(255 255 255 / .34)); border-top:1px solid rgb(255 255 255 / .7); border-bottom:1px solid rgb(100 116 139 / .27); transform:skewX(-36deg); box-shadow:inset 0 1px rgb(255 255 255 / .65),0 10px 18px rgb(15 23 42 / .16); pointer-events:none; }
+.gravity-plane { top:10px; left:9%; width:82%; z-index:3; transform:rotateX(16deg) translateZ(-76px) scale(.93); background:linear-gradient(155deg,rgb(230 255 250 / .69),rgb(248 250 252 / .35)); filter:drop-shadow(0 38px 24px rgb(15 23 42 / .11)); }
+.enterprise-plane { top:330px; left:5.5%; width:89%; z-index:5; transform:rotateX(12deg) translateZ(-24px) scale(.97); background:linear-gradient(155deg,rgb(229 234 255 / .76),rgb(255 255 255 / .32)); border-color:rgb(99 102 241 / .36); filter:drop-shadow(0 42px 27px rgb(49 46 129 / .12)); }
+.protocol-plane { top:650px; left:1.5%; width:97%; z-index:7; transform:rotateX(9deg) translateZ(28px); background:linear-gradient(155deg,rgb(240 233 255 / .84),rgb(255 255 255 / .35)); border-color:rgb(139 92 246 / .4); filter:drop-shadow(0 46px 30px rgb(76 29 149 / .13)); }
+.plane-heading { position:absolute; z-index:8; top:17px; left:8%; display:flex; align-items:baseline; gap:10px; text-transform:uppercase; letter-spacing:.14em; }
+.plane-heading span { color:#94a3b8; font:600 9px ui-monospace,monospace; }
+.plane-heading strong { color:#334155; font-size:11px; }
+.plane-heading em { color:#94a3b8; font:normal 9px ui-monospace,monospace; letter-spacing:.08em; }
+.layer-topology { position:absolute; z-index:3; inset:0; width:100%; height:100%; overflow:visible; pointer-events:none; }
+.layer-topology line { vector-effect:non-scaling-stroke; transition:opacity .45s ease; }
+.topology-fill { vector-effect:non-scaling-stroke; transition:opacity .7s ease; }
+.topology-glow { stroke-width:8; opacity:.17; stroke-linecap:round; }
+.topology-edge { stroke-width:calc(.9px + var(--edge-strength) * .58px); stroke-linecap:round; opacity:.9; animation:topology-breathe 5.6s ease-in-out infinite; }
+.protocol-topology .topology-glow { stroke:#8b5cf6; }.protocol-topology .topology-edge { stroke:#7c3aed; }.protocol-topology .topology-fill { fill:rgb(139 92 246 / .055); stroke:rgb(139 92 246 / .12); }
+.enterprise-topology .topology-glow { stroke:#818cf8; }.enterprise-topology .topology-edge { stroke:#4f46e5; }.enterprise-topology .topology-fill { fill:rgb(99 102 241 / .048); stroke:rgb(99 102 241 / .12); }
+.gravity-topology .topology-glow { stroke:#5eead4; }.gravity-topology .topology-edge { stroke:#5e8f91; }.gravity-topology .topology-fill { fill:rgb(94 234 212 / .045); stroke:rgb(13 148 136 / .11); }
+.layer-topology .is-muted { opacity:.16; }.layer-topology .is-emphasized { opacity:1; }
+.architecture-node,.gravity-field { position:absolute; z-index:9; transform:translate(-50%,-50%); border:0; background:transparent; cursor:pointer; color:#64748b; transition:color .65s ease,opacity .65s ease,filter .65s ease; }
+.architecture-node { min-width:72px; min-height:58px; display:grid; justify-items:center; align-content:center; gap:4px; }
+.architecture-node span { padding:2px 5px; border-radius:5px; background:rgb(255 255 255 / .76); box-shadow:0 1px 5px rgb(15 23 42 / .04); font-size:10px; font-weight:650; white-space:nowrap; }
+.architecture-node:focus-visible,.gravity-field:focus-visible,.state-selector button:focus-visible { outline:2px solid #7c3aed; outline-offset:4px; border-radius:8px; }
+.enterprise-node i { width:8px; height:8px; border:1px solid rgb(99 102 241 / .55); background:rgb(255 255 255 / .86); transform:rotate(45deg); box-shadow:0 0 0 4px rgb(99 102 241 / .06); transition:all .65s ease; }
+.enterprise-node.is-active,.enterprise-node.is-related { color:#3730a3; filter:drop-shadow(0 5px 8px rgb(79 70 229 / .22)); }
+.enterprise-node.is-active i,.enterprise-node.is-related i { background:#6366f1; border-color:#c7d2fe; box-shadow:0 0 0 6px rgb(99 102 241 / .13),0 0 14px rgb(99 102 241 / .25); }
+.protocol-node { color:#7c3aed; opacity:.64; }.protocol-node.is-active,.protocol-node.is-related { color:#6d28d9; opacity:1; filter:drop-shadow(0 7px 10px rgb(124 58 237 / .22)); }
+.protocol-node::before { content:''; position:absolute; width:24px; height:10px; top:28px; border-radius:50%; background:radial-gradient(ellipse,rgb(139 92 246 / .28),transparent 70%); opacity:0; transition:opacity .6s ease; }.protocol-node.is-active::before,.protocol-node.is-related::before { opacity:1; }
+.mineral-glyph { width:29px; height:37px; overflow:visible; transition:width .6s ease,height .6s ease; }.protocol-node.is-active .mineral-glyph,.protocol-node.is-related .mineral-glyph { width:37px; height:46px; }
+.gravity-field { --gravity-weight:.5; width:110px; height:90px; display:grid; place-items:center; color:#475569; }
+.gravity-field i,.gravity-field i::before,.gravity-field i::after { position:absolute; border-radius:999px; border:1px solid rgb(71 116 116 / calc(.1 + var(--gravity-weight) * .27)); }
+.gravity-field i { width:calc(30px + var(--gravity-weight) * 34px); height:calc(30px + var(--gravity-weight) * 34px); background:radial-gradient(circle,rgb(153 246 228 / calc(var(--gravity-weight) * .2)),transparent 68%); box-shadow:0 0 calc(var(--gravity-weight) * 22px) rgb(45 212 191 / .14); transition:all 1.2s cubic-bezier(.22,1,.36,1); }
+.gravity-field i::before { content:''; inset:-9px; }.gravity-field i::after { content:''; inset:-18px; }
+.gravity-field.is-related i { box-shadow:0 0 28px rgb(45 212 191 / .28); filter:brightness(1.12); }
+.gravity-field span { position:absolute; top:73%; padding:2px 5px; border-radius:5px; background:rgb(255 255 255 / .76); font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.07em; }
+.vertical-bridge-network { position:absolute; inset:0; z-index:6; width:100%; height:100%; pointer-events:none; overflow:visible; }
+.mobile-network { display:none; }.light-bridge { --bridge-strength:1; transition:opacity .5s ease; }.light-bridge.is-muted { opacity:.09; }.light-bridge.is-emphasized { opacity:calc(.4 + var(--bridge-strength) * .38); }
+.light-bridge line { vector-effect:non-scaling-stroke; stroke:url(#bridge-light-false); stroke-linecap:round; }.mobile-network .light-bridge line { stroke:url(#bridge-light-true); }
+.bridge-atmosphere { stroke-width:30; opacity:.1; filter:blur(6px); }.bridge-volume { stroke-width:11; opacity:.17; filter:blur(2.5px); }.bridge-core { stroke-width:1.25; opacity:.4; }
+.bridge-bloom { fill:rgb(221 214 254 / .2); stroke:none; filter:drop-shadow(0 0 4px rgb(167 243 208 / .55)); }.bridge-refraction { fill:none; stroke:#c4b5fd; stroke-width:.2; vector-effect:non-scaling-stroke; filter:drop-shadow(0 0 3px rgb(196 181 253 / .82)); }.bridge-spark { fill:#fff; filter:drop-shadow(0 0 4px #a7f3d0); }
+.state-console { position:absolute; z-index:12; right:7%; top:15px; display:flex; align-items:center; gap:13px; padding:5px 6px 5px 10px; border:1px solid rgb(148 163 184 / .18); border-radius:12px; background:rgb(255 255 255 / .46); backdrop-filter:blur(8px); box-shadow:0 7px 20px rgb(15 23 42 / .06); }
+.state-readout { display:grid; min-width:105px; text-align:right; }.state-readout span { color:#94a3b8; font:9px ui-monospace,monospace; text-transform:uppercase; letter-spacing:.1em; }.state-readout strong { margin-top:2px; color:#334155; font-size:12px; }
+.state-selector { display:flex; gap:3px; }.state-selector button { width:22px; height:22px; border:0; background:transparent; cursor:pointer; position:relative; }.state-selector button::after { content:''; position:absolute; inset:8px; border-radius:99px; background:#cbd5e1; transition:inset .3s ease,background .3s ease; }.state-selector button.is-active::after { inset:6px; background:#7c3aed; }
+@keyframes topology-breathe { 0%,100%{opacity:.72} 50%{opacity:1} }
+
+@media (max-width:639px) {
+  .architecture-section { background:radial-gradient(ellipse at 50% 50%,rgb(237 233 254 / .68),transparent 64%); }
+  .architecture-instrument { height:1010px; width:calc(100vw - 20px); perspective:1120px; perspective-origin:50% 45%; }
+  .glass-plane { height:280px; backdrop-filter:blur(5px) saturate(116%); clip-path:polygon(4% 0,100% 0,96% 100%,0 100%); }
+  .gravity-plane { top:0; left:3%; width:94%; transform:rotateX(8deg) translateZ(-25px) scale(.96); }.enterprise-plane { top:335px; left:2%; width:96%; transform:rotateX(6deg) translateZ(-7px) scale(.98); }.protocol-plane { top:670px; left:1%; width:98%; transform:rotateX(4deg) translateZ(10px); }
+  .slab-edge { height:5px; transform:skewX(-25deg); }.plane-heading { left:7%; top:15px; }.plane-heading em { display:none; }
+  .architecture-node { min-width:58px; min-height:48px; }.architecture-node span,.gravity-field span { font-size:9px; }
+  .gravity-field { width:86px; height:76px; }.gravity-field span { top:76%; }.gravity-field:nth-of-type(4) { left:19%!important; top:72%!important; }.gravity-field:nth-of-type(5) { left:78%!important; top:72%!important; }
+  .desktop-network { display:none; }.mobile-network { display:block; }.mobile-network .mobile-secondary { display:none; }.bridge-atmosphere { stroke-width:18; filter:blur(3.5px); }.bridge-volume { stroke-width:7; filter:blur(1.5px); }
+  .layer-topology .topology-glow { stroke-width:5; }.state-console { top:auto; right:5%; bottom:14px; gap:5px; padding-left:8px; }.state-readout { min-width:93px; }.state-readout span { font-size:8px; }.state-selector { gap:1px; }.state-selector button { width:19px; height:22px; }
+}
+@media (prefers-reduced-motion:reduce) {
+  .topology-edge { animation:none; opacity:.9; }.light-bridge,.layer-topology line,.architecture-node,.gravity-field,.gravity-field i,.state-selector button::after { transition-duration:.01ms!important; }
+}

--- a/frontend/app/src/landing/protocol/ProtocolToEnterprise.tsx
+++ b/frontend/app/src/landing/protocol/ProtocolToEnterprise.tsx
@@ -1,77 +1,122 @@
-import { SectionHeader } from '../enterprise/primitives';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { AnimatePresence, MotionConfig, motion, useMotionValue, useReducedMotion } from 'framer-motion';
 import { MINERALS } from '../enterprise/minerals';
-import { CrystalCluster } from './CrystalCluster';
+import { CapabilityMineral } from './capabilityDock/CapabilityMineral';
+import { CAPABILITY_FAMILIES } from './content';
+import type { CapabilityId } from './capabilityDock/dockTokens';
+import './ProtocolToEnterprise.css';
 
-const PROTOCOL_OWNS = ['Identity', 'Integrity', 'Capabilities', 'Sovereignty', 'Interoperability'];
-const ENTERPRISE_OWNS = ['Governance', 'Access', 'Decisions', 'Obligations', 'Grants', 'Revocation', 'Evidence', 'Assurance'];
+type GravityId = 'creator' | 'user' | 'community' | 'organization' | 'platform';
+type EnterpriseId = 'governance' | 'access' | 'decisions' | 'obligations' | 'grants' | 'revocation' | 'evidence' | 'assurance';
+type LayerId = 'protocol' | 'enterprise' | 'gravity';
+type Point = { x: number; y: number };
+type Edge<T extends string> = { from: T; to: T; strength?: number };
+type VerticalBridge<F extends string, T extends string> = { from: F; to: T; strength?: number };
+type ArchitectureState = {
+  id: GravityId | 'deliberate'; label: string;
+  protocol: CapabilityId[]; enterprise: EnterpriseId[]; gravity: Record<GravityId, number>;
+  protocolEdges: Edge<CapabilityId>[]; enterpriseEdges: Edge<EnterpriseId>[]; gravityEdges: Edge<GravityId>[];
+  protocolShape: CapabilityId[]; enterpriseShape: EnterpriseId[]; gravityShape: GravityId[];
+  protocolToEnterprise: VerticalBridge<CapabilityId, EnterpriseId>[];
+  enterpriseToGravity: VerticalBridge<EnterpriseId, GravityId>[];
+};
+type ActiveTarget = { layer: LayerId; id: string } | null;
+
+const protocolPositions: Record<CapabilityId, Point> = {
+  identity: { x: 15, y: 34 }, integrity: { x: 35, y: 63 }, provenance: { x: 54, y: 30 }, portability: { x: 72, y: 60 },
+  interoperability: { x: 88, y: 31 }, verifiability: { x: 22, y: 76 }, licensing: { x: 55, y: 76 }, 'governance-compatibility': { x: 79, y: 79 },
+};
+const enterpriseNodes: { id: EnterpriseId; label: string; x: number; y: number }[] = [
+  { id: 'governance', label: 'Governance', x: 14, y: 35 }, { id: 'access', label: 'Access', x: 35, y: 62 },
+  { id: 'decisions', label: 'Decisions', x: 52, y: 31 }, { id: 'obligations', label: 'Obligations', x: 70, y: 61 },
+  { id: 'grants', label: 'Grants', x: 86, y: 34 }, { id: 'revocation', label: 'Revocation', x: 23, y: 77 },
+  { id: 'evidence', label: 'Evidence', x: 55, y: 78 }, { id: 'assurance', label: 'Assurance', x: 82, y: 78 },
+];
+const gravityFields: { id: GravityId; label: string; x: number; y: number }[] = [
+  { id: 'creator', label: 'Creator', x: 14, y: 39 }, { id: 'user', label: 'User', x: 34, y: 66 },
+  { id: 'community', label: 'Community', x: 53, y: 34 }, { id: 'organization', label: 'Organization', x: 71, y: 67 },
+  { id: 'platform', label: 'Platform', x: 87, y: 38 },
+];
+const enterprisePositions = Object.fromEntries(enterpriseNodes.map(({ id, x, y }) => [id, { x, y }])) as Record<EnterpriseId, Point>;
+const gravityPositions = Object.fromEntries(gravityFields.map(({ id, x, y }) => [id, { x, y }])) as Record<GravityId, Point>;
+const edge = <T extends string>(from: T, to: T, strength = 1): Edge<T> => ({ from, to, strength });
+const bridge = <F extends string, T extends string>(from: F, to: T, strength = 1): VerticalBridge<F, T> => ({ from, to, strength });
+
+// Curated edges and bridges are explanatory compositions, never normative Protocol mappings.
+const architectureStates: ArchitectureState[] = [
+  { id: 'creator', label: 'Creator-led', protocol: ['identity', 'provenance', 'licensing'], enterprise: ['access', 'grants', 'evidence'], gravity: { creator: 1, user: .52, community: .34, organization: .28, platform: .2 }, protocolEdges: [edge('identity','provenance'),edge('provenance','licensing'),edge('licensing','identity')], enterpriseEdges: [edge('access','grants'),edge('grants','evidence'),edge('evidence','access')], gravityEdges: [edge('creator','user'),edge('user','community'),edge('community','creator')], protocolShape: ['identity','provenance','licensing'], enterpriseShape: ['access','grants','evidence'], gravityShape: ['creator','community','user'], protocolToEnterprise: [bridge('identity','access'),bridge('identity','evidence',.7),bridge('provenance','evidence'),bridge('licensing','grants')], enterpriseToGravity: [bridge('access','creator'),bridge('access','user',.75),bridge('evidence','community'),bridge('grants','creator',.7)] },
+  { id: 'user', label: 'User-led', protocol: ['identity','portability','interoperability'], enterprise: ['access','decisions','revocation'], gravity: { creator: .38, user: 1, community: .5, organization: .28, platform: .2 }, protocolEdges: [edge('identity','portability'),edge('portability','interoperability'),edge('interoperability','identity')], enterpriseEdges: [edge('access','decisions'),edge('decisions','revocation'),edge('revocation','access')], gravityEdges: [edge('creator','user',.7),edge('user','community'),edge('community','organization',.55)], protocolShape: ['identity','interoperability','portability'], enterpriseShape: ['access','decisions','revocation'], gravityShape: [], protocolToEnterprise: [bridge('identity','access'),bridge('portability','access',.7),bridge('portability','revocation'),bridge('interoperability','decisions')], enterpriseToGravity: [bridge('access','user'),bridge('access','creator',.55),bridge('decisions','community'),bridge('revocation','user',.8)] },
+  { id: 'community', label: 'Community-led', protocol: ['provenance','interoperability','governance-compatibility'], enterprise: ['governance','decisions','obligations'], gravity: { creator: .48, user: .52, community: 1, organization: .42, platform: .2 }, protocolEdges: [edge('provenance','interoperability'),edge('interoperability','governance-compatibility'),edge('governance-compatibility','provenance')], enterpriseEdges: [edge('governance','decisions'),edge('decisions','obligations'),edge('obligations','governance')], gravityEdges: [edge('creator','community'),edge('community','user'),edge('community','organization')], protocolShape: ['provenance','interoperability','governance-compatibility'], enterpriseShape: ['governance','decisions','obligations'], gravityShape: [], protocolToEnterprise: [bridge('provenance','governance',.7),bridge('provenance','decisions'),bridge('interoperability','decisions'),bridge('governance-compatibility','obligations')], enterpriseToGravity: [bridge('governance','community'),bridge('decisions','community'),bridge('decisions','user',.65),bridge('obligations','organization',.65)] },
+  { id: 'organization', label: 'Organization-led', protocol: ['integrity','verifiability','governance-compatibility'], enterprise: ['governance','obligations','assurance'], gravity: { creator: .24, user: .3, community: .38, organization: 1, platform: .44 }, protocolEdges: [edge('integrity','verifiability'),edge('verifiability','governance-compatibility'),edge('governance-compatibility','integrity')], enterpriseEdges: [edge('governance','obligations'),edge('obligations','assurance'),edge('assurance','governance')], gravityEdges: [edge('community','organization'),edge('organization','platform'),edge('organization','user',.55)], protocolShape: ['integrity','governance-compatibility','verifiability'], enterpriseShape: ['governance','obligations','assurance'], gravityShape: [], protocolToEnterprise: [bridge('integrity','assurance'),bridge('verifiability','assurance'),bridge('verifiability','governance',.7),bridge('governance-compatibility','obligations')], enterpriseToGravity: [bridge('governance','organization'),bridge('obligations','organization'),bridge('assurance','platform',.7),bridge('assurance','community',.5)] },
+  { id: 'platform', label: 'Platform-led', protocol: ['integrity','portability','verifiability'], enterprise: ['access','decisions','assurance'], gravity: { creator: .22, user: .3, community: .22, organization: .52, platform: 1 }, protocolEdges: [edge('integrity','portability'),edge('portability','verifiability'),edge('verifiability','integrity')], enterpriseEdges: [edge('access','decisions'),edge('decisions','assurance'),edge('assurance','access')], gravityEdges: [edge('user','platform',.55),edge('platform','organization'),edge('organization','community',.45)], protocolShape: ['integrity','portability','verifiability'], enterpriseShape: ['access','decisions','assurance'], gravityShape: [], protocolToEnterprise: [bridge('integrity','assurance'),bridge('portability','access'),bridge('portability','decisions',.65),bridge('verifiability','assurance')], enterpriseToGravity: [bridge('access','platform'),bridge('decisions','platform'),bridge('decisions','organization',.65),bridge('assurance','organization') ] },
+  { id: 'deliberate', label: 'Deliberately balanced', protocol: ['identity','integrity','provenance','interoperability','governance-compatibility'], enterprise: ['governance','access','decisions','evidence','assurance'], gravity: { creator: .76, user: .82, community: .68, organization: .72, platform: .58 }, protocolEdges: [edge('identity','integrity'),edge('integrity','governance-compatibility'),edge('governance-compatibility','interoperability'),edge('interoperability','provenance'),edge('provenance','identity'),edge('integrity','provenance',.6)], enterpriseEdges: [edge('governance','access'),edge('access','evidence'),edge('evidence','assurance'),edge('assurance','decisions'),edge('decisions','governance'),edge('decisions','evidence',.6)], gravityEdges: [edge('creator','user'),edge('user','organization'),edge('organization','platform'),edge('platform','community'),edge('community','creator')], protocolShape: ['identity','provenance','interoperability','governance-compatibility','integrity'], enterpriseShape: ['governance','decisions','assurance','evidence','access'], gravityShape: ['creator','community','platform','organization','user'], protocolToEnterprise: [bridge('identity','access'),bridge('identity','evidence',.6),bridge('integrity','assurance'),bridge('provenance','evidence'),bridge('interoperability','decisions'),bridge('governance-compatibility','governance')], enterpriseToGravity: [bridge('access','user'),bridge('access','creator',.7),bridge('governance','community'),bridge('decisions','organization'),bridge('evidence','creator',.65),bridge('assurance','platform') ] },
+];
 
 const amethyst = MINERALS.amethyst;
-const sapphire = MINERALS.sapphire;
+const pointString = <T extends string>(ids: T[], positions: Record<T, Point>) => ids.map((id) => `${positions[id].x},${positions[id].y}`).join(' ');
+const touches = (active: ActiveTarget, layer: LayerId, from: string, to: string) => !active || active.layer !== layer || active.id === from || active.id === to;
 
-// The one section on the Protocol page that deliberately shows two
-// Capability Minerals side by side — Protocol's own Amethyst column next to
-// Enterprise's Sapphire column — because this is the exact seam where the
-// two capability families hand off to each other.
+function LayerTopology<T extends string>({ stateId, layer, edges, shape, positions, activeTarget }: { stateId: string; layer: LayerId; edges: Edge<T>[]; shape: T[]; positions: Record<T, Point>; activeTarget: ActiveTarget }) {
+  return <svg className={`layer-topology ${layer}-topology`} viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><AnimatePresence mode="wait" initial={false}><motion.g key={`${stateId}-${layer}`} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 1.1, ease: [0.22,1,0.36,1] }}>
+    {shape.length > 2 ? <polygon className="topology-fill" points={pointString(shape, positions)} /> : null}
+    {edges.map((item) => { const from = positions[item.from]; const to = positions[item.to]; return <g key={`${item.from}-${item.to}`} className={touches(activeTarget, layer, item.from, item.to) ? 'is-emphasized' : 'is-muted'}><line className="topology-glow" x1={from.x} y1={from.y} x2={to.x} y2={to.y}/><line className="topology-edge" x1={from.x} y1={from.y} x2={to.x} y2={to.y} style={{ '--edge-strength': item.strength ?? 1 } as CSSProperties}/></g>; })}
+  </motion.g></AnimatePresence></svg>;
+}
+
+function MineralNode({ capability, active, related, onIntent }: { capability: (typeof CAPABILITY_FAMILIES)[number] & { id: CapabilityId }; active: boolean; related: boolean; onIntent: (value: boolean) => void }) {
+  const influence = useMotionValue(active || related ? 1 : 0);
+  useEffect(() => { influence.set(active || related ? 1 : 0); }, [active, related, influence]);
+  const point = protocolPositions[capability.id];
+  return <button type="button" className={`architecture-node protocol-node ${active ? 'is-active' : ''} ${related ? 'is-related' : ''}`} style={{ left: `${point.x}%`, top: `${point.y}%` }} onMouseEnter={() => onIntent(true)} onMouseLeave={() => onIntent(false)} onFocus={() => onIntent(true)} onBlur={() => onIntent(false)} aria-pressed={active}><CapabilityMineral id={capability.id} influence={influence} className="mineral-glyph"/><span>{capability.name}</span></button>;
+}
+
+type LayerBounds = { left: number; top: number; width: number; height: number };
+
+function bridgeCoordinates<F extends string, T extends string>(item: VerticalBridge<F,T>, from: Record<F,Point>, to: Record<T,Point>, lower: LayerBounds, upper: LayerBounds, sceneHeight: number) {
+  return { x1: lower.left + from[item.from].x * lower.width / 100, y1: (lower.top + from[item.from].y * lower.height / 100) / sceneHeight * 100, x2: upper.left + to[item.to].x * upper.width / 100, y2: (upper.top + to[item.to].y * upper.height / 100) / sceneHeight * 100 };
+}
+
+function VerticalBridgeNetwork({ state, activeTarget, mobile = false }: { state: ArchitectureState; activeTarget: ActiveTarget; mobile?: boolean }) {
+  const sceneHeight = mobile ? 1010 : 960;
+  const bounds: Record<LayerId,LayerBounds> = mobile
+    ? { gravity: { left:3,top:0,width:94,height:280 }, enterprise: { left:2,top:335,width:96,height:280 }, protocol: { left:1,top:670,width:98,height:280 } }
+    : { gravity: { left:9,top:10,width:82,height:270 }, enterprise: { left:5.5,top:330,width:89,height:270 }, protocol: { left:1.5,top:650,width:97,height:270 } };
+  const renderBridge = <F extends string,T extends string>(item: VerticalBridge<F,T>, from: Record<F,Point>, to: Record<T,Point>, fromLayer: LayerId, toLayer: LayerId, index: number) => {
+    const p = bridgeCoordinates(item, from, to, bounds[fromLayer], bounds[toLayer], sceneHeight);
+    const emphasized = !activeTarget || (activeTarget.layer === fromLayer && activeTarget.id === item.from) || (activeTarget.layer === toLayer && activeTarget.id === item.to);
+    return <g key={`${fromLayer}-${item.from}-${item.to}-${index}`} className={`light-bridge ${emphasized ? 'is-emphasized' : 'is-muted'} ${index > 3 ? 'mobile-secondary' : ''}`} style={{ '--bridge-strength': item.strength ?? 1 } as CSSProperties}>
+      <line className="bridge-atmosphere" x1={p.x1} y1={p.y1} x2={p.x2} y2={p.y2}/><line className="bridge-volume" x1={p.x1} y1={p.y1} x2={p.x2} y2={p.y2}/><line className="bridge-core" x1={p.x1} y1={p.y1} x2={p.x2} y2={p.y2}/>
+      <ellipse className="bridge-bloom" cx={p.x1} cy={p.y1} rx="3.6" ry="1.15"/><ellipse className="bridge-bloom" cx={p.x2} cy={p.y2} rx="3.6" ry="1.15"/>
+      <ellipse className="bridge-refraction" cx={p.x1} cy={p.y1} rx="2.25" ry=".72"/><ellipse className="bridge-refraction" cx={p.x2} cy={p.y2} rx="2.25" ry=".72"/><circle className="bridge-spark" cx={p.x1} cy={p.y1} r=".32"/><circle className="bridge-spark" cx={p.x2} cy={p.y2} r=".38"/>
+    </g>;
+  };
+  return <svg className={`vertical-bridge-network ${mobile ? 'mobile-network' : 'desktop-network'}`} viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><defs><linearGradient id={`bridge-light-${mobile}`} x1="0" y1="1" x2="0" y2="0"><stop stopColor="#8b5cf6" stopOpacity=".55"/><stop offset=".5" stopColor="#818cf8" stopOpacity=".46"/><stop offset="1" stopColor="#99f6e4" stopOpacity=".52"/></linearGradient></defs><AnimatePresence mode="wait" initial={false}><motion.g key={`${state.id}-${mobile}`} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 1.25, ease: [0.22,1,0.36,1] }}>
+    {state.protocolToEnterprise.map((item,index) => renderBridge(item, protocolPositions, enterprisePositions, 'protocol','enterprise',index))}
+    {state.enterpriseToGravity.map((item,index) => renderBridge(item, enterprisePositions, gravityPositions, 'enterprise','gravity',index))}
+  </motion.g></AnimatePresence></svg>;
+}
+
 export function ProtocolToEnterprise() {
-  return (
-    <section id="protocol-to-enterprise" className="scroll-mt-16 max-w-7xl mx-auto px-6 py-20 border-t border-slate-200">
-      <SectionHeader
-        eyebrow="Protocol to Enterprise"
-        title="Protocol defines what an asset can be. Enterprise decides how it's used."
-        description="Protocol describes. AOC Enterprise decides, executes, observes and audits — operationalizing governance for organizations that need to control how assets built on the protocol are actually used."
-        mineral="amethyst"
-      />
-
-      <div className="grid md:grid-cols-2 gap-6">
-        <div className={`relative overflow-hidden rounded-2xl border ${amethyst.border} ${amethyst.soft} p-6 md:p-7`}>
-          <div className="relative z-10">
-            <p className={`text-[11px] uppercase tracking-[0.2em] font-mono ${amethyst.text}`}>AOC Protocol defines</p>
-            <ul className="mt-5 space-y-2.5">
-              {PROTOCOL_OWNS.map((item) => (
-                <li key={item} className="flex items-center gap-2.5 text-sm text-slate-900">
-                  <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${amethyst.dot}`} />
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="pointer-events-none absolute bottom-3 right-3 hidden h-[78%] w-[38%] sm:block md:bottom-4 md:right-4 md:h-[76%] md:w-[40%] lg:right-6 lg:w-[38%]">
-            <CrystalCluster variant="protocol" />
-          </div>
-        </div>
-
-        <div className={`relative overflow-hidden rounded-2xl border ${sapphire.border} ${sapphire.soft} p-6 md:p-7`}>
-          <div className="relative z-10">
-            <p className={`text-[11px] uppercase tracking-[0.2em] font-mono ${sapphire.text}`}>AOC Enterprise operationalizes</p>
-            <ul className="mt-5 space-y-2.5">
-              {ENTERPRISE_OWNS.map((item) => (
-                <li key={item} className="flex items-center gap-2.5 text-sm text-slate-900">
-                  <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${sapphire.dot}`} />
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="pointer-events-none absolute bottom-3 right-3 hidden h-[78%] w-[38%] sm:block md:bottom-4 md:right-4 md:h-[76%] md:w-[40%] lg:right-6 lg:w-[38%]">
-            <CrystalCluster variant="enterprise" />
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-        <a
-          href="/?view=docs#getting-started"
-          className={`inline-flex items-center justify-center rounded-2xl ${amethyst.solid} px-8 py-4 text-white font-semibold ${amethyst.solidHover} transition-all active:scale-[0.98]`}
-        >
-          Review Protocol Documentation
-        </a>
-        <a
-          href="/?view=enterprise"
-          className="inline-flex items-center justify-center rounded-2xl border border-slate-200 hover:border-slate-300 text-slate-900 font-semibold px-8 py-4 transition-all active:scale-[0.98]"
-        >
-          Explore AOC Enterprise &rarr;
-        </a>
-      </div>
-    </section>
-  );
+  const reducedMotion = useReducedMotion() ?? false;
+  const sectionRef = useRef<HTMLElement>(null);
+  const [stateIndex, setStateIndex] = useState(0);
+  const [isVisible, setIsVisible] = useState(true);
+  const [activeTarget, setActiveTarget] = useState<ActiveTarget>(null);
+  const state = architectureStates[stateIndex];
+  useEffect(() => { const element = sectionRef.current; if (!element || !('IntersectionObserver' in window)) return; const observer = new IntersectionObserver(([entry]) => setIsVisible(entry.isIntersecting), { rootMargin: '120px' }); observer.observe(element); return () => observer.disconnect(); }, []);
+  useEffect(() => { if (reducedMotion || !isVisible || activeTarget) return; const timer = window.setInterval(() => setStateIndex((value) => (value + 1) % architectureStates.length), 7500); return () => window.clearInterval(timer); }, [activeTarget,isVisible,reducedMotion]);
+  const relatedProtocol = (id: CapabilityId) => activeTarget?.layer === 'enterprise' && state.protocolToEnterprise.some((item) => item.from === id && item.to === activeTarget.id);
+  const relatedEnterprise = (id: EnterpriseId) => (activeTarget?.layer === 'protocol' && state.protocolToEnterprise.some((item) => item.from === activeTarget.id && item.to === id)) || (activeTarget?.layer === 'gravity' && state.enterpriseToGravity.some((item) => item.from === id && item.to === activeTarget.id));
+  const relatedGravity = (id: GravityId) => activeTarget?.layer === 'enterprise' && state.enterpriseToGravity.some((item) => item.from === activeTarget.id && item.to === id);
+  return <section ref={sectionRef} id="protocol-to-enterprise" className="architecture-section scroll-mt-16 border-t border-slate-200" aria-labelledby="architecture-title"><div className="max-w-7xl mx-auto px-6 py-20">
+    <header className="max-w-3xl"><p className={`text-xs font-bold uppercase tracking-[0.14em] ${amethyst.text}`}>Designing centers of gravity</p><h2 id="architecture-title" className="mt-3.5 text-3xl md:text-[2.5rem] font-extrabold tracking-tight text-slate-900 leading-[1.15]">Capabilities shape platforms.</h2><p className="mt-3.5 text-lg md:text-xl font-medium text-slate-600">How you combine them determines where power lives.</p><p className="mt-3 max-w-2xl text-[15px] md:text-base leading-relaxed text-slate-500">AOC exposes composable technological capabilities so platforms can deliberately design how control, authority and responsibility are distributed.</p></header>
+    <MotionConfig reducedMotion="user" transition={{ duration: 1.2, ease: [0.22,1,0.36,1] }}><div className="architecture-instrument mt-10" aria-describedby="architecture-description"><p id="architecture-description" className="sr-only">Each architecture example creates a different topology of AOC Protocol capabilities, AOC Enterprise operations and centers of gravity. Soft vertical relationships illustrate possible explanatory connections between layers and are not normative Protocol mappings. Architectural examples are choices, not moral rankings.</p>
+      <VerticalBridgeNetwork state={state} activeTarget={activeTarget}/><VerticalBridgeNetwork state={state} activeTarget={activeTarget} mobile/>
+      <div className="glass-plane gravity-plane"><div className="slab-edge" aria-hidden/><div className="plane-heading"><span>03</span><strong>Centers of gravity</strong><em>Distribution of power</em></div><LayerTopology stateId={state.id} layer="gravity" edges={state.gravityEdges} shape={state.gravityShape} positions={gravityPositions} activeTarget={activeTarget}/>{gravityFields.map((field) => { const weight=state.gravity[field.id]; return <button key={field.id} type="button" className={`gravity-field ${(activeTarget?.layer === 'gravity' && activeTarget.id === field.id) || relatedGravity(field.id) ? 'is-related' : ''}`} style={{ left:`${field.x}%`,top:`${field.y}%`,'--gravity-weight':weight } as CSSProperties} onMouseEnter={() => setActiveTarget({layer:'gravity',id:field.id})} onMouseLeave={() => setActiveTarget(null)} onFocus={() => setActiveTarget({layer:'gravity',id:field.id})} onBlur={() => setActiveTarget(null)} aria-label={`${field.label}: ${Math.round(weight*100)} percent relative emphasis in ${state.label} example`}><i aria-hidden/><span>{field.label}</span></button>; })}</div>
+      <div className="glass-plane enterprise-plane"><div className="slab-edge" aria-hidden/><div className="plane-heading"><span>02</span><strong>AOC Enterprise</strong><em>Operationalization</em></div><LayerTopology stateId={state.id} layer="enterprise" edges={state.enterpriseEdges} shape={state.enterpriseShape} positions={enterprisePositions} activeTarget={activeTarget}/>{enterpriseNodes.map((node) => <button key={node.id} type="button" className={`architecture-node enterprise-node ${state.enterprise.includes(node.id)?'is-active':''} ${relatedEnterprise(node.id)?'is-related':''}`} style={{left:`${node.x}%`,top:`${node.y}%`}} onMouseEnter={() => setActiveTarget({layer:'enterprise',id:node.id})} onMouseLeave={() => setActiveTarget(null)} onFocus={() => setActiveTarget({layer:'enterprise',id:node.id})} onBlur={() => setActiveTarget(null)} aria-pressed={state.enterprise.includes(node.id)}><i aria-hidden/><span>{node.label}</span></button>)}</div>
+      <div className="glass-plane protocol-plane"><div className="slab-edge" aria-hidden/><div className="plane-heading"><span>01</span><strong>AOC Protocol</strong><em>Composable primitives</em></div><LayerTopology stateId={state.id} layer="protocol" edges={state.protocolEdges} shape={state.protocolShape} positions={protocolPositions} activeTarget={activeTarget}/>{(CAPABILITY_FAMILIES as ((typeof CAPABILITY_FAMILIES)[number]&{id:CapabilityId})[]).map((capability) => <MineralNode key={capability.id} capability={capability} active={state.protocol.includes(capability.id)} related={relatedProtocol(capability.id)} onIntent={(value) => setActiveTarget(value?{layer:'protocol',id:capability.id}:null)}/>)}</div>
+      <div className="state-console"><div className="state-readout" aria-live="polite"><span>Architecture example</span><AnimatePresence mode="wait" initial={false}><motion.strong key={state.id} initial={{opacity:0,y:4}} animate={{opacity:1,y:0}} exit={{opacity:0,y:-4}}>{state.label}</motion.strong></AnimatePresence></div><div className="state-selector" aria-label="Architecture examples">{architectureStates.map((item,index)=><button key={item.id} type="button" className={index===stateIndex?'is-active':''} onClick={()=>setStateIndex(index)} aria-label={`Show ${item.label} architecture`} aria-pressed={index===stateIndex}/>)}</div></div>
+    </div></MotionConfig>
+    <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"><a href="/?view=docs#getting-started" className={`inline-flex w-full sm:w-auto items-center justify-center rounded-2xl ${amethyst.solid} px-8 py-4 text-white font-semibold ${amethyst.solidHover} transition-all active:scale-[0.98]`}>Review Protocol Documentation</a><a href="/?view=enterprise" className="inline-flex w-full sm:w-auto items-center justify-center rounded-2xl border border-slate-200 hover:border-slate-300 text-slate-900 font-semibold px-8 py-4 transition-all active:scale-[0.98]">Explore AOC Enterprise &rarr;</a></div>
+  </div></section>;
 }


### PR DESCRIPTION
### Motivation

- Replace a decorative two-crystal illustration with an explanatory, interactive three-layer visualization showing Protocol capabilities, Enterprise operations, and centers of gravity so readers can explore relationships and design choices.
- Improve accessibility, semantics and responsiveness while providing an animated, state-driven explanation of capability-to-enterprise and enterprise-to-gravity relationships.

### Description

- Replaced the previous simple `ProtocolToEnterprise` presentation with a new interactive component that renders three glass "planes" (protocol, enterprise, gravity) using SVG topologies, vertical bridge networks, and animated node/bridge states, and added `ProtocolToEnterprise.css` for styling. 
- Introduced typed models and helpers (`ArchitectureState`, `Edge`, `VerticalBridge`, `bridgeCoordinates`, `pointString`, etc.) and an array of curated `architectureStates` to drive different topology examples and the state selector.
- Implemented new subcomponents `LayerTopology`, `VerticalBridgeNetwork`, `MineralNode`, and interactive controls with `framer-motion` for animation, `IntersectionObserver` for visibility-driven autoplay, and `useReducedMotion` to respect motion preferences.
- Updated tests in `DocsPage.test.tsx` to assert the new semantic headings and interactive controls (e.g., the architecture heading, centers of gravity text, AOC Enterprise/AOC Protocol labels, and a `Creator:` button) instead of the prior decorative SVG assertions.

### Testing

- Ran unit tests with `vitest` which include the updated `DocsPage.test.tsx` assertions, and the test run completed successfully. 
- Verified the updated component renders expected headings and interactive elements via the updated test assertions in `DocsPage.test.tsx` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78bd7385b4832580e4142b171b9d9a)