### PR TITLE
Refine protocol Hero thesis — replace headline and remove subline

### DIFF
--- a/frontend/app/src/landing/protocol/Hero.tsx
+++ b/frontend/app/src/landing/protocol/Hero.tsx
@@ -5,12 +5,11 @@ const m = MINERALS.amethyst;
 
 // Dark bookend, matching the visual rhythm every other AOC surface's hero
 // uses (../enterprise/Hero.tsx, governed-access/Hero.tsx, assurance/Hero.tsx):
-// light-primary page, dark #0B1220 hero + closing CTA. Copy is unchanged
-// from the W004 rebuild — only the shell now matches the unified system.
+// light-primary page, dark #0B1220 hero + closing CTA.
 export function Hero() {
   return (
     <section id="overview" className="scroll-mt-16 bg-[#0B1220] px-6 pt-20 pb-24 md:pt-28 md:pb-32 text-center">
-      <div className="max-w-3xl mx-auto flex flex-col items-center">
+      <div className="max-w-5xl mx-auto flex flex-col items-center">
         <div className="flex items-center gap-2.5">
           <LogoRotating size={18} inverted />
           <p className={`text-xs font-bold uppercase tracking-[0.14em] ${m.onDark}`}>
@@ -18,15 +17,10 @@ export function Hero() {
           </p>
         </div>
 
-        <h1 className="mt-7 text-[44px] md:text-7xl font-extrabold tracking-tight text-white leading-[1.05]">
-          Digital assets should be capable of more than being stored.
+        <h1 className="mt-7 text-[40px] md:text-6xl lg:text-7xl font-extrabold tracking-tight text-white leading-[1.05]">
+          A digital asset is only legitimate when its owners can explicitly define how it is
+          governed.
         </h1>
-
-        <p className="mt-6 max-w-xl text-lg md:text-xl text-slate-400">
-          AOC Protocol is an open, provider-neutral language for digital assets — a way to give any
-          file or resource identity, integrity, provenance and declared capabilities that
-          compatible systems can interpret.
-        </p>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
           <a


### PR DESCRIPTION
### Motivation

- Reduce text density and make the Hero feel more declarative by replacing the existing headline with the new core thesis and removing the descriptive subline while keeping all visual and structural systems intact.

### Description

- Updated `frontend/app/src/landing/protocol/Hero.tsx` to replace the headline text and remove the descriptive paragraph under the Hero. 
- Replaced the heading copy from "Digital assets should be capable of more than being stored." to "A digital asset is only legitimate when its owners can explicitly define how it is governed." and preserved the heading as the primary semantic `h1`.
- Removed the subline: "AOC Protocol is an open, provider-neutral language for digital assets — a way to give any file or resource identity, integrity, provenance and declared capabilities that compatible systems can interpret." with no replacement copy added.
- Adjusted container and headline classes to accommodate the longer thesis by changing `max-w-3xl` to `max-w-5xl` and updating headline sizing from `text-[44px] md:text-7xl` to `text-[40px] md:text-6xl lg:text-7xl` to preserve scale and natural wrapping across breakpoints.

### Testing

- Ran `npm run typecheck` in `frontend/app` and it completed successfully (exit 0). 
- Ran targeted ESLint on the modified file with `npx eslint src/landing/protocol/Hero.tsx` and it completed successfully (exit 0). 
- Ran unit tests with `npm test -- --run` and the suite produced 19 passing tests and 1 failing test which is unrelated to this change (`CapabilityDock` desktop test reported duplicate "Identity" elements); the failure predates and is not caused by the Hero edits. 
- Ran `npm run build` in `frontend/app` and a production build completed successfully (Vite build warning about large chunk size only). 
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b8320ffa8832593f8aa4eff33d20a)