### PR TITLE
Refine Enterprise Hero messaging

### DIFF
--- a/frontend/app/src/landing/enterprise/Hero.tsx
+++ b/frontend/app/src/landing/enterprise/Hero.tsx
@@ -12,11 +12,11 @@ export function Hero() {
         </div>
 
         <h1 className="mt-7 text-[44px] md:text-7xl font-extrabold tracking-tight text-white leading-[1.05]">
-          Governed access to every system your product depends on.
+          Governance should follow the asset — not stop at the platform.
         </h1>
 
         <p className="mt-6 max-w-xl text-lg md:text-xl text-slate-400">
-          Provable, revocable, auditable access — designed, implemented, and maintained for you.
+          AOC Enterprise turns declared rights and authority into provable, revocable and auditable access.
         </p>
 
         <div className="mt-8 flex items-center gap-3 text-[13px] font-bold tracking-[0.16em] text-indigo-300">


### PR DESCRIPTION
### Motivation
- Clarify the relationship between AOC Protocol and AOC Enterprise by updating the Hero copy so Enterprise reads as the operationalization of Protocol's asset-level governance.

### Description
- Replace in `frontend/app/src/landing/enterprise/Hero.tsx` the headline from `Governed access to every system your product depends on.` to `Governance should follow the asset — not stop at the platform.` and the supporting sentence from `Provable, revocable, auditable access — designed, implemented, and maintained for you.` to `AOC Enterprise turns declared rights and authority into provable, revocable and auditable access.`, while preserving the `PROVABLE · REVOCABLE · AUDITABLE` proof line, the `See how it works` CTA and its target, and leaving layout, responsive behavior, typography, accessibility, and other Hero structure unchanged.

### Testing
- Ran `npm run typecheck`, `npx eslint src/landing/enterprise/Hero.tsx`, `npm run test -- --run` (Vitest), `npm run build`, and `git diff --check`; typecheck, ESLint, and build succeeded, Vitest ran 20 tests with 19 passing and 1 unrelated pre-existing test failure in the Protocol `CapabilityDock` suite, and there are no diff/check issues in the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b8db9cb3c8325a6cf82571577b738)