### PR TITLE
chore(protocol): refresh release evidence for canonical main after SM-10 squash

### DIFF
--- a/docs/release/evidence/aoc-protocol-0.1.0-release-manifest.json
+++ b/docs/release/evidence/aoc-protocol-0.1.0-release-manifest.json
@@ -29,7 +29,7 @@
   },
   "source": {
     "repository": "git+https://github.com/Architects-of-Change-Protocol/Architects_of_Change_Protocol.git",
-    "gitCommit": "f30a72d46944e491a44ef51092dea790c24bc192",
+    "gitCommit": "73b259a5803628aea8108ec7927e790ed73deef0",
     "protocolWorkspaceClean": true
   },
   "toolchain": {
@@ -45,7 +45,7 @@
     "npmIntegrity": "sha512-4hIA1oWik+n3UBTS2rO2MhITYzFgjGxNDDeWks8m8W/mObxBBLodIDgkbja91I3o3BBdRl2EseGC1rgoA6pjDg==",
     "reproducible": true
   },
-  "generatedAt": "2026-08-18T20:20:50.778Z",
+  "generatedAt": "2026-08-18T20:53:49.509Z",
   "files": [
     "LICENSE",
     "NOTICE",

--- a/docs/release/evidence/aoc-protocol-0.1.0.sbom.spdx.json
+++ b/docs/release/evidence/aoc-protocol-0.1.0.sbom.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "@aoc/protocol@0.1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/@aoc%2fprotocol-0.1.0-cafc01c8-76ae-4fda-ae6d-3c088a3fa9da",
+  "documentNamespace": "http://spdx.org/spdxdocs/@aoc%2fprotocol-0.1.0-07b75651-3ddc-41df-af72-662999fc9b5c",
   "creationInfo": {
-    "created": "2026-08-18T20:20:51.583Z",
+    "created": "2026-08-18T20:53:50.428Z",
     "creators": [
       "Tool: npm/cli-10.9.7"
     ]


### PR DESCRIPTION
Post-squash canonical-main evidence refresh — the final step of the established release evidence lifecycle, following #376.

## Why

Squash-merging #376 rewrote the semantic commit `f30a72d`, which no longer exists on `main`. The release manifest's `source.gitCommit` was therefore naming an unreachable commit. It now names the canonical merged commit `73b259a`.

## The artifact did not change

The squash preserved the tree exactly — `7ae18d53907fd4c67aa33608d3be7ec5581fac0e` on both the pre-merge branch tip and canonical main — so the recorded tarball is byte-identical:

| | Before | After |
| --- | --- | --- |
| `tarball.sha256` | `c9a3c0cb…51968c` | `c9a3c0cb…51968c` (unchanged) |
| `tarball.fileCount` | 406 | 406 (unchanged) |
| `tarball.reproducible` | true | true |
| `package.exports` | 15 subpaths | unchanged |
| `runtimeDependencies` | `{}` | `{}` |
| `source.gitCommit` | `f30a72d…` (unreachable) | **`73b259a…`** (canonical main) |

The complete diff is four lines: `source.gitCommit`, `generatedAt`, and the SBOM's `documentNamespace` and `created` timestamps.

## This repairs no failure

`protocol:rc:check` was **already green on canonical main before this commit** (21/21, including `release manifest evidence` and `SBOM evidence`). The RC validator compares the recorded tarball **hash**, not the commit reference, so the stale `source.gitCommit` was cosmetic. This closes the lifecycle rather than fixing a break — and it converges: because this commit touches nothing under `packages/protocol`, the tarball built from it is identical to the one built from `73b259a`, so the recorded commit stays accurate after this PR merges.

## Scope

Evidence only. No source, no contract, no test, no documentation change. Two files:

- `docs/release/evidence/aoc-protocol-0.1.0-release-manifest.json`
- `docs/release/evidence/aoc-protocol-0.1.0.sbom.spdx.json`

SM-11 (Legacy Convergence / Protocol–Enterprise Cleanup) has not been started and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Np54a7LFzKRhPEyNen4wPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Np54a7LFzKRhPEyNen4wPS)_