### PR TITLE
Refine protocol closing thesis

### DIFF
--- a/frontend/app/src/landing/protocol/CtaSection.test.tsx
+++ b/frontend/app/src/landing/protocol/CtaSection.test.tsx
@@ -9,6 +9,15 @@ describe('Protocol closing handoff', () => {
   it('offers public source first and public documentation second', () => {
     render(<CtaSection />);
 
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Ownership should survive the platform.' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'AOC Protocol makes identity, capabilities and governance portable by design.',
+      ),
+    ).toBeInTheDocument();
+
     const links = screen.getAllByRole('link');
     expect(links.map((link) => link.textContent?.trim())).toEqual([
       'View @aoc/protocol on GitHub',

--- a/frontend/app/src/landing/protocol/CtaSection.tsx
+++ b/frontend/app/src/landing/protocol/CtaSection.tsx
@@ -12,11 +12,10 @@ export function CtaSection() {
     <section className="scroll-mt-16 bg-[#0B1220] px-6 py-24 md:py-28 text-center">
       <div className="max-w-2xl mx-auto flex flex-col items-center">
         <h2 className="text-[32px] md:text-5xl font-extrabold tracking-tight text-white">
-          Build digital assets that retain identity, integrity and capabilities beyond a single
-          application.
+          Ownership should survive the platform.
         </h2>
         <p className="mt-4 max-w-xl text-base md:text-lg text-slate-400">
-          Open, provider-neutral, and reviewable today in the public repository.
+          AOC Protocol makes identity, capabilities and governance portable by design.
         </p>
 
         <a


### PR DESCRIPTION
### Motivation
- Replace the current verbose closing copy with the approved, concise manifesto-style thesis that emphasizes portability of ownership, identity, capabilities and governance across platforms.

### Description
- Updated `frontend/app/src/landing/protocol/CtaSection.tsx` to replace the headline from `Build digital assets that retain identity, integrity and capabilities beyond a single application.` to `Ownership should survive the platform.` and the supporting line from `Open, provider-neutral, and reviewable today in the public repository.` to `AOC Protocol makes identity, capabilities and governance portable by design.`, preserved the existing `h2` semantics, layout and CTAs, and added targeted assertions in `frontend/app/src/landing/protocol/CtaSection.test.tsx` to validate the new copy (2 files changed).

### Testing
- Ran `npm run typecheck`, `npx eslint src/landing/protocol/CtaSection.tsx src/landing/protocol/CtaSection.test.tsx`, `npx vitest run src/landing/protocol/CtaSection.test.tsx` (2 tests passed), `npm run build`, and `git diff --check`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b87059d608325863a54cecd145b11)