### PR TITLE
chore(protocol): refresh release manifest evidence

### DIFF
--- a/docs/release/evidence/aoc-protocol-0.1.0-release-manifest.json
+++ b/docs/release/evidence/aoc-protocol-0.1.0-release-manifest.json
@@ -25,7 +25,7 @@
   },
   "source": {
     "repository": "git+https://github.com/Architects-of-Change-Protocol/Architects_of_Change_Protocol.git",
-    "gitCommit": "be12510fe5ae691f46a3685781fb2e6d276d9910",
+    "gitCommit": "b1b40560ec5a6eef9816df7b9979277738877a3a",
     "protocolWorkspaceClean": true
   },
   "toolchain": {
@@ -34,14 +34,14 @@
   },
   "tarball": {
     "filename": "aoc-protocol-0.1.0.tgz",
-    "sizeBytes": 67729,
-    "fileCount": 271,
-    "sha256": "f09b4976f158fa8ce6b46ed539a0efd465a4daf702c98333baf2af55591c3742",
-    "sha512": "349a0bd8e147147efc0ae69bbb5bb6d38a0ba87581800a77cfb211b80c825e9a7a6b209a552fbb32fad21c0911341a605f5d402f34fdd89a792190f5722ba785",
-    "npmIntegrity": "sha512-NJoL2OFHFH78Cuabu1u204oLqHWBgAp3z7IRuAyCXpp6ayCaVS+7MvrSHAkRNBpgX11ALzT92Jp5IZD1ciunhQ==",
+    "sizeBytes": 73498,
+    "fileCount": 274,
+    "sha256": "451085019b902e93d28318d3081dd70ccd649095839db6f7c22d8afb1c373076",
+    "sha512": "ead662c4181c78d41b0ba2f24f5e382d2a4ef109468a382c99f119db4092e92aba5926481e4b4bff3276863654e0c65e7be76e294085315c9129d9b16099d26e",
+    "npmIntegrity": "sha512-6tZixBgceNQbC6LyT144LSpO8QlGijgsmfEZ20CS6Sq6WSZIHktL/zJ2hjZU4MZee+duKUCFMVyRKdmxYJnSbg==",
     "reproducible": true
   },
-  "generatedAt": "2026-08-17T13:21:03.193Z",
+  "generatedAt": "2026-08-17T16:48:30.368Z",
   "files": [
     "LICENSE",
     "NOTICE",
@@ -247,6 +247,9 @@
     "dist/identity/sovereign-asset-id.d.ts",
     "dist/identity/sovereign-asset-id.d.ts.map",
     "dist/identity/sovereign-asset-id.js",
+    "dist/identity/subject-reference.d.ts",
+    "dist/identity/subject-reference.d.ts.map",
+    "dist/identity/subject-reference.js",
     "dist/manifest/claims.d.ts",
     "dist/manifest/claims.d.ts.map",
     "dist/manifest/claims.js",

--- a/docs/release/evidence/aoc-protocol-0.1.0.sbom.spdx.json
+++ b/docs/release/evidence/aoc-protocol-0.1.0.sbom.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "@aoc/protocol@0.1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/@aoc%2fprotocol-0.1.0-622f5cea-0a07-4999-94b6-be909a8bdda7",
+  "documentNamespace": "http://spdx.org/spdxdocs/@aoc%2fprotocol-0.1.0-d7ea1080-a526-471f-acdb-9f181e8489fc",
   "creationInfo": {
-    "created": "2026-08-17T13:21:03.844Z",
+    "created": "2026-08-17T16:48:31.095Z",
     "creators": [
       "Tool: npm/cli-10.9.7"
     ]


### PR DESCRIPTION
## Fixes the one CI failure introduced by #364

`RC Validation` is red on `main` at `b1b4056`. Exactly one of its 21 checks fails — **`release manifest evidence`** — and it is my regression from #364, not a pre-existing condition.

### Root cause

SM-02 added three files to the packed `@aoc/protocol` tarball:

```
dist/identity/subject-reference.js
dist/identity/subject-reference.d.ts
dist/identity/subject-reference.d.ts.map
```

The committed evidence in `docs/release/evidence/` still described the pre-SM-02 pack (271 files, `sha256 f09b4976…`). `scripts/validate-release-candidate.mjs` verifies evidence *freshness* against a fresh pack, so it failed. Note that `protocol:release:manifest:check` — which I did run before merging #364, and which passed — only proves **reproducibility**, not evidence freshness; the freshness assertion lives solely in `protocol:rc:check`. That gap is why this reached `main`.

Confirmed as introduced rather than pre-existing by reconstructing the packed file set at each commit against the committed evidence:

| Commit | Reconstructed packed files | Matches committed evidence |
| --- | --- | --- |
| `0ed38d4` (pre-SM-02 baseline) | 271 | **yes** |
| `b1b4056` (post-SM-02 `main`) | 274 | **no** — the 3 files above are missing from it |

### Fix

Regenerated both evidence artifacts with `npm run protocol:release:manifest` against the merged commit:

- `aoc-protocol-0.1.0-release-manifest.json` — 274 files, refreshed `sha256`/`sha512`/npm integrity, `gitCommit: b1b4056`, `protocolWorkspaceClean: true`, two consecutive packs byte-identical
- `aoc-protocol-0.1.0.sbom.spdx.json` — regenerated from the extracted tarball, still describes `@aoc/protocol@0.1.0`

Same remedy and shape as the existing precedent `c79e752` ("chore(protocol): refresh release manifest evidence", #353).

Evidence only — it records a pack and authorizes nothing. No source, contract, export, schema or version change; no changeset needed.

### Verification

`npm run protocol:rc:check` → **PASSED (21 checks)**, including `release manifest evidence`, `SBOM evidence`, `tests`, `typecheck`, `build`, `reproducibility`, `tarball contents`, `consumer fixtures` (all three packed fixtures ok) and `private publication block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDUBQTXF6nYFXBRd4e4v4W

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDUBQTXF6nYFXBRd4e4v4W)_